### PR TITLE
Add issue templates: debt, bug, feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,57 @@
+name: Bug
+description: Broken behavior in shipped code.
+title: "<short summary>"
+labels: ["type:bug"]
+body:
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "severity:critical — blocks correctness or release"
+        - "severity:high — bites real meetings"
+        - "severity:medium — workaround exists"
+        - "severity:low — paper-cut"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - "area:asr"
+        - "area:diar"
+        - "area:notes"
+        - "area:llm"
+        - "area:ci"
+        - "area:storage"
+        - "area:ipc"
+        - "area:mac-shell"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal commands or steps to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS / arch / panops version / model paths if relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: Feature
+description: A new capability not yet planned in a slice.
+title: "<short summary>"
+labels: ["type:feature"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - "area:asr"
+        - "area:diar"
+        - "area:notes"
+        - "area:llm"
+        - "area:ci"
+        - "area:storage"
+        - "area:ipc"
+        - "area:mac-shell"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What gap in the current behavior motivates this?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: Sketch — port shape, adapter, prompt, etc. Reference design spec sections if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How will we know this is done? Test, behavior, threshold.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,60 @@
+name: Tech debt
+description: A known limitation, shortcut, or deferred work item.
+title: "<short summary>"
+labels: ["type:debt"]
+body:
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "severity:critical — blocks correctness or release"
+        - "severity:high — bites real meetings; pay before v0.1"
+        - "severity:medium — schedule when nearby"
+        - "severity:low — polish, paper-cuts"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - "area:asr"
+        - "area:diar"
+        - "area:notes"
+        - "area:llm"
+        - "area:ci"
+        - "area:storage"
+        - "area:ipc"
+        - "area:mac-shell"
+    validations:
+      required: true
+  - type: input
+    id: slice
+    attributes:
+      label: Slice introduced
+      description: Which slice incurred this debt? (e.g. 02, 03, 04)
+      placeholder: "03"
+    validations:
+      required: true
+  - type: textarea
+    id: blocks
+    attributes:
+      label: What it blocks
+      description: What capability, quality bar, or release gate is held back by this?
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why deferred
+      description: What was the trade-off — cost, scope, missing dependency, intentional sequencing?
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Spec sections, related PRs, related issues, prior commits.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add three structured issue forms under `.github/ISSUE_TEMPLATE/`: tech-debt, bug, feature.
- Disable blank issues via `config.yml`.
- Templates auto-apply the matching `type:` label and require fields appropriate to their kind:
  - **tech-debt** — Severity, Area, Slice introduced, What it blocks, Why deferred (slice is debt-specific).
  - **bug** — Severity, Area, Repro, Expected, Actual.
  - **feature** — Area, Problem, Proposed approach, Acceptance (severity doesn't apply to features; slice introduced is debt-only).

Pairs with the new label taxonomy (16 typed labels: 4 type, 8 area, 4 severity) and three milestones (`v0.1`, `before-slice-06-mac-shell`, `before-slice-07-live-capture`) created via gh CLI.

## Test plan
- [x] Labels created and visible via `gh label list`
- [x] Milestones created via API
- [ ] Open https://github.com/vfmatzkin/panops/issues/new/choose and confirm 3 templates render, no blank option
- [ ] File a test debt issue from the form to confirm fields + auto-label