### PR TITLE
docs: name etymology section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Hexagonal Rust core engine + SwiftUI macOS shell + Swift sidecars (WhisperKit + 
 
 Pre-alpha. Slice 01 (skeleton) lands the Cargo workspace and test fixtures. Subsequent slices land the headless CLI, post-pass + diarization, notes generation, IPC, the SwiftUI shell, and live capture.
 
+## Name
+
+From Argus Panoptes, the hundred-eyed giant in Greek myth. *Pan* (all) + *ops* (seeing). Fits the wedge: panops watches the screen, captures system audio, and stitches the recording into screenshot-anchored notes you can navigate later. The chevron inside the `o` of the wordmark is the visual cue.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Short ## Name section after License explaining where the project name comes from. Argus Panoptes (Greek myth, hundred-eyed giant), *pan* + *ops*. Ties the etymology to the project's wedge and the chevron inside the `o` of the wordmark banner.

No code changes.