### PR TITLE
infra: ci, dependabot, deny, lefthook, pr template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      rust-deps:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "rust"]
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      gh-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Slice
+
+<!-- e.g., Slice 02 — Headless CLI on fixture audio. Or "Infra" / "Docs" if not a slice. -->
+
+## What changed
+
+-
+
+## Why
+
+## Verification
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo nextest run --workspace`
+- [ ] Conformance suite passes for any new adapter
+- [ ] Plan checkboxes updated in `docs/superpowers/plans/`
+
+## Notes for review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.16.0
+        with:
+          toolchain: stable
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.16.0
+        with:
+          toolchain: stable
+          components: clippy
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.16.0
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@v2.75.27
+        with:
+          tool: cargo-nextest
+      - run: cargo nextest run --workspace --locked
+      - run: cargo test --workspace --locked --doc
+
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2.0.17
+        with:
+          command: check all
+
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.46.0
+
+  audit-scheduled:
+    name: scheduled audit
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2.0.17
+        with:
+          command: check advisories

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
   <img src="docs/assets/panops-banner.png" alt="panops" width="600" />
 </p>
 
+<p align="center">
+  <a href="https://github.com/vfmatzkin/panops/actions/workflows/ci.yml"><img src="https://github.com/vfmatzkin/panops/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license" /></a>
+</p>
+
 Open-source local-first macOS recorder with screenshot-anchored meeting notes. Captures audio (mic + system + per-app), screen, and time-anchored screenshots; transcribes live and refines with a higher-quality post-pass; emits markdown notes with embedded screenshots via a BYO local-or-cloud LLM.
 
 The wedge no other OSS tool occupies: **screen + audio + screenshot-anchored notes, fully local, BYO-everything, no account required**.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+[graph]
+targets = [
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-unknown-linux-gnu" },
+]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+]
+confidence-threshold = 0.9
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,20 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt:
+      glob: "*.rs"
+      run: cargo fmt --all -- --check
+    clippy:
+      glob: "*.rs"
+      run: cargo clippy --workspace --all-targets --locked -- -D warnings
+    typos:
+      run: typos
+  skip:
+    - merge
+    - rebase
+
+commit-msg:
+  commands:
+    length:
+      run: |
+        head -1 "{1}" | awk 'length > 72 { exit 1 }'


### PR DESCRIPTION
## Slice

Infra (not a slice). Lands the CI and tooling recommended for slice 02 readiness.

## What changed

- **CI** (`.github/workflows/ci.yml`): matrix on `ubuntu-latest` + `macos-latest`, jobs for fmt, clippy, test (via `cargo-nextest`), `cargo-deny`, `typos`. Weekly cron job runs `cargo deny check advisories` for fresh RustSec data.
- **Dependabot** (`.github/dependabot.yml`): grouped weekly PRs for cargo and github-actions. Single PR per ecosystem instead of N noisy ones.
- **cargo-deny** (`deny.toml`): allowlist of compatible licenses (MIT/Apache-2.0/BSD/ISC/Unicode/MPL-2.0/CC0/Zlib), denies wildcards and unknown registries, warns on multi-version crates.
- **lefthook** (`lefthook.yml`): pre-commit runs fmt + clippy + typos in parallel; commit-msg enforces the global rule of single-line messages under 72 chars.
- **PR template** (`.github/pull_request_template.md`): slice header + verification checkboxes matching the AGENTS.md discipline.
- **README badges**: CI + MIT license.

## Why

Recommendations sourced from a research subagent that verified every action version against current state (rust-toolchain action v1.16.0, cargo-deny-action v2.0.17, typos v1.46.0, install-action v2.75.27). Picks chosen for low-noise, solo-OSS-Rust-project fit.

Highlights of what was deliberately skipped (and why):

- **Renovate** — Dependabot grouping covers our small workspace; switch later if Swift/SPM shows up and Dependabot's SPM support feels weak.
- **commitlint / Conventional Commits** — global rule mandates single-line imperative; CC's `type(scope):` prefix would be the wrong format. lefthook commit-msg hook enforces our actual rule.
- **CODEOWNERS** — solo repo.
- **codecov, semantic-release, Mergify, CodeRabbit** — overkill at v0.1.0.

## PR base

This PR's base is `slice-01-skeleton` so CI can find `Cargo.toml` and the workspace it actually checks. After PR #1 merges to `main`, GitHub auto-retargets this PR to `main`.

## Manual TODOs after merge

- [ ] `lefthook install` once locally to wire up the git hooks.
- [ ] Apply branch protection on `main` via `gh api` (the snippet is in the research notes; key flags: require CI green, no force-push, no deletion, `enforce_admins=false` so Fran can still self-merge).
- [ ] In repo Settings → Code security: enable secrets scanning, push protection, Dependabot security updates, private vulnerability reporting.

## Verification

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [ ] `cargo deny check all` (not installed locally; CI will verify)
- [ ] `cargo nextest run --workspace` (not installed locally; CI will verify)