### PR TITLE
Public roadmap (rules + specs + research) and local conversation extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-# ----- Agent / IDE working context (internal, do not publish) -----
-AGENTS.md
+# ----- Agent / IDE working context -----
+# AGENTS.md, CLAUDE.md, and design specs ARE tracked (public roadmap).
+# *.local.md and IDE-specific dirs stay private.
 AGENTS.local.md
-CLAUDE.md
 CLAUDE.local.md
 .claude/
 .cursor/
@@ -10,9 +10,12 @@ CLAUDE.local.md
 .specstory/
 GEMINI.md
 
-# ----- Internal docs: sessions, plans, research, specs (working notes) -----
-docs/superpowers/
-docs/research/
+# ----- Internal working notes (private) -----
+# Sessions = work journal. Plans = in-flight task checkboxes. Conversations = chat snapshots.
+# Specs and research are tracked at docs/superpowers/specs/ and docs/research/.
+docs/superpowers/plans/
+docs/superpowers/sessions/
+docs/superpowers/conversations/
 docs/internal/
 
 # ----- Rust -----

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# AGENTS.md — panops
+
+Open-source local-first macOS recorder with screenshot-anchored meeting notes. Hexagonal Rust core + SwiftUI Mac shell + Swift sidecars (WhisperKit/FluidAudio for ASR, Apple FoundationModels for LLM).
+
+This file IS the workflow contract. Every rule here is enforced. If a rule is unclear or you (the agent) disagree with it, raise it with Fran before acting — don't reinterpret silently.
+
+## Sources of truth
+
+| Surface | What it owns | Where |
+|---|---|---|
+| **GitHub Project board** | Open work, status, severity, slice ownership. **Lead with this.** | https://github.com/users/vfmatzkin/projects/1 (linked at https://github.com/vfmatzkin/panops/projects) |
+| **Design spec** | Architecture (locked). Don't restructure ports/adapters without revising. | `docs/superpowers/specs/2026-04-30-panops-design.md` |
+| **Slice spec** | The active slice's design (locked once approved). | `docs/superpowers/specs/<latest>-slice-NN-*.md` |
+| **Slice plan** (private) | Step-by-step checklist for the active slice. Checkbox state IS progress. | `docs/superpowers/plans/<latest>.md` (not in `done/`) |
+| **Session log** (private) | Journal of what happened in each work block. | `docs/superpowers/sessions/NNN-YYYY-MM-DD-<slug>.md` |
+| **Market scan** | Verified library + pattern picks (April 2026). | `docs/research/2026-04-30-market-scan.md` |
+
+When the project board and a markdown artifact disagree, the project board wins.
+
+## Repo conventions
+
+- Rust workspace, `resolver = "2"`. Crates: `panops-core` (domain + ports), `panops-portable`, `panops-mac` (`#[cfg(target_os="macos")]`), `panops-engine` (binary), `panops-protocol` (IPC types).
+- Swift (slice 06+): SwiftUI app under `apps/Panops/`, sidecars `apps/panops-asr-mac/` and `apps/panops-llm-mac/`.
+- Storage: SQLite per meeting at `~/Library/Application Support/panops/meetings/<uuid>/meeting.db`. Cross-meeting registry at `~/Library/Application Support/panops/panops.db`.
+- IPC: Unix socket at `~/Library/Application Support/panops/engine.sock`. JSON-RPC 2.0 control + WebSocket events.
+- Notes output: markdown + YAML frontmatter, `NotionEnhanced` dialect by default, `Basic` via toggle.
+- License: MIT.
+
+## Commands
+
+```bash
+cargo build --workspace
+cargo test --workspace --locked
+cargo fmt --all && cargo clippy --workspace --all-targets --locked -- -D warnings
+gh pr checks <num>            # CI status
+gh issue list --label type:debt --state open --limit 50
+gh project item-list 1 --owner vfmatzkin --format json
+```
+
+Mac app build commands land in slice 06.
+
+## Execution discipline (MUST follow)
+
+- **MUST** ship thin vertical slices end-to-end. Walking skeleton first.
+- **MUST** ship the headless CLI before any Swift. Live capture last.
+- **MUST** introduce one trait at a time + one real impl + one fake. **NEVER** pre-trait for hypothetical future adapters.
+- **MUST** keep test fixtures in `tests/fixtures/` as adapters that satisfy the same conformance suite as live impls.
+- **MUST** write a conformance fn per port. Every adapter passes the same harness.
+- **MUST** keep one slice = one PR = Fran's review gate. **NEVER** start slice N+1 until slice N's PR is merged.
+- **MUST** scope plans per-slice. **NEVER** write whole-project step lists.
+
+## Slice sequence
+
+1. Skeleton — Cargo workspace, fixtures (audio, video, screenshots).
+2. Headless CLI — `AsrProvider` trait + `whisper-rs` adapter, JSON segments to stdout.
+3. Post-pass + diarization — pyannote via sherpa-rs adapter, speaker labels merged.
+4. Notes generation — `LlmProvider` port + `NotesGenerator` pipeline + `MarkdownExporter`.
+5. IPC — JSON-RPC + WebSocket over Unix socket, exercised by Rust test client.
+6. SwiftUI shell + ASR sidecar — WhisperKit + FluidAudio sidecar.
+7. Live ScreenCaptureKit capture — risk-last, real audio + screen + screenshots.
+
+Slices 1–3 shipped. Active slice: see project board milestones (`slice-04-notes-generation` etc.).
+
+## Session rituals
+
+### Pickup ritual (run at the START of every session)
+
+1. Run `git status` and `git log -10 --oneline`.
+2. Open the project board. Find the active slice milestone (issues with `Status: In Progress`, or the slice the latest session log is working on).
+3. Read the most recent file in `docs/superpowers/sessions/` for context.
+4. Read the active plan in `docs/superpowers/plans/` (latest file not in `done/`).
+5. Identify next action: top-severity open issue in the active milestone with `Status: Todo` and no blocker, OR next unchecked step in the active plan.
+6. State explicitly: `"Slice 0N is X/Y done. Last session: <slug>. Next: <issue #N or step>. Blockers: <list or 'none'>."`
+7. **MUST** wait for Fran's "go" before resuming code changes.
+
+### Handoff ritual (run when STOPPING for the session)
+
+1. Update project-board state: move touched issues to `In progress` / `Done`. Open issues for any new debt (per Debt rule below).
+2. Tick checkboxes in the active plan for completed steps.
+3. Append new decisions to the plan's `Decisions made this slice` section.
+4. Append new blockers to the plan AND to the matching project issue.
+5. Write `docs/superpowers/sessions/NNN-YYYY-MM-DD-<slug>.md` (increment counter). Format: see `docs/superpowers/sessions/README.md`. Terse.
+6. **NEVER** auto-commit. Leave changes staged or note them in the session log.
+7. End message: `"Stopping at <step or issue #>. Next pickup: project board, then sessions/<latest>.md and plans/<active>.md."`
+
+### When a slice ships (after Fran merges its PR)
+
+1. Move `docs/superpowers/plans/<slice>.md` into `docs/superpowers/plans/done/`.
+2. Close the slice's milestone on the project board (`gh api -X PATCH repos/vfmatzkin/panops/milestones/<n> -f state=closed`).
+3. Brainstorm the next slice via the `superpowers:brainstorming` skill, then `superpowers:writing-plans`. **NEVER** queue multiple slice plans ahead.
+4. Open a slice tracking issue for the new milestone (label `type:feature`, milestone = new slice's). Body links to spec + plan + key tasks.
+
+## Debt rule (MUST follow)
+
+Anytime a spec, plan, or session log says **"deferred"** / **"follow-up"** / **"out of scope"** / **"later slice"** / **"defer to"**, open a GitHub issue. Don't let debt live only in markdown.
+
+**How to file:**
+
+1. Use the tech-debt template: https://github.com/vfmatzkin/panops/issues/new?template=tech-debt.yml — or `gh issue create` with the body fields below.
+2. Apply labels: `type:debt` + one `area:*` + one `severity:*`.
+3. Add to the project board: `gh project item-add 1 --owner vfmatzkin --url <issue-url>`. Populate `Severity`, `Area`, `Slice introduced` fields.
+4. Set milestone only if a specific slice will own the fix. Otherwise leave milestone-less (backlog).
+5. Add `release:v0.1` label if it must land before the v0.1 release.
+
+**Label taxonomy (canonical):**
+
+- `type:` — `bug`, `feature`, `debt`, `docs`. One per issue.
+- `area:` — `asr`, `diar`, `notes`, `llm`, `ci`, `storage`, `ipc`, `mac-shell`. One per issue.
+- `severity:` — `critical`, `high`, `medium`, `low`. Only on `type:debt` and `type:bug`.
+- `release:v0.1` — must land in v0.1. Label (not milestone) so it composes with slice ownership.
+
+Issue templates live at `.github/ISSUE_TEMPLATE/`.
+
+## Don'ts (NEVER do these)
+
+- **NEVER** propose live-capture work or native API bindings before slice 6/7.
+- **NEVER** add features beyond the active slice's plan.
+- **NEVER** pre-trait. One trait when needed, one real impl, one fake.
+- **NEVER** auto-commit or push. Fran commits when he wants.
+- **NEVER** give time estimates (no "ships in weeks", "X-day project", schedule framing). Compare options on capability/risk/cleanliness.
+- **NEVER** phone home. Zero telemetry, ever, even opt-in.
+- **NEVER** delete or rewrite files in `docs/superpowers/{specs,plans,sessions}/` or `docs/research/` without explicit instruction. They're history.
+- **NEVER** leave a "deferred" item only in markdown — file it as an issue (see Debt rule).
+- **NEVER** mark an issue as "wontfix" via label. Close as "not planned" with a comment instead.
+
+## When in doubt
+
+Re-read the design spec. Architecture is locked. Slice plans iterate; the design doesn't.
+
+## Local additions
+
+Personal notes that shouldn't ship publicly go in `AGENTS.local.md` (gitignored). Keep public-facing rules in this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+@AGENTS.md
+
+## Claude Code addenda
+
+- For non-trivial architectural changes, use plan mode (the `Plan` agent or `EnterPlanMode`) before touching code. Trivial fixes (typos, single-line changes, obvious renames) can skip planning.
+- Use the `superpowers:brainstorming` skill before opening a slice spec, and `superpowers:writing-plans` before opening a slice plan. **NEVER** invoke other implementation skills mid-brainstorm — brainstorming's terminal state is `writing-plans`.
+- Use the `superpowers:subagent-driven-development` skill to execute slice plans, dispatching one fresh implementer subagent per task with two-stage review (spec compliance → code quality) between tasks.
+- Personal preferences for this machine go in `CLAUDE.local.md` (gitignored).

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+ANE = "ANE"     # Apple Neural Engine
+ture = "ture"   # split-cell artifact in markdown tables

--- a/docs/research/2026-04-30-market-scan.md
+++ b/docs/research/2026-04-30-market-scan.md
@@ -1,0 +1,73 @@
+---
+date: 2026-04-30
+topic: Local macOS recorder + transcriber + notes app — market scan & existing-asset map
+status: research notes (pre-design)
+---
+
+# Research notes — local recorder + transcriber + notes
+
+## TL;DR
+The wedge nobody owns: **open-source, local-first, audio + screen + screenshot-anchored meeting notes**. Tier-1 paid apps (MacWhisper, TranscribeX, BB Recorder, Superwhisper) are audio-only. OSS priors (Meetily, Hyprnote) are audio-only. Screenpipe captures screen+audio but is a passive search index, not a notes generator. Granola/Otter are cloud and don't store media. The "screen recording with auto-sampled screenshots tied to transcript timestamps, summarized into a notes doc with embedded frames" angle is unclaimed.
+
+## Pain points to remove (from current manual workflow)
+
+1. OBS setup (pick window, start, stop) — should be a one-click button.
+2. Pre-record then upload — should be live.
+3. Manual ffmpeg screenshot extraction — should be auto-sampled on visual change.
+4. Separate AI session run by hand — should be in-app, BYO key.
+5. Multi-step app-switching — should be one app from "record" to "notes".
+
+## Competitive map
+
+### Tier 1 — paid native Mac, audio-focused
+| App | Recording | Live | Local engine | API engine | Diariz | Notes | Screenshots | Notable |
+|---|---|---|---|---|---|---|---|---|
+| MacWhisper | mic + sys audio | yes | Whisper Tiny→v4, **Parakeet v2/v3 MLX (~300x RT M-series)** | ElevenLabs/Deepgram | yes (Pro) | yes | no | speed king |
+| TranscribeX | mic + sys audio | yes | Whisper, Parakeet | OpenAI/Gemini/Ollama | yes (Pro) | yes | no | YouTube bulk |
+| BB Recorder | mic + sys audio | yes | bundled Whisper | BYO Deepgram/OAI/Anthropic | yes | yes | **no (audio only — verified)** | $0 forever, BYO keys |
+| Superwhisper | mic-first dictation | yes | Whisper Large | OpenAI/Claude/Llama/etc | ? | "Meeting Assistant" | no | dictation-anywhere |
+| Aiko | file only | no | Whisper-v3 | none | no | none | no | free, accuracy |
+
+### Tier 2 — meeting-notes (cloud)
+- **Granola** ($14–35) — bot-free system audio, "Enhance Notes" on user bullets, doesn't store media. Cloud-only.
+- **Cleft** ($7–9) — voice-only, on-device transcript, neurodivergent angle.
+- **Otter** ($8–20) — desktop bot-free or bot-on-call, agents.
+- **Wispr Flow** — dictation only, cloud.
+
+### Tier 3 — OSS building blocks
+- **whisper.cpp** — Metal/Neural Engine, GGML quantized. The de facto local Whisper.
+- **mlx-whisper / mlx-audio (Parakeet MLX)** — fastest on Apple Silicon. Parakeet ~0.5s vs whisper-turbo ~1.0s same clip.
+- **WhisperKit** — Argmax's Apple-optimized Whisper, used by MacWhisper.
+- **WhisperX** — wav2vec2 forced alignment, ±50ms word timestamps + diarization, 70x RT large-v2.
+- **pyannote.audio Community-1** — open diarization standard.
+- **Parakeet TDT v2/v3 (NVIDIA)** — fastest single-pass ASR, English-heavy, 25 EU langs.
+- **whisper-large-v3-turbo** — 809M, ~1–2% WER off large-v3, 99 langs.
+- **distil-whisper** — 6x faster, English-only.
+- **Meetily** (MIT, Rust) — closest prior art: Parakeet/Whisper + Ollama + BYO Claude/Groq/OpenRouter. Audio-only.
+- **Hyprnote / Char** — OSS, markdown-native, sys audio, BYO LLM. Audio-only.
+- **Screenpipe** (MIT) — 24/7 screen+audio capture with OCR + transcript search. Search index, not notes.
+
+## Niche analysis
+
+1. **Screenshots-anchored local notes is the real gap.** No Tier 1 / Tier 2 / OSS competitor ships it. BBRecorder's marketing positions it as audio-only despite the screenshot the user saw — likely a non-shipped or misread feature. Wide open.
+2. **Live-transcription stack 2026** — leaders run Parakeet (MLX) for speed-tier + Whisper-large-v3-turbo (WhisperKit/MLX) for accuracy-tier + pyannote for diarization. Parakeet hits 300x RT on M-series; turbo is the multilingual default.
+3. **Defensible angles for a one-person OSS project (pick two, max)**:
+   - **A) Notes-with-screenshots**: screen + sys audio + mic → live Parakeet → screenshots sampled on slide/window change (CGWindowList + perceptual-hash diff) → LLM emits markdown with embedded frames. Drop-in for Obsidian.
+   - **B) BYO-everything**: local Whisper/Parakeet + optional pyannote + BYO Claude/OpenAI/Ollama for summary. Replaces the manual OBS → batch-transcript → manual-notes chain.
+   - Skip: another dictation app (saturated), cloud meetings (Granola/Otter own it), passive memory (Screenpipe).
+
+## Constraints / decisions to make
+- **Form factor**: native Swift app vs Tauri/Electron vs Python web app. Determines screen-capture API access, distribution path, dev velocity.
+- **Live engine**: Parakeet MLX (fast, mostly English) vs Whisper-turbo via WhisperKit (multilingual) vs both with auto-pick.
+- **Screen capture**: ScreenCaptureKit (macOS 12.3+, AVFoundation-tied) is the only modern path; gives system-audio + screen in one shot.
+- **Diarization**: bundle pyannote (heavy, ~1GB) vs optional download vs API-only.
+- **Output target**: Markdown + Obsidian links by default; SRT/VTT for transcript-only export.
+- **Scope of MVP**: audio-first then screen, screen-from-day-1, or full-bore.
+
+## Open questions for design phase
+1. MVP scope: audio+notes only (replace existing chain) vs full screen+screenshots from v0.1?
+2. Stack: Tauri (Rust+web UI, easiest cross-target later) vs SwiftUI native (best ScreenCaptureKit story, Mac-only)?
+3. Live engine default: Parakeet or Whisper-turbo? (auto-detect by language?)
+4. Multi-language? Fran works in English/Spanish/Italian — Parakeet is English-heavy.
+5. Distribution: GitHub release dmg, Homebrew cask, or Mac App Store?
+6. Should it record meetings end-to-end OR also do "anywhere dictation" (Superwhisper space)? Probably no — stay focused.

--- a/docs/superpowers/specs/2026-04-30-panops-design.md
+++ b/docs/superpowers/specs/2026-04-30-panops-design.md
@@ -1,0 +1,314 @@
+---
+project: panops
+date: 2026-04-30
+status: design (pre-implementation)
+authors: Fran Matzkin
+type: design
+---
+
+# panops — design
+
+## Summary
+
+panops is an open, local-first macOS recorder that captures audio (mic + system + per-app), screen, and time-anchored screenshots, transcribes live, refines with a higher-quality post-pass on the saved media, and emits markdown meeting notes with embedded screenshots via a BYO local-or-cloud LLM. The wedge — verified unclaimed in the OSS landscape as of 2026-04-30 — is **screenshot-anchored notes** built on a portable engine, with a thin native macOS shell. No accounts, no cloud-required path, no per-meeting cap.
+
+## Goals
+
+- Replace a manual OBS → batch-transcript → manual-notes chain with a single local app.
+- Live transcription during the meeting, plus a higher-quality second pass on the saved file, plus diarization on the post-pass.
+- Multilingual day 1 (EN / ES / IT first; Whisper covers 99). One-tap language toggle for bilingual meetings, including mid-meeting switching.
+- Native macOS performance via WhisperKit + FluidAudio + ScreenCaptureKit.
+- Portable engine: same Rust binary runs headless on Linux/Windows once non-Mac capture and ASR adapters are added; Mac-only code is one feature flag away.
+- Hexagonal architecture; every platform-specific concern is a port with at least two adapter implementations (or one + a clear extension point) so the boundary is real, not aspirational.
+- BYO-everything: local Whisper / Parakeet / Apple FoundationModels / Ollama / llama.cpp; cloud OpenAI / Anthropic / Groq / OpenRouter behind one trait.
+- Output is plain markdown + embedded screenshot files. Drop-in for Obsidian-style folders. SRT / VTT / TXT / JSON also exported.
+
+## Non-goals
+
+- Always-on screen recall (Screenpipe owns that).
+- Cloud-hosted team workspace (Granola, Otter own that).
+- System-wide dictation / push-to-talk (Superwhisper, MacWhisper own that).
+- Joining meetings as a bot (BB Recorder / Granola own that; we record the local audio output instead).
+- Real-time translation (post-pass only, if at all).
+- Mobile clients.
+
+## Architecture
+
+Hexagonal / Ports & Adapters in Rust. The core domain has zero platform code. Every OS- or vendor-specific concern is a trait. Each trait has a `mac-native` adapter and a `portable` adapter. Cargo features select which compiles. Compile-time selection is the primary mechanism; an optional `Fallback<T>` decorator (off by default, enabled in shipping config for the ASR port only) retries the secondary at runtime if the primary errors.
+
+```
+                    ┌────────────────────────────┐
+                    │     Panops.app (SwiftUI)   │  ← Mac shell, thin client
+                    │  capture · UI · screenshots│
+                    └──────────────┬─────────────┘
+                                   │ JSON-RPC (control) + WebSocket (events)
+                                   │ over Unix domain socket
+                    ┌──────────────▼─────────────┐
+                    │     panops-engine (Rust)   │  ← portable, headless-capable
+                    │  use cases · orchestration │
+                    └──────────────┬─────────────┘
+                                   │ traits (ports)
+        ┌──────────────────────────┼──────────────────────────┐
+        ▼                          ▼                          ▼
+   AsrProvider              AudioCapture               LlmProvider
+   ┌──────────┐             ┌────────────┐            ┌────────────┐
+   │ mac:     │             │ mac:       │            │ mac:       │
+   │ panops-  │             │ ScreenCap- │            │ Foundation │
+   │ asr-mac  │             │ tureKit    │            │ Models     │
+   │ (Swift   │             │ (objc2)    │            │ (Swift)    │
+   │ sidecar) │             ├────────────┤            ├────────────┤
+   ├──────────┤             │ portable:  │            │ portable:  │
+   │ portable:│             │ cpal       │            │ rust-genai │
+   │ whisper- │             │            │            │ (Ollama,   │
+   │ rs       │             │            │            │ OpenAI,    │
+   │          │             │            │            │ Anthropic, │
+   │          │             │            │            │ Groq, …)   │
+   └──────────┘             └────────────┘            └────────────┘
+```
+
+The Swift sidecar `panops-asr-mac` is a tiny binary that wraps WhisperKit (Argmax Pro SDK 2) and FluidAudio (CoreML/ANE Parakeet TDT v3). It exposes one stdin/stdout protocol: receive PCM frames, emit JSON segments. The Rust engine treats it like any other `AsrProvider` adapter. On Linux/Windows the sidecar isn't built; the engine uses `whisper-rs` with whatever backend (CUDA, Vulkan, CPU).
+
+## Repo layout
+
+```
+panops/
+├── Cargo.toml                      (workspace, resolver = "2")
+├── README.md
+├── LICENSE                          (MIT)
+├── crates/
+│   ├── panops-core/                 domain types, ports (traits), use cases. zero platform code.
+│   ├── panops-portable/             impls of every port that work everywhere
+│   ├── panops-mac/                  #[cfg(target_os="macos")] impls (objc2 + sidecar runners)
+│   ├── panops-engine/               binary: wires ports → adapters, IPC server, CLI mode
+│   └── panops-protocol/             IPC schema (serde types, JSON-RPC method definitions)
+├── apps/
+│   ├── Panops/                      SwiftUI macOS app (Xcode project)
+│   └── panops-asr-mac/              Swift Package binary: WhisperKit + FluidAudio sidecar
+├── proto/
+│   └── ipc.md                       human-readable protocol doc (mirrors panops-protocol)
+├── docs/
+│   ├── superpowers/specs/           design docs (this file)
+│   └── research/                    market scan, verification reports
+├── tests/
+│   └── adapter-conformance/         every adapter passes the same trait test suite
+└── scripts/
+    └── package.sh                   builds .app, signs, notarizes
+```
+
+## Adapter table
+
+Verified 2026-04-30. URLs cited inline only on swaps; full citation list in `docs/research/2026-04-30-market-scan.md`.
+
+| Port | mac-native adapter | portable adapter | Notes |
+|---|---|---|---|
+| `AsrProvider` (live) | `panops-asr-mac` Swift sidecar — **Parakeet TDT v3 via FluidAudio (CoreML/ANE)**, ~110× RTF on M4 Pro, ~2.5× faster than Parakeet-MLX (FluidAudio v0.14.3, Apr 2026). | `whisper-rs` 0.16.0 wrapping whisper.cpp 1.8.4 (Metal on Mac, Vulkan/CUDA/CPU elsewhere). | Default ASR is the live path on incoming PCM frames. Language hint per chunk. |
+| `AsrProvider` (post-pass) | Same Swift sidecar, **whisper-large-v3-turbo via WhisperKit (Argmax Pro SDK 2)** with `beam_size=5`, VAD-gated. | `whisper-rs` with whisper-large-v3 (full, not turbo), beam=5. | Optional Mistral **Voxtral-Mini-3B** via `voxtral.c` MPS as a quality alternative on long meetings. |
+| `Diarizer` | FluidAudio diarizer (CoreML, pyannote-derived weights). | `pyannote.audio Community-1` via `ort` 2.x with CoreML EP on Mac, CPU elsewhere. | Runs on post-pass only. Heavy; downloaded on first use, not bundled. |
+| `AudioCapture` | ScreenCaptureKit (mic + system audio + per-app, macOS 14+) via `objc2` + `screencapturekit-rs`. | `cpal` (mic only — Linux/Win system-audio capture is OS-specific, deferred). | One unified API on Mac avoids BlackHole / Loopback. |
+| `VideoCapture` | ScreenCaptureKit screen / window / display. | `xcap` (Linux X11 + Wayland, Windows DXGI, video record WIP). | Replaces unmaintained `scrap`. |
+| `Encoder` | AVFoundation hw H.264/HEVC via Swift sidecar or objc2. | `ffmpeg` subprocess (simplest), `gstreamer-rs` if a pipeline DSL is needed later. | |
+| `ScreenshotSampler` | `VNGenerateImageFeaturePrintRequest` (Apple Vision feature-print embedding) via objc2. | `image_hasher` 3.x (maintained fork; original `img_hash` is dead). | Visual-change detection only; not a recall index. |
+| `LlmProvider` | `AppleFoundationModelsAdapter` (macOS 26 Tahoe, ~3B on-device) called from a small **separate** Swift sidecar (`panops-llm-mac`, distinct from the ASR sidecar to keep concerns separated and avoid loading WhisperKit when only the LLM runs). | `rust-genai` (Ollama / OpenAI / Anthropic / Gemini / Groq / DeepSeek / xAI / Cohere behind one trait). | Provider chosen per template; user picks default. |
+| `Storage` | — *(none planned; SQLite is portable already)* | `rusqlite` (single-user local-first; sqlx async overhead unneeded). | One SQLite per meeting + media files in `~/Library/Application Support/panops/meetings/<id>/`. The trait still exists so a future `PostgresStorage` or cloud-sync adapter can drop in. |
+| `Vad` | Silero VAD via Apple's Core ML runtime through the Swift sidecar. | `Silero` ONNX via `ort` 2.x. | Internal to the live pipeline; gates ASR windows so we don't burn cycles on silence. |
+
+## Live + post-pass pipeline
+
+A single `AsrProvider` trait exposes both methods — `transcribe_window` for live and `transcribe_full` for post-pass. Each adapter decides whether the two methods share a model (e.g. portable adapter uses `whisper-large-v3-turbo` for both) or use different models per method (e.g. mac-native uses Parakeet for live, whisper-large-v3-turbo for post-pass).
+
+**Live pass** (during recording):
+1. Mac shell captures audio with ScreenCaptureKit at native sample rate, downsamples to 16 kHz mono for ASR, streams 20 ms PCM frames over Unix socket to engine.
+2. Engine runs `Vad::should_emit(window)` — silent windows are skipped before ASR.
+3. Engine batches frames into a ring buffer (configurable, default 5 s window with 1.5 s overlap).
+4. On each non-silent window, engine calls `AsrProvider::transcribe_window(pcm, language_hint)` which forwards to the Swift sidecar; sidecar runs Parakeet TDT v3 on ANE.
+5. Sidecar emits `Segment { start, end, text, language_detected, confidence, is_partial }`.
+6. Engine deduplicates overlap, merges into the current `Meeting.live_transcript`, emits to UI via WebSocket.
+
+**Post-pass** (after recording stops):
+1. Engine reads the saved audio file (already on disk, never crossed IPC during the meeting).
+2. Calls `AsrProvider::transcribe_full(file_path, language_hint, mode=highest_quality)`.
+3. Sidecar runs whisper-large-v3-turbo via WhisperKit with `beam_size=5`, VAD filter, `condition_on_previous_text=true`.
+4. Engine reconciles: post-pass transcript replaces live transcript; live segment IDs are preserved where text matches (so live edits don't get clobbered).
+5. `Diarizer::label_speakers(audio_path, segments)` runs FluidAudio diarizer; assigns `speaker_id` per segment.
+6. User reviews segments + speaker labels in UI, can rename speakers (`Speaker 1` → `Fran`), edit text.
+7. `LlmProvider::summarize(transcript, screenshots, template)` produces markdown notes with screenshot embeds.
+
+## Multilingual & language toggle
+
+State machine:
+
+```
+Language ::= Auto | En | Es | It | <iso639-1>
+```
+
+- Default: `Auto`. Whisper-large-v3-turbo auto-detects per chunk; reasonable for monolingual sessions.
+- Toggle button in the menu bar / record window: `Auto / EN / ES / IT / Other…`. State stored on the `Meeting`.
+- On user click during recording: engine flushes the current window, rewinds 1.5 s, and starts the next window with the new `language_hint`. No model swap (Whisper is multilingual). Parakeet TDT v3 covers EN + 25 EU langs incl. ES; for IT or unsupported langs, engine downgrades to Whisper for that window.
+- On post-pass: per-segment `language_detected` from live is honored; chunks with mismatched detection are flagged for review.
+- Notes generation runs once with the dominant language as the LLM prompt language, but transcript is preserved verbatim per segment.
+
+## Screen + audio capture
+
+ScreenCaptureKit gives screen + system audio + per-app audio in one API on macOS 14+. macOS 26 Tahoe added HDR screenshot output; SCK itself unchanged. Per-app audio capture is the killer feature — record only the meeting app's audio, no music / system sounds bleeding in.
+
+Inputs the user picks before starting:
+- **Audio sources**: any combination of (default mic, default system audio, specific app audio, specific input device).
+- **Video source**: full display, specific display, specific window, or none (audio-only mode).
+- **Camera overlay**: optional, picture-in-picture, off by default.
+
+Recording lifecycle:
+- `Meeting::start(config)` → engine creates `~/.../meetings/<uuid>/` with `audio.m4a`, `video.mp4`, `meeting.db`, `screenshots/`.
+- Mac shell pipes audio frames to engine for live ASR.
+- Mac shell writes video directly to disk (never crosses IPC); video file path is registered in the meeting.
+- Mac shell runs the screenshot sampler in-process: every 500 ms, downsamples the latest video frame to 320×180, computes Vision FeaturePrint, compares to last kept frame; if cosine distance > threshold (default 0.15), writes full-res JPEG to `screenshots/<timestamp_ms>.jpg` and notifies engine.
+- `Meeting::stop()` → flush, finalize files, kick off post-pass.
+
+## Screenshot-anchored notes
+
+The differentiator. Pipeline:
+1. Recording produces N timestamped screenshots.
+2. Post-pass produces a transcript with start/end times per segment.
+3. Notes generation prompt receives: the transcript + a list of `(timestamp, file_path, optional_caption)` screenshots + the user's notes template + the active `MarkdownDialect`'s syntax cheat-sheet.
+4. LLM is instructed to embed screenshots inline when they're temporally relevant to the surrounding paragraph (`![](./screenshots/00:14:32.jpg)`) and to use dialect-appropriate syntax for callouts, toggles, action-item blocks, etc. Under `NotionEnhanced` it can emit `<callout icon="🎯">…</callout>`, `<details><summary>…</summary>…</details>`, `<table>` blocks, `{color="..."}` block colors. Under `Basic` it stays in CommonMark.
+5. Default template carries verified-speaker rules and narrative reconstruction. User can swap templates; templates declare which dialect features they assume.
+6. Output written by the active `NotesExporter`. The default `MarkdownExporter` produces `notes/YYYYMMDD-<slug>.md` with YAML frontmatter, the LLM-generated body, and relative image paths to `screenshots/`. Future `NotionExporter` POSTs the same dialect-`NotionEnhanced` body to the Notion API.
+
+The strict speaker-verification rule becomes part of the prompt: "Never attribute a quote to a speaker unless segment metadata includes a confirmed `speaker_id` from diarization."
+
+## IPC protocol
+
+**Transport**: Unix domain socket at `~/Library/Application Support/panops/engine.sock`.
+**Control plane**: JSON-RPC 2.0.
+**Event plane**: WebSocket upgrade on the same socket (or a sibling socket); server pushes events.
+
+Method shape (defined in `crates/panops-protocol`):
+
+```
+// Control
+meeting.start(config: MeetingConfig) -> MeetingId
+meeting.stop(id: MeetingId) -> Meeting
+meeting.set_language(id, lang: Language) -> ()
+meeting.list() -> [MeetingSummary]
+meeting.get(id) -> Meeting
+meeting.delete(id) -> ()
+
+asr.post_pass(meeting_id, opts: PostPassOpts) -> JobId
+asr.cancel(job_id) -> ()
+
+notes.generate(meeting_id, template_id, llm_provider, dialect?) -> JobId
+notes.export(meeting_id, exporter_id, opts) -> JobId      // markdown file | future: notion | obsidian | …
+
+llm.probe() -> ProbeResult                                 // detects available providers + recommended default
+llm.providers() -> [ProviderInfo]
+llm.test(provider_id) -> TestResult
+
+settings.get / settings.set
+```
+
+```
+// Events (over WS)
+{ "type": "asr.partial", "meeting_id": "...", "segment": Segment }
+{ "type": "asr.final",   "meeting_id": "...", "segment": Segment }
+{ "type": "screenshot",  "meeting_id": "...", "timestamp_ms": 873200, "path": "..." }
+{ "type": "job.progress", "job_id": "...", "phase": "diarize", "pct": 0.42 }
+{ "type": "job.done", "job_id": "...", "result": ... }
+{ "type": "job.error", "job_id": "...", "error": "..." }
+```
+
+The sidecar (`panops-asr-mac`) speaks a sub-protocol on stdin/stdout — `json-lines`, one PCM-or-control message per line. Engine wraps it in the same `AsrProvider` trait the portable adapter implements.
+
+## Storage model
+
+Per-meeting SQLite at `~/.../meetings/<uuid>/meeting.db`:
+
+```sql
+CREATE TABLE meeting (
+  id TEXT PRIMARY KEY, created_at INTEGER, started_at INTEGER, ended_at INTEGER,
+  title TEXT, language TEXT, audio_path TEXT, video_path TEXT, config_json TEXT
+);
+CREATE TABLE segment (
+  id INTEGER PRIMARY KEY, meeting_id TEXT, start_ms INTEGER, end_ms INTEGER,
+  text TEXT, language TEXT, confidence REAL, speaker_id INTEGER,
+  source TEXT  -- 'live' | 'post_pass'
+);
+CREATE TABLE speaker (
+  id INTEGER PRIMARY KEY, meeting_id TEXT, label TEXT, embedding BLOB
+);
+CREATE TABLE screenshot (
+  id INTEGER PRIMARY KEY, meeting_id TEXT, timestamp_ms INTEGER,
+  path TEXT, feature_print BLOB, caption TEXT
+);
+CREATE TABLE note (
+  id INTEGER PRIMARY KEY, meeting_id TEXT, template_id TEXT, content_md TEXT,
+  dialect TEXT NOT NULL DEFAULT 'notion-enhanced',
+  llm_provider TEXT, generated_at INTEGER
+);
+CREATE TABLE job (
+  id TEXT PRIMARY KEY, meeting_id TEXT, kind TEXT, status TEXT,
+  progress REAL, error TEXT, created_at INTEGER, finished_at INTEGER
+);
+```
+
+Cross-meeting registry at `~/.../panops.db`: just `meeting_id → path` and global settings.
+
+## Testing strategy
+
+- `panops-core` is pure Rust: unit-tested directly.
+- Each port has an `adapter-conformance` test suite in `tests/adapter-conformance/`. Both the `mac-native` and `portable` adapters run against the same suite. CI runs the portable suite on Linux + macOS; macOS-only job runs the mac-native suite too.
+- Live ASR has a fixture set: short bilingual EN/ES clips with known transcripts. Adapters must hit a WER threshold; both must agree on segment count within tolerance.
+- Diarizer: fixture meetings with known speaker counts; check ARI / DER thresholds.
+- Notes generation: snapshot tests on prompt construction, not LLM output. LLM call is mocked in tests; real LLM calls are gated behind a manual integration test that costs API credits.
+- IPC: integration tests spawn the engine, drive it via a test client, assert event sequences.
+- Property-based tests (`proptest`) on segment merging / overlap deduplication / language-toggle state machine.
+
+## Build & distribution
+
+- Mac app: Xcode build → universal binary (arm64 + x86_64 fallback) → notarized `.dmg` and Homebrew cask.
+- Engine binary: `cargo build --release` → bundled inside `.app` for the Mac distribution; standalone `.tar.gz` for headless / Linux / Windows.
+- Sidecar binary: built with the Mac app's Xcode pipeline; not shipped to non-Mac targets.
+- CI: GitHub Actions, matrix on (macOS-arm64, macOS-x86_64, ubuntu-latest, windows-latest), gating release on the conformance suite.
+- Auto-update: Sparkle for the Mac app (standard OSS Mac app pattern).
+
+## Decisions (locked 2026-04-30)
+
+1. **License: MIT.** Maximum adoption, no licensing friction. Bundled libraries keep their own licenses (WhisperKit Apache-2.0, FluidAudio Apache-2.0, pyannote MIT, whisper.cpp MIT, etc.) — all compatible.
+2. **Default LLM provider: machine-spec detection + first-run prompt with the detected default pre-selected.** On first launch the engine runs a `ProviderProbe`:
+   - If on macOS 26+ → Apple FoundationModels available; pre-select it.
+   - Else if `ollama` binary on `PATH` and `ollama list` returns at least one model → pre-select Ollama with the largest installed model.
+   - Else if `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY` env vars present → pre-select the matching cloud provider.
+   - Else → no default; user picks from the list.
+   The first-run dialog shows the detected default highlighted ("Use Apple Intelligence (recommended for your Mac)") with a "Choose another" affordance. Detected default is a fallback the engine will use if the user dismisses the dialog without picking — it is never used silently the first time without consent.
+3. **App display name = `panops`** (binary name, repo name, menu bar name — same everywhere).
+4. **Notes format: enhanced markdown by default, basic markdown via toggle.** YAML frontmatter on every notes file.
+   - **Frontmatter** (always emitted, both dialects):
+     ```yaml
+     ---
+     title: <derived from first heading or LLM-generated>
+     date: 2026-04-30
+     started_at: 2026-04-30T14:32:11-03:00
+     duration: 1h 23m 4s
+     language: en           # or "mixed: en, es"
+     participants: [Fran, Ada, ...]
+     template: default
+     dialect: notion-enhanced  # or "basic"
+     panops_version: 0.1.0
+     meeting_id: <uuid>
+     audio: ./audio.m4a
+     video: ./video.mp4
+     screenshots_dir: ./screenshots/
+     ---
+     ```
+   - **`MarkdownDialect` enum**: `NotionEnhanced` (default) | `Basic`. Future: `Obsidian`, `Roam`. Selectable globally in settings, overridable per meeting / per template.
+   - **`NotionEnhanced` dialect** = Notion-flavored markdown ([Notion Enhanced Markdown reference](https://developers.notion.com/llms.txt)): supports `<callout>`, `<details>` toggles, `<columns>`, `<table>`, `<mention-*>`, `<table_of_contents>`, `{color="..."}` block colors, etc. Renders cleanly in Notion (POSTable to `/v1/pages` for the future Notion exporter), degrades gracefully in renderers that ignore unknown HTML-like tags.
+   - **`Basic` dialect** = CommonMark-only fallback: headings, lists, tables, code blocks, image embeds, plain blockquotes. For Obsidian / GitHub / vanilla markdown viewers that don't tolerate the Notion extensions.
+   - **`NotesGenerator` is dialect-aware**: the LLM prompt includes the active dialect's syntax cheat-sheet, so the model emits compliant markup for that target. Dialect is passed as a structured arg, not freeform.
+   - **`NotesExporter` trait** ships at v1.0 with `MarkdownExporter` (writes the `.md` file + frontmatter + screenshots beside it). Future: `NotionExporter` (POSTs the Notion-Enhanced markdown to the Notion API), `ObsidianExporter` (path conventions), etc. Adding an exporter is a new adapter, no UI changes.
+5. **Telemetry: zero, ever.** No phone-home, no opt-in toggle, no anonymous metrics. Crash logs stay local.
+
+## Decision-driven additions to the architecture
+
+- New port: `LlmProviderProbe` in `panops-core`. `mac-native` adapter detects macOS version + FoundationModels availability via the LLM sidecar. `portable` adapter checks `PATH` for `ollama`, env vars for cloud keys.
+- New port: `NotesExporter` in `panops-core`. `MarkdownExporter` (default, ships at v1.0) writes `.md` + frontmatter + screenshots. Future exporters drop in as new adapters.
+- New domain type: `MarkdownDialect` enum. Stored on `Meeting`, defaulted from global setting, overridable per-meeting in the UI.
+- `notes` table: add `dialect TEXT NOT NULL DEFAULT 'notion-enhanced'` column. The `content_md` column already covers both dialects.
+

--- a/docs/superpowers/specs/2026-04-30-slice-02-headless-cli-design.md
+++ b/docs/superpowers/specs/2026-04-30-slice-02-headless-cli-design.md
@@ -1,0 +1,297 @@
+---
+project: panops
+date: 2026-04-30
+status: design (pre-implementation)
+slice: 02
+authors: Fran Matzkin
+type: design
+---
+
+# Slice 02 — Headless CLI on fixture audio
+
+## Summary
+
+The walking skeleton: feed a fixture WAV to the engine, get JSON segments back. Establishes the `AsrProvider` port, the portable `whisper-rs` adapter, the conformance harness pattern, and the JSON contract that every later slice (notes, IPC, Mac shell) consumes.
+
+Multilingual from day one. The `panops-engine` binary is a developer/CI surface only — the SwiftUI Mac app is the actual product, and the binary exists for OSS portability and as the engine the future IPC server (slice 05) will host.
+
+## Goals
+
+- First slice that actually transcribes audio. End-to-end: WAV → segments → JSON.
+- Land the `AsrProvider` trait + `Segment` domain type in `panops-core` (born when needed, not pre-traited).
+- Land `panops-portable` with the `whisper-rs` adapter (real impl).
+- Land a fake adapter under `tests/fixtures/` (reads the `*.transcript.txt` sidecar files committed in slice 01).
+- Land the conformance harness pattern: both real and fake adapters pass the same test suite.
+- Multilingual: EN, ES, and mixed fixtures all transcribe via Whisper auto-detect; per-segment `language_detected` populated.
+- `panops-engine` binary: minimal dev/CI surface (`panops-engine <wav> [--model <path>]`).
+
+## Non-goals
+
+- Live streaming / partial segments. `is_partial` is always `false` in slice 02 (kept in the schema for forward compat).
+- Subcommands or polished CLI UX. The binary's `--help` says "dev/debug tool — see Panops.app for the actual product."
+- Multiple output formats (SRT/VTT/TXT). JSON only. The other formats arrive in a later slice when a real consumer needs them.
+- Diarization, post-pass quality model, screenshots — those are slices 03 / 04.
+- Mac-specific code. Slice 02 is target-os-agnostic; the `panops-mac` crate doesn't get touched.
+
+## Architecture
+
+```
+┌──────────────────────────────────────┐
+│       panops-engine (binary)         │
+│  CLI: parse args, dispatch, emit     │
+│  JSON to stdout. Dev/CI surface.     │
+└──────────────┬───────────────────────┘
+               │ depends on
+               ▼
+┌──────────────────────────────────────┐    ┌────────────────────────────┐
+│          panops-portable             │───▶│         panops-core         │
+│  WhisperRsAsr (impl AsrProvider)     │    │  trait AsrProvider          │
+│  Wraps whisper-rs 0.16.0.            │    │  struct Segment             │
+└──────────────────────────────────────┘    │  struct Transcript          │
+                                            │  pub mod conformance::asr   │
+┌──────────────────────────────────────┐    │  (test harness, runs fixtures
+│  tests/fixtures/fake_adapter         │───▶│   against any impl).        │
+│  TranscriptFileFake (impl AsrProv.)  │    └────────────────────────────┘
+│  Reads *.transcript.txt sidecar.     │
+└──────────────────────────────────────┘
+```
+
+## Public contracts
+
+### `AsrProvider` trait (`panops-core`)
+
+```rust
+pub trait AsrProvider {
+    /// Transcribe a complete audio file. Blocking, file-based.
+    /// `language_hint` is `None` for auto-detect, `Some("en")` etc. to force.
+    fn transcribe_full(
+        &self,
+        audio_path: &Path,
+        language_hint: Option<&str>,
+    ) -> Result<Transcript, AsrError>;
+}
+```
+
+`transcribe_window` (live streaming) is deliberately omitted. It lands in slice 06/07 when live capture exists.
+
+### `Segment` and `Transcript` types
+
+```rust
+pub struct Segment {
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+    pub language_detected: Option<String>,  // ISO 639-1, None if undetermined
+    pub confidence: f32,                    // [0.0, 1.0]
+    pub is_partial: bool,                   // always false in slice 02
+}
+
+pub struct Transcript {
+    pub segments: Vec<Segment>,
+    pub model: String,                      // e.g., "ggml-tiny-q5_1"
+    pub audio_path: PathBuf,
+    pub audio_duration_ms: u64,
+}
+```
+
+### JSON wire shape (binary stdout)
+
+```json
+{
+  "schema_version": 1,
+  "model": "ggml-tiny-q5_1",
+  "audio_path": "tests/fixtures/audio/en_30s.wav",
+  "audio_duration_ms": 26944,
+  "segments": [
+    {
+      "start_ms": 0,
+      "end_ms": 4520,
+      "text": "The quick brown fox jumps over the lazy dog.",
+      "language_detected": "en",
+      "confidence": 0.91,
+      "is_partial": false
+    }
+  ]
+}
+```
+
+Serialized via `serde` derives on `Transcript` and `Segment`. Field naming uses `snake_case` consistently (no `serde(rename_all)` aliasing).
+
+### CLI surface
+
+```
+panops-engine <wav> [--model <path>] [--language <code>]
+
+Args:
+  <wav>             Path to a 16 kHz mono WAV file.
+
+Flags:
+  --model <path>    Override the default model location. Defaults to
+                    <data_dir>/panops/models/ggml-tiny-q5_1.bin, downloaded
+                    on first run if absent.
+  --language <code> ISO 639-1 hint. Default: auto-detect per segment.
+
+Output: JSON Transcript on stdout. Diagnostics on stderr.
+Exit codes: 0 success, 1 input error, 2 transcription error, 3 model error.
+```
+
+`--help` includes the line "Dev/CI tool. See https://github.com/vfmatzkin/panops for the desktop app."
+
+## Crate layout
+
+New workspace members:
+
+- `crates/panops-portable/` — library crate.
+  - `Cargo.toml`: depends on `panops-core`, `whisper-rs = "0.16"`, `hound` (WAV reader), `directories = "5"`, `reqwest` (download), `sha2` (checksum).
+  - `src/lib.rs`: `pub struct WhisperRsAsr { model_path: PathBuf, ctx: WhisperContext }`. `impl AsrProvider for WhisperRsAsr`.
+  - `src/model.rs`: `fn ensure_model(name: &str, dest: &Path) -> Result<()>`. Idempotent download, sha256 verify.
+  - `tests/conformance.rs`: instantiates `WhisperRsAsr`, calls `panops_core::conformance::asr::run_suite`.
+  - Marked `#[cfg(not(target_arch = "wasm32"))]` on the model fetcher; not relevant yet but documents intent.
+
+- `crates/panops-engine/` — binary crate.
+  - `Cargo.toml`: depends on `panops-core`, `panops-portable`, `clap = { version = "4", features = ["derive"] }`, `serde_json`.
+  - `src/main.rs`: clap-derived CLI, dispatches to `WhisperRsAsr::transcribe_full`, emits JSON.
+
+`panops-core` grows:
+- `src/lib.rs`: re-exports.
+- `src/segment.rs`: `Segment` + `Transcript`.
+- `src/asr.rs`: `AsrProvider` trait + `AsrError` enum.
+- `src/conformance/mod.rs`: `pub mod asr;` (only public test-helper module so far).
+- `src/conformance/asr.rs`: `run_suite(&impl AsrProvider, fixtures_dir: &Path)`.
+
+`tests/fixtures/fake_adapter/` is **not** a workspace crate. It's a tiny module under `panops-core`'s `dev-dependencies` path:
+- `panops-core/src/conformance/fakes.rs`: `pub struct TranscriptFileFake;` reads the sibling `*.transcript.txt`, returns a single `Segment` covering the whole audio.
+- `tests/conformance_fake.rs` in `panops-core`: instantiates `TranscriptFileFake`, runs the conformance suite.
+
+Rationale: keeping the fake inside `panops-core` (behind a `pub` module that's only useful at test-time) avoids a separate workspace crate for one tiny struct. The `dev-dependencies` ergonomic remains intact.
+
+## Model handling
+
+Default model: `ggml-tiny-q5_1.bin` (~31 MB, multilingual quantized).
+
+Resolution order:
+1. `--model <path>` flag, if provided.
+2. `PANOPS_MODEL` env var (escape hatch for CI), if set.
+3. `<data_dir>/panops/models/ggml-tiny-q5_1.bin`, where `data_dir` is from `directories::ProjectDirs::from("dev", "panops", "panops").data_dir()`.
+   - macOS: `~/Library/Application Support/panops/models/`
+   - Linux: `~/.local/share/panops/models/`
+   - Windows: `%APPDATA%\panops\panops\data\models\`
+
+If absent at the resolved path, download from `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin`. Verify sha256 against a hardcoded constant. Stderr message: `Downloading ggml-tiny-q5_1.bin (31 MB)... done.`. No interactive prompt — silent acceptance, since the binary is non-interactive by design.
+
+CI: GitHub Actions cache step keys on the model filename. Cache path: `~/.cache/panops/models/`. Override `PANOPS_MODEL=~/.cache/panops/models/ggml-tiny-q5_1.bin` in the workflow so tests use the cached file without touching the platform data dir.
+
+## Fake adapter
+
+`TranscriptFileFake` reads `<audio_path>.transcript.txt` (sibling file) and returns a single `Segment` with:
+- `start_ms = 0`
+- `end_ms = audio_duration_ms` (computed via `hound` from the WAV header)
+- `text = the full transcript file contents, trimmed`
+- `language_detected = Some(<derived from filename prefix>)`:
+  - `en_*` → `"en"`
+  - `es_*` → `"es"`
+  - `mixed_*` → `"en"` (arbitrary; the mixed-fixture conformance assertion accepts en or es)
+  - anything else → `None`
+- `confidence = 1.0`
+- `is_partial = false`
+
+The fake does **not** parse the bracketed `[en, 0.0s..27.0s]` markers in the mixed transcript. That heuristic is real-adapter territory.
+
+## Conformance harness
+
+`panops_core::conformance::asr::run_suite(provider: &impl AsrProvider, fixtures_dir: &Path)`:
+
+For each fixture in a hardcoded list `[en_30s, es_30s, mixed_60s]`:
+1. Locate `<fixtures_dir>/audio/<name>.wav` and `<fixtures_dir>/audio/<name>.transcript.txt`.
+2. Call `provider.transcribe_full(&audio_path, None)`.
+3. Assert the contract:
+   - `segments.len() >= 1`
+   - For each segment: `start_ms <= end_ms <= audio_duration_ms + 100ms` (slack for rounding).
+   - For consecutive segments `s[i]` and `s[i+1]`: `s[i].end_ms <= s[i+1].start_ms` (non-overlapping, ordered).
+   - At least one segment has `language_detected.is_some()`.
+4. Per-fixture language assertion:
+   - `en_30s`: at least one segment has `language_detected == Some("en")`.
+   - `es_30s`: at least one segment has `language_detected == Some("es")`.
+   - `mixed_60s`: at least one segment has `language_detected.as_deref() == Some("en") || Some("es")`.
+5. WER assertion (skipped if `provider.is_fake()` returns true — see below):
+   - `en_30s`: WER between concatenated segment text and `en_30s.transcript.txt` ground truth ≤ 0.30.
+   - `es_30s`: same, ≤ 0.30.
+   - `mixed_60s`: no WER threshold; the auto-detect transcript is too unstable to gate on.
+
+`AsrProvider` adds an optional `fn is_fake(&self) -> bool { false }` so fakes opt out of WER (their text is the transcript by construction; WER is trivially 0). Slight smell, but cleaner than two suite functions.
+
+WER computation: a small in-tree implementation (`Levenshtein on whitespace-tokenized lowercase strings, ignoring punctuation`). No new crate dep.
+
+## Build, test, CI
+
+- `cargo build --workspace` — builds all four crates.
+- `cargo test --workspace` — runs:
+  - `panops-core`: unit tests + `tests/conformance_fake.rs` (fake adapter passes the suite).
+  - `panops-portable`: `tests/conformance.rs` (real adapter passes the suite, including WER assertions). Requires the model.
+  - `panops-engine`: smoke test invoking the binary on `en_30s.wav` and asserting the output JSON parses + matches the schema.
+- CI workflow update: add a "fetch model" step before `cargo test` for the matrix jobs:
+  ```yaml
+  - name: Cache Whisper model
+    uses: actions/cache@v4
+    with:
+      path: ~/.cache/panops/models
+      key: ggml-tiny-q5_1-v1
+  - name: Ensure model
+    run: |
+      mkdir -p ~/.cache/panops/models
+      [ -f ~/.cache/panops/models/ggml-tiny-q5_1.bin ] || \
+        curl -fL -o ~/.cache/panops/models/ggml-tiny-q5_1.bin \
+          https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin
+    env:
+      PANOPS_MODEL: ~/.cache/panops/models/ggml-tiny-q5_1.bin
+  ```
+  `PANOPS_MODEL` is then propagated into the test step's env.
+
+## Performance budget
+
+On a clean GitHub Actions runner (no GPU), tiny.q5_1 transcribes 30 s of audio in roughly 5–15 s of CPU time. The conformance suite's three fixtures total ~110 s of audio, so the worst-case test pass is roughly 30–60 s. Acceptable for a per-PR check.
+
+## Risks
+
+- **Tiny model + synthetic TTS = noisy transcripts.** The 0.30 WER threshold is generous to cover this. If reality is even worse, we either bump the threshold (loosens the gate) or swap to base.q5_1 (~57 MB, slower but accurate). Decision deferred to first CI run.
+- **Hugging Face URL availability.** Mirror via R2 / GitHub release asset if the HF URL is rate-limited or removed. Out of scope for slice 02; revisit if it bites.
+- **Cold-cache CI.** First CI run after `actions/cache` invalidation pulls 31 MB. Tolerable.
+
+## Decisions locked
+
+1. Model: `ggml-tiny-q5_1.bin` (multilingual quantized, ~31 MB), downloaded on first run.
+2. Cache path: cross-platform via `directories` crate. CI uses `~/.cache/panops/models/` via `PANOPS_MODEL` env.
+3. Binary surface: `panops-engine <wav> [--model <path>] [--language <code>]`. Dev/CI only, no subcommands.
+4. JSON shape: wrapper object with `schema_version`, `model`, `audio_path`, `audio_duration_ms`, `segments[]`. Timestamps in ms.
+5. `is_partial` field present in schema, always `false` in slice 02.
+6. New crates: `panops-portable`, `panops-engine`. `panops-core` grows the trait + types + conformance harness module.
+7. Fake adapter lives inside `panops-core::conformance::fakes`, single-segment per audio file, language inferred from filename.
+8. WER threshold: 0.30 on EN and ES fixtures via Levenshtein on whitespace-tokenized lowercase. Skipped for fakes via `is_fake()` opt-out.
+9. CLI emits JSON only. SRT/VTT/TXT exporters land in a later slice when a consumer demands them.
+
+## Open questions / followups (NOT blocking slice 02)
+
+- Mirror the HF model URL on a project-controlled host before v0.1 release.
+- Pick whether `confidence` is the avg of token log-probs or the segment-level `no_speech_prob` complement. (whisper-rs exposes both; we'll just pick one in implementation and note it.)
+- Decide whether to expose `--no-download` flag for CI air-gapped scenarios. Likely yes once we hit one.
+
+## Model selection UX — deferred to the desktop app
+
+Slice 02 hardcodes `ggml-tiny-q5_1` because the binary is a dev/CI surface. End users never see this default — the desktop app does the picking. The model-picker UX lands later (likely riding slice 06 SwiftUI shell) and mirrors the LLM-provider picker pattern locked in the master design spec (Decision #2):
+
+1. **First-run probe** via a new `ModelProbe` port. Inspects machine class (Apple Silicon yes/no, RAM, ANE) and pre-selects a default:
+   - Apple Silicon + ≥16 GB RAM → `large-v3-turbo` (via WhisperKit + ANE on Mac).
+   - Apple Silicon + 8 GB RAM → `medium.q5_1`.
+   - Intel Mac or Linux → `base.q5_1`.
+   - Probe fails / unknown → `tiny.q5_1`.
+2. **First-run prompt** dialog with the detected default highlighted ("Recommended for your Mac"). User can accept or pick another. Detected default is a fallback, never used silently.
+3. **Settings panel** lists models with quality/size/speed badges and a per-entry Download button. Mirrors the LLM provider settings UI.
+4. **Per-meeting override** on the record sheet for one-off "use a heavier model this time" cases.
+
+For slice 02 we just lock the contract that the engine accepts an arbitrary model path via `--model` (or `PANOPS_MODEL` env). The desktop app will call the binary with the user's chosen path. No engine-side picker UI in scope here.
+
+`ModelProbe` itself is a new port that lands when slice 06's settings panel needs it. Slice 02 does not introduce it.
+
+---
+
+Ready to invoke writing-plans on this. Approve to proceed?

--- a/docs/superpowers/specs/2026-05-01-slice-03-postpass-diarization-design.md
+++ b/docs/superpowers/specs/2026-05-01-slice-03-postpass-diarization-design.md
@@ -1,0 +1,380 @@
+---
+project: panops
+date: 2026-05-01
+status: design (pre-implementation)
+slice: 03
+authors: Fran Matzkin
+type: design
+---
+
+# Slice 03 — Post-pass + diarization
+
+## Summary
+
+Adds the `Diarizer` port and a portable adapter (sherpa-onnx via `sherpa-rs`), upgrades the production Whisper model from `tiny.q5_1` to `large-v3-turbo-q5_0`, and merges speaker labels into segments. Slice 03 ships the post-pass-after-recording flow; the rolling-during-recording variant lands in slice 06+ on top of these same ports.
+
+CI gets a model split: production users download `large-v3-turbo-q5_0` (~547 MB) on first run; CI uses `base.q5_1` (~57 MB) routed via `PANOPS_MODEL`. Closes issue #9 along the way.
+
+## Goals
+
+- Land the `Diarizer` trait in `panops-core` (born when needed, not pre-traited).
+- Land the portable diarization adapter via `sherpa-rs`.
+- Add `speaker_id: Option<u32>` to `Segment`. Engine merges diarizer output into ASR output by timestamp overlap.
+- Bump the default Whisper model to `large-v3-turbo-q5_0` for production. CI continues with a smaller model for tractable runtime.
+- Add a multi-speaker test fixture and the conformance suite for `Diarizer`.
+- Engine binary: `panops-engine <wav>` diarizes by default; `--no-diarize` opts out.
+- Keep ports stateless and chunk-friendly so slice 06's live capture can wire rolling-during-recording or at-end without changes here.
+
+## Non-goals
+
+- Live ASR / streaming. No `transcribe_window` work — slice 06/07.
+- Rolling re-pass during recording. The orchestrator that schedules post-pass on completed buffers is slice 06+.
+- LLM grammar cleanup / notes generation. Slice 04.
+- Mac-native diarization (FluidAudio's CoreML diarizer). Slice 06's `panops-mac` adapter.
+- Model picker UX in the desktop app. Deferred to slice 06.
+- WhisperKit / Argmax SDK integration on Mac. Slice 06.
+- ARI/DER metrics with tight thresholds. Slice 03 uses loose structural assertions; tightening lands in a follow-up.
+
+## Architecture (delta from slice 02)
+
+```
+┌──────────────────────────────────────┐
+│       panops-engine (binary)         │
+│  CLI: parse, dispatch ASR + diarize, │
+│  merge by timestamp, emit JSON.      │
+└──────┬───────────────────┬───────────┘
+       │                   │
+       ▼                   ▼
+┌──────────────┐    ┌──────────────────┐
+│ panops-core  │    │ panops-portable  │
+│ Segment      │◀───│ WhisperRsAsr     │
+│   + speaker  │    │ (impl AsrProv)   │
+│ AsrProvider  │    │                  │
+│ Diarizer     │◀───│ SherpaDiarizer   │
+│ SpeakerTurn  │    │ (impl Diarizer)  │
+│ conformance::│    │ model::registry  │
+│   asr,diar   │    │   tiny | base |  │
+└──────────────┘    │   large-v3-turbo │
+                    └──────────────────┘
+```
+
+The engine pipeline becomes:
+
+```
+audio.wav
+  │
+  ├──▶ AsrProvider::transcribe_full ─▶ Vec<Segment>  (no speaker_id)
+  │
+  └──▶ Diarizer::diarize ─────────────▶ Vec<SpeakerTurn>
+                                            │
+   merge_by_overlap(segments, turns) ───────┘
+                                            │
+                                            ▼
+                                     Vec<Segment> (speaker_id populated)
+                                            │
+                                            ▼
+                                       Transcript JSON
+```
+
+## Public contracts
+
+### `Diarizer` trait (`panops-core`)
+
+```rust
+pub trait Diarizer {
+    /// Run speaker diarization on a complete audio file. Stateless.
+    /// Returns a list of speaker-labeled time spans, ordered by `start_ms`,
+    /// non-overlapping. Speaker IDs are integers stable within one call;
+    /// they have no meaning across calls.
+    fn diarize(&self, audio_path: &Path) -> Result<Vec<SpeakerTurn>, DiarError>;
+
+    /// Marker for the conformance harness; production impls leave the default.
+    fn is_fake(&self) -> bool {
+        false
+    }
+}
+```
+
+### `SpeakerTurn` and `DiarError`
+
+```rust
+pub struct SpeakerTurn {
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub speaker_id: u32,
+}
+
+#[derive(Debug, Error)]
+pub enum DiarError {
+    #[error("audio file not found: {0}")]
+    AudioNotFound(PathBuf),
+    #[error("invalid audio: {0}")]
+    InvalidAudio(String),
+    #[error("model error: {0}")]
+    Model(String),
+    #[error("diarization failed: {0}")]
+    Diarization(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+### `Segment` grows one field
+
+```rust
+pub struct Segment {
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+    pub language_detected: Option<String>,
+    pub confidence: f32,
+    pub is_partial: bool,
+    pub speaker_id: Option<u32>,    // NEW. None = not diarized.
+}
+```
+
+`schema_version` bumps to `2`. The added field is `Option`-typed so the JSON shape stays additive: deserializers expecting v1 ignore the new field; v2 deserializers default `None` if it's missing.
+
+### JSON wire shape (binary stdout)
+
+```json
+{
+  "schema_version": 2,
+  "model": "ggml-large-v3-turbo-q5_0",
+  "audio_path": "tests/fixtures/audio/multi_speaker_60s.wav",
+  "audio_duration_ms": 60000,
+  "diarized": true,
+  "segments": [
+    {
+      "start_ms": 0,
+      "end_ms": 5200,
+      "text": "Hello, this is the first speaker talking.",
+      "language_detected": "en",
+      "confidence": 0.92,
+      "is_partial": false,
+      "speaker_id": 0
+    }
+  ]
+}
+```
+
+`diarized: bool` is a top-level field that says whether the diarizer ran (true) or was suppressed by `--no-diarize` (false). Cleaner than guessing from segment fields.
+
+### CLI surface
+
+```
+panops-engine <wav> [--model <path>] [--language <code>] [--no-diarize]
+
+New flag:
+  --no-diarize    Skip the diarization pass. ASR-only output.
+                  Faster; segments have speaker_id = null.
+```
+
+Default behavior changes: diarization is **on** by default. Slice 02 binaries that didn't pass `--no-diarize` will diarize; same JSON shape, plus `speaker_id` populated. CI tests opt out via `--no-diarize` for the ASR-only conformance and opt in for the diarizer conformance.
+
+## Crate layout
+
+New code in existing crates (no new crates):
+
+- `crates/panops-core/src/diar.rs` (NEW): `Diarizer`, `SpeakerTurn`, `DiarError`.
+- `crates/panops-core/src/segment.rs`: add `speaker_id` field, bump `SCHEMA_VERSION` to `2`, add `diarized` to `Transcript`.
+- `crates/panops-core/src/conformance/diar.rs` (NEW): `run_suite(provider, fixtures_dir)` for `Diarizer`.
+- `crates/panops-core/src/conformance/fakes.rs`: add `KnownTurnsFake` (a `Diarizer` fake that reads a sidecar `*.turns.json`).
+- `crates/panops-core/src/lib.rs`: `pub mod diar;` re-exports.
+- `crates/panops-portable/src/sherpa_diarizer.rs` (NEW): `SherpaDiarizer` impl.
+- `crates/panops-portable/src/model.rs`: registry refactor (see below).
+- `crates/panops-portable/src/lib.rs`: `pub use sherpa_diarizer::SherpaDiarizer;`.
+- `crates/panops-portable/Cargo.toml`: add `sherpa-rs = "0.6"` (or current version at impl time).
+- `crates/panops-portable/tests/conformance_diar.rs` (NEW): real `SherpaDiarizer` against the multi-speaker fixture.
+- `crates/panops-engine/src/main.rs`: add `--no-diarize` flag, wire diarization, merge segments.
+- `tests/fixtures/audio/multi_speaker_60s.{wav,transcript.txt,turns.json}` (NEW): three TTS turns, two voices (A-B-A pattern).
+- `tests/fixtures/scripts/generate.sh`: append the multi-speaker generation step.
+
+## Model registry refactor
+
+`crates/panops-portable/src/model.rs` grows from one hardcoded model to a registry:
+
+```rust
+pub struct ModelInfo {
+    pub name: &'static str,           // e.g., "ggml-large-v3-turbo-q5_0"
+    pub url: &'static str,
+    pub sha256: &'static str,
+    pub approx_size_mb: u32,
+}
+
+pub const MODELS: &[ModelInfo] = &[
+    ModelInfo {
+        name: "ggml-tiny-q5_1",
+        url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin",
+        sha256: "818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7",
+        approx_size_mb: 31,
+    },
+    ModelInfo {
+        name: "ggml-base-q5_1",
+        url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
+        sha256: "422f1ae452ade6f30a004d7e5c6a43195e4433bc370bf23fac9cc591f01a8898",
+        approx_size_mb: 57,
+    },
+    ModelInfo {
+        name: "ggml-large-v3-turbo-q5_0",
+        url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+        sha256: "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2",
+        approx_size_mb: 547,
+    },
+];
+
+pub const DEFAULT_MODEL_NAME: &str = "ggml-large-v3-turbo-q5_0";
+
+pub fn ensure_model_by_name(name: &str, dest: &Path) -> Result<PathBuf, AsrError>;
+pub fn default_model_path() -> Result<PathBuf, AsrError>;  // resolves DEFAULT_MODEL_NAME
+```
+
+Plus a separate registry for diarization models:
+
+```rust
+pub const DIAR_MODELS: &[ModelInfo] = &[
+    ModelInfo {
+        name: "sherpa-pyannote-segmentation-3-0",
+        // Tarball; ensure_diar_model unpacks it next to itself before returning the .onnx path.
+        url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2",
+        sha256: "24615ee884c897d9d2ba09bb4d30da6bb1b15e685065962db5b02e76e4996488",
+        approx_size_mb: 7,
+    },
+    ModelInfo {
+        name: "3dspeaker-eres2net-base",
+        url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx",
+        sha256: "1a331345f04805badbb495c775a6ddffcdd1a732567d5ec8b3d5749e3c7a5e4b",
+        approx_size_mb: 38,
+    },
+];
+```
+
+The `SherpaDiarizer::new()` takes paths to both ONNX files; a helper `default_diar_paths()` resolves them via the same `directories` data dir.
+
+Sha256 values are computed once during implementation (Task 0) and baked in. CI verifies them just like the Whisper model.
+
+## CI strategy: production / test split
+
+The engine binary's `default_model_path()` resolves to `large-v3-turbo-q5_0` when no env override is set. CI overrides via `PANOPS_MODEL=<path-to-base-q5_1>` and the workflow's "Ensure model" step downloads `base.q5_1` (not `large-v3-turbo`).
+
+Why `base.q5_1` for CI rather than keeping `tiny.q5_1`:
+- WER threshold gets meaningful headroom (issue #9 documented the 3.5% margin pain on tiny).
+- Still small enough to download in <10 s.
+- Real model behavior, not toy-model behavior.
+
+WER threshold drops from 0.35 to ~0.15 (verified at impl time on the actual fixture). Headroom target: ≥ 5%.
+
+Diarization weights (~28 MB total) get the same cache-then-download treatment as Whisper. The CI cache key incorporates the `model.rs` hash so a registry change invalidates cleanly.
+
+## Multi-speaker fixture
+
+`tests/fixtures/audio/multi_speaker_60s.wav` — 60 s, three turns:
+
+| Turn | Range | Voice (`say -v`) | Speaker | Sample text |
+|---|---|---|---|---|
+| 1 | 0–20 s | Samantha (en) | A | "Welcome to this meeting. Let's go over the agenda for today." |
+| 2 | 20–40 s | Daniel (en, British male) | B | "Thanks. The first item is the budget review for next quarter." |
+| 3 | 40–60 s | Samantha (en) | A (returning) | "Right. I'll start with the marketing line items, then move to engineering." |
+
+Generated by `scripts/generate.sh` via three `say -o` calls (different `-v`) + `ffmpeg concat`. Voice A returns in turn 3 to test speaker re-identification (the genuinely-hard diarization case).
+
+Sidecar `multi_speaker_60s.turns.json`:
+
+```json
+[
+  {"start_ms": 0, "end_ms": 20000, "speaker_id": 0},
+  {"start_ms": 20000, "end_ms": 40000, "speaker_id": 1},
+  {"start_ms": 40000, "end_ms": 60000, "speaker_id": 0}
+]
+```
+
+The fake `KnownTurnsFake` reads this file. The real `SherpaDiarizer` runs sherpa-onnx and we compare structurally.
+
+## Conformance harness for `Diarizer`
+
+`panops_core::conformance::diar::run_suite(provider, fixtures_dir)` runs:
+
+For `multi_speaker_60s.wav`:
+1. Returns ≥ 2 distinct `speaker_id` values across all turns.
+2. Total covered duration ≥ 80% of audio duration (allowing for short silences).
+3. For each consecutive turn pair: `turn[i].end_ms <= turn[i+1].start_ms` (ordered, non-overlapping).
+4. **Re-identification structural check (real adapter only, skipped for fakes):** the speaker assigned to the largest portion of `0–20 s` and the speaker assigned to the largest portion of `40–60 s` are the **same** id. (Speaker A returns.)
+5. Real adapter only: ≥ 1 turn intersects each ground-truth turn from `multi_speaker_60s.turns.json` for ≥ 50% of its duration. (Per-turn coverage; not strict ARI/DER yet.)
+
+Loose. Tightens in a follow-up issue once we know what real sherpa-onnx output looks like on this fixture.
+
+## ASR conformance update
+
+The existing `asr::run_suite` continues to assert structural + WER on the EN/ES/mixed fixtures. Adds:
+- A `multi_speaker_60s` case asserting structural ASR works (segments cover the audio, language detected, etc.) — no WER threshold (multi-voice TTS is harder than the single-voice fixtures, would push WER too high).
+
+## Engine merge logic
+
+`panops-engine`'s `run()` after slice 03:
+
+```rust
+let segments = asr.transcribe_full(&audio_path, lang_hint)?;
+let segments = if args.no_diarize {
+    segments
+} else {
+    let turns = diar.diarize(&audio_path)?;
+    merge_speaker_turns(segments, &turns)
+};
+```
+
+`merge_speaker_turns` is a small function in `panops-core::segment` (or a new `merge.rs`):
+
+```rust
+pub fn merge_speaker_turns(
+    segments: Vec<Segment>,
+    turns: &[SpeakerTurn],
+) -> Vec<Segment> {
+    segments.into_iter().map(|mut seg| {
+        seg.speaker_id = dominant_speaker(seg.start_ms, seg.end_ms, turns);
+        seg
+    }).collect()
+}
+```
+
+`dominant_speaker` returns the speaker who covers the most milliseconds of the segment, or `None` if no turn overlaps. Unit-tested with synthetic segments + turns.
+
+## Risks
+
+- **`sherpa-rs` build complexity.** Like `whisper-rs`, it pulls a C++ dependency (sherpa-onnx) via cmake. First build is slow. CI cmake build for both whisper.cpp + sherpa-onnx pushes the cold-cache CI runtime to ~10 min. Acceptable; warm cache stays fast. If it bites, swap to a pure-Rust diarizer (writing one over `ort` is a research project — defer).
+- **Linux SIMD issue (issue #7) extends to sherpa-onnx.** Same `-march=native` cross-CPU SIGILL risk. If it fires, Linux CI stays compile-only for diarization tests too. Document in the same issue.
+- **Model registry sha256 churn.** Three Whisper models + two diarization models = 5 hashes to maintain. If HF or k2-fsa re-upload, all break. Issue #8 (mirror to project-controlled host) becomes more urgent — track but don't block.
+- **Speaker re-identification accuracy.** sherpa-onnx with the 3dspeaker eres2net model on TTS audio (which has artificially clean voice characteristics) might over-cluster (one speaker per turn) or under-cluster (everything is speaker 0). The conformance assertion is loose precisely because of this; if it fails on the first CI run, we either tune sherpa params or weaken the assertion. Don't lower below "≥ 2 distinct speakers" without flagging.
+
+## Decisions locked
+
+1. **`Diarizer` is its own port**, not a method on `AsrProvider`. Stateless. Returns `Vec<SpeakerTurn>`. Engine merges into segments by timestamp overlap.
+2. **`Segment` grows `speaker_id: Option<u32>`.** `Transcript.schema_version` bumps to 2. Added field is optional so v1 consumers don't break.
+3. **`Transcript` grows `diarized: bool`** at the top level. Makes "was the diarizer run?" explicit, not inferred.
+4. **Library: `sherpa-rs`**, not hand-rolled `ort`. Wraps sherpa-onnx, gives us pyannote segmentation + speaker embedding + clustering as a single pipeline. Refines the master design's "pyannote via ort" — sherpa-onnx uses ONNX Runtime under the hood.
+5. **Diarization models:** `sherpa-onnx-pyannote-segmentation-3-0` (~7 MB tarball, contains the segmentation `.onnx`) + `3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx` (~38 MB embedding model). Total ~45 MB. Downloaded on first run from k2-fsa/sherpa-onnx GitHub releases. URLs and sha256s baked into the registry above.
+6. **Whisper production model bump: `large-v3-turbo-q5_0`** (~547 MB). Slice 02's `tiny.q5_1` becomes the demo / debug model.
+7. **CI model: `base.q5_1`** (~57 MB) via `PANOPS_MODEL` override. Closes issue #9. WER threshold drops to ~0.15 (verified at impl time, ≥ 5% headroom required).
+8. **Engine default: `--diarize` is implicit.** `--no-diarize` opts out. Reflects "post-pass = ASR + diarization" semantic from the master design.
+9. **Multi-speaker fixture: `multi_speaker_60s.wav`** with three TTS turns (Samantha → Daniel → Samantha). A-B-A pattern tests speaker re-identification.
+10. **Conformance for `Diarizer`: structural only.** Distinct count, coverage, ordering, re-identification of A in turns 1+3. ARI/DER metrics deferred.
+11. **Slice scope stays scoped.** Rolling-during-recording orchestrator is slice 06+. Ports designed stateless / chunk-friendly so slice 06 can wire either at-end or rolling without changes here.
+
+## Open questions / followups (NOT blocking slice 03)
+
+- Mac-native diarization adapter using FluidAudio's CoreML diarizer (slice 06's `panops-mac` crate).
+- Real ARI/DER metrics with tighter thresholds (when we have a non-TTS fixture or real meeting recordings).
+- Streaming diarization (incremental speaker assignment as audio comes in). sherpa-onnx supports VAD + per-window speaker ID — the streaming pieces exist, the orchestrator doesn't.
+- Speaker enrollment / persistent speaker IDs across meetings. ("This is Fran, this is Ada"). Different system; deferred.
+- Reconciliation between live ASR transcript and post-pass transcript. Slice 06+ when live exists.
+
+## Slice budget
+
+- ~700 LOC across the new files (Diarizer trait + adapter + harness + fixture + engine merge logic).
+- ~5 min cold CI runtime added (sherpa-onnx cmake build + diar models download ~45 MB + diar inference). Warm cache: +30 s.
+- 3 Whisper model entries + 2 diarization model entries in the new registry, total ~648 MB of artifacts the production user pulls on first run (CI continues to pull ~57 MB via the `base.q5_1` override).
+- One new fixture (`multi_speaker_60s.{wav,transcript.txt,turns.json}`).
+- New deps: `sherpa-rs`, `tar`, `bzip2` (the last two for unpacking the segmentation tarball).
+
+---
+
+Ready to invoke writing-plans. Approve to proceed?

--- a/docs/superpowers/specs/2026-05-01-slice-04-notes-generation-design.md
+++ b/docs/superpowers/specs/2026-05-01-slice-04-notes-generation-design.md
@@ -1,0 +1,368 @@
+# Slice 04 — Notes generation: design
+
+**Status**: Locked 2026-05-01.
+**Goal**: End-to-end pipeline from a diarized transcript + a screenshot stream to a markdown notes file with embedded screenshots, via a multi-call LLM pipeline that produces a typed intermediate representation rendered deterministically per `MarkdownDialect`.
+
+This slice introduces the project's first LLM port and the first port whose output is user-visible content rather than structured data. It is the foundation that later prompt-iteration, ensemble, verifier, and cross-meeting-context work builds on. Slice 04 ships less LLM cleverness and more architecture: the IR, the per-stage prompt boundaries, the dialect-aware exporter, and a working baseline pipeline that produces clean (if shallow) notes from the slice 03 multi-speaker fixture.
+
+## Why this shape
+
+The main design spec sketches `LlmProvider::summarize(transcript, screenshots, template) → markdown` as a single call. We diverge: a single mega-prompt is brittle (no per-stage validation, no per-role model swap, output drift on minor prompt edits). The structured-IR pipeline:
+
+- Locks in the IR shape early so prompt iteration in later slices doesn't churn ports.
+- Lets each stage swap models independently (small/fast for extraction, smarter for narrative).
+- Makes prompts unit-testable via `MockLlm` that pattern-matches prompt fingerprints to canned responses.
+- Renders markdown deterministically in Rust, eliminating a class of formatting bugs from LLM output.
+
+Cross-meeting context, speaker-name resolution, verifier passes, Slack summary, transcription corrections, and ensemble voting are explicitly out of scope here — slice 04.5+ will plug them into this architecture without touching ports.
+
+## Ports introduced
+
+### `LlmProvider` (low-level)
+
+```rust
+pub trait LlmProvider: Send + Sync {
+    fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError>;
+}
+
+pub struct LlmRequest {
+    pub system: Option<String>,
+    pub user: String,
+    pub schema: Option<JsonSchema>,   // when set, response must validate against it
+    pub temperature: f32,             // 0.0..=2.0; default 0.2 for extraction, 0.6 for narrative
+    pub max_tokens: u32,
+}
+
+pub enum LlmResponse {
+    Text(String),
+    Json(serde_json::Value),
+}
+
+pub enum LlmError {
+    Network(String),
+    InvalidSchema { expected: String, got: String },
+    EmptyResponse,
+    Provider(String),       // adapter-specific, opaque
+    Cancelled,
+}
+```
+
+Adapters: `MockLlm` (in `panops-core::conformance::fakes`, deterministic, prompt-fingerprint keyed) and `GenaiLlm` (in `panops-portable`, wraps `rust-genai` 0.4 with provider auto-detection: env vars for cloud keys, `OLLAMA_HOST` for local, future Apple-FM through the sidecar).
+
+`MockLlm` is the conformance fake: tests register `(prompt_fingerprint, response)` pairs; unmatched prompts panic loudly so tests catch prompt drift. Fingerprint = sha256 of `system + user`.
+
+### `NotesGenerator` (high-level pipeline)
+
+`NotesGenerator` is **not a trait** in slice 04 — it's a single concrete pipeline in `panops-core::notes` parameterised by an `&dyn LlmProvider`. It will become a trait if we ever need a non-LLM path (e.g. fully template-rendered notes); YAGNI for now.
+
+```rust
+pub struct NotesGenerator<'a> {
+    pub llm: &'a dyn LlmProvider,
+    pub dialect: MarkdownDialect,
+}
+
+impl NotesGenerator<'_> {
+    pub fn generate(&self, input: NotesInput) -> Result<StructuredNotes, NotesError>;
+}
+
+pub struct NotesInput {
+    pub transcript: Vec<Segment>,           // diarized segments from slice 03
+    pub screenshots: Vec<Screenshot>,       // (ms_since_start, file_path, optional_caption)
+    pub meeting_metadata: MeetingMetadata,  // started_at, duration_ms, source_path, language hint
+}
+```
+
+### `NotesExporter` (output)
+
+```rust
+pub trait NotesExporter: Send + Sync {
+    fn export(&self, notes: &StructuredNotes, dest: &Path) -> Result<ExportArtifact, ExportError>;
+}
+
+pub struct ExportArtifact {
+    pub primary_file: PathBuf,             // .../notes.md
+    pub assets: Vec<PathBuf>,              // copied / referenced screenshots
+}
+```
+
+Slice 04 ships one impl: `MarkdownExporter` in `panops-portable`, writing `<dest>/notes.md` + a sibling `screenshots/` dir of referenced images. Future `NotionExporter` is a separate adapter.
+
+## Domain types
+
+### `MarkdownDialect`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MarkdownDialect {
+    NotionEnhanced,    // default
+    Basic,             // CommonMark only
+}
+```
+
+- `NotionEnhanced`: emits `<callout icon="🎯">…</callout>`, `<details><summary>…</summary>…</details>`, `<table>` blocks, `{color="..."}` block colors. Renders cleanly in Notion (POSTable to `/v1/pages` for the future Notion exporter), degrades gracefully in renderers that ignore unknown HTML-like tags.
+- `Basic`: CommonMark only (headings, lists, tables, code blocks, image embeds, plain blockquotes). For Obsidian / GitHub / vanilla viewers.
+
+The dialect is passed as a structured arg to every LLM stage that emits markdown, alongside a per-dialect cheat-sheet string.
+
+### `StructuredNotes` IR
+
+```rust
+pub struct StructuredNotes {
+    pub schema_version: u32,                // 1 in slice 04
+    pub frontmatter: NotesFrontmatter,
+    pub sections: Vec<NotesSection>,
+    pub language: LanguageCode,             // dominant language; LLM prompt language
+    pub generated_at: DateTime<Utc>,
+}
+
+pub struct NotesFrontmatter {
+    pub title: String,
+    pub date: NaiveDate,
+    pub started_at: DateTime<FixedOffset>,
+    pub duration_ms: u64,
+    pub speakers: Vec<String>,              // raw speaker_id labels; name-resolution is later slice
+    pub tags: Vec<String>,                  // LLM-generated, lowercase, hyphenated
+    pub template: String,                   // "default" in slice 04
+    pub dialect: MarkdownDialect,
+    pub panops_version: String,             // env!("CARGO_PKG_VERSION") of panops-engine
+    pub source_audio: Option<PathBuf>,      // relative to notes dir
+}
+
+pub struct NotesSection {
+    pub index: u32,                         // 1-based
+    pub title: String,                      // narrative, not "Section 1"
+    pub time_range_ms: (u64, u64),
+    pub narrative_md: String,               // dialect-compliant markdown body
+    pub key_points: Vec<String>,            // short bullets, may be empty
+    pub action_items: Vec<ActionItem>,      // owner_TBD if unknown
+    pub screenshots: Vec<Screenshot>,       // anchored to this section by timestamp
+}
+
+pub struct ActionItem {
+    pub description: String,
+    pub owner: Option<String>,              // None ⇒ "owner TBD"
+    pub due: Option<NaiveDate>,
+}
+
+pub struct Screenshot {
+    pub ms_since_start: u64,
+    pub path: PathBuf,                      // absolute on input, relative on render
+    pub caption: Option<String>,            // None until later slice
+}
+```
+
+The IR is owned by `panops-core`. It's `Serialize + Deserialize` so engineers can dump intermediate state for debugging.
+
+## Pipeline stages
+
+`NotesGenerator::generate` runs five stages in order. Stage 2 is parallelised across sections; the rest are sequential.
+
+### 1. Topic segmentation (deterministic)
+
+Rule-based, no LLM call. Walks `Vec<Segment>`, opens a new section whenever:
+- A silence gap > `TOPIC_GAP_MS` (default 8000) appears between consecutive segments, **or**
+- The dominant speaker switches AND the new speaker has spoken < 10% of the previous section.
+
+Minimum section length: `MIN_SECTION_MS` (default 30000). Below threshold, merge into the adjacent section.
+
+For the slice 03 multi-speaker fixture (60s, A-B-A pattern, ~3 turns), this typically yields 1–3 sections. That's fine — testing exercises the pipeline shape, not segmentation quality.
+
+LLM-based topic clustering is a slice 04.5+ concern.
+
+### 2. Per-section narrative (LLM, parallel)
+
+For each section, one LLM call. Prompt receives:
+- The section's diarized transcript (speaker_id + text + timestamps).
+- The active dialect's cheat-sheet (~150-token reference of allowed syntax).
+- The strict speaker-attribution rule: never attribute a quote to a speaker unless segment metadata includes a confirmed `speaker_id` from diarization; otherwise use passive voice.
+- Output language hint (the dominant language of the input, except: the user can override in `NotesInput::meeting_metadata.output_language` — slice 04 defaults to dominant; English-only mode is slice 04.5+).
+
+Schema-constrained JSON response:
+
+```json
+{
+  "title": "string",
+  "narrative_md": "string (dialect-compliant)",
+  "key_points": ["string", ...],
+  "action_items": [{"description": "string", "owner": "string|null"}]
+}
+```
+
+`temperature: 0.6`. Parallel via `rayon::par_iter` (CPU-bound on JSON parsing; the actual blocking is the HTTP I/O, but `rust-genai` is sync-blocking — fine for a CLI). Cap concurrency at 4 to avoid rate-limiting cloud providers.
+
+If a section's LLM call fails, the section narrative falls back to a rendered transcript block (speaker_id: text, one line each) and `narrative_md` carries a `<!-- panops: llm error: ... -->` HTML comment in `NotionEnhanced`, or a similar plain-text marker in `Basic`. The pipeline does not abort — partial notes are better than no notes.
+
+### 3. Screenshot anchoring (deterministic)
+
+For each `Screenshot { ms_since_start }`, place it in the section whose `time_range_ms` contains that timestamp. If multiple, pick the one with `time_range_ms.0 ≤ ms < time_range_ms.1` (half-open). If none (rare, edge case at boundaries), attach to the nearest section by midpoint distance.
+
+Blank/low-info filtering deferred to slice 04.5+.
+
+### 4. Frontmatter + title + tags (LLM, single call)
+
+One LLM call given:
+- Section titles + key_points (compact summary; full narrative omitted to save tokens).
+- Meeting metadata (date, duration, language).
+
+Schema-constrained JSON response:
+
+```json
+{
+  "title": "string",
+  "tags": ["string", ...]
+}
+```
+
+`temperature: 0.3`. Tags constrained: lowercase, kebab-case, max 10. Title <= 80 chars.
+
+### 5. Render (deterministic)
+
+`MarkdownExporter::export` walks the IR and emits markdown:
+
+- YAML frontmatter (always, both dialects).
+- Per-section: `## N. <title>` heading, `*[M:SS – M:SS]*` time-range italic line, `narrative_md`, then screenshots appended at section end as a 2-column gallery in `NotionEnhanced`, single-column image stack in `Basic`. Inline-by-paragraph placement is deferred to slice 04.5+.
+- `---` separator between sections.
+
+Screenshot files are copied (not symlinked) into `<dest>/screenshots/` and referenced with relative paths.
+
+## File layout
+
+```
+crates/panops-core/src/
+├── llm.rs              # LlmProvider trait, LlmRequest, LlmResponse, LlmError
+├── notes/
+│   ├── mod.rs          # public re-exports
+│   ├── ir.rs           # StructuredNotes, NotesSection, ActionItem, Screenshot, NotesFrontmatter
+│   ├── input.rs        # NotesInput, MeetingMetadata, LanguageCode
+│   ├── dialect.rs      # MarkdownDialect + dialect cheat-sheets
+│   ├── pipeline.rs     # NotesGenerator + stages
+│   ├── prompts.rs      # prompt builders (system + user templates)
+│   └── error.rs        # NotesError
+├── exporter.rs         # NotesExporter trait, ExportArtifact, ExportError
+└── conformance/
+    ├── llm.rs          # LlmProvider conformance harness
+    ├── notes.rs        # NotesGenerator end-to-end harness
+    ├── exporter.rs     # NotesExporter harness (golden-file)
+    └── fakes.rs        # add MockLlm
+
+crates/panops-portable/src/
+├── lib.rs              # pub use new modules
+├── genai_llm.rs        # GenaiLlm wrapping rust-genai
+└── markdown_exporter.rs # MarkdownExporter
+
+crates/panops-portable/tests/
+├── conformance_genai_llm.rs       # gated behind PANOPS_RUN_LLM_TESTS env var
+└── conformance_markdown_exporter.rs
+
+crates/panops-engine/src/
+└── main.rs              # extend to add `notes` subcommand
+
+tests/fixtures/notes/
+├── multi_speaker_60s.expected.md       # golden file
+└── multi_speaker_60s.expected.json     # golden IR
+```
+
+## CLI surface (panops-engine)
+
+Slice 04 adds a `notes` subcommand alongside the existing transcribe behavior:
+
+```bash
+panops notes <audio.wav> [--screenshots <dir>] [--out <dir>] [--dialect notion-enhanced|basic] [--no-diarize] [--llm-provider auto|ollama|openai|anthropic] [--llm-model <name>]
+```
+
+- `--out` defaults to `./<basename>-notes/`. Created if missing.
+- `--screenshots` defaults to none → no images in output (notes still generated).
+- `--dialect` defaults to `notion-enhanced`.
+- `--llm-provider auto`: rust-genai's auto-detection (env vars for cloud keys, then `OLLAMA_HOST`).
+- Existing `panops <audio.wav>` (no subcommand) keeps emitting JSON segments, unchanged.
+
+Default `--llm-model` per provider:
+- `ollama` → `gemma3:4b` (small, fast, local; matches "fast LLMs prompted differently")
+- `anthropic` → `claude-haiku-4-5-20251001`
+- `openai` → `gpt-4o-mini`
+- `auto` resolves to whichever provider was detected, with the above per-provider default.
+
+## Testing strategy
+
+### Unit tests (panops-core)
+
+- `notes::ir`: `Serialize` / `Deserialize` round-trip on every IR type.
+- `notes::dialect`: dialect cheat-sheet strings exist, are non-empty, contain expected syntax markers.
+- `notes::pipeline::topic_segmentation`: hand-built `Vec<Segment>` produces expected sections (gap rule, speaker-shift rule, min-length merging).
+- `notes::pipeline::screenshot_anchoring`: screenshots with various ms_since_start placed in correct sections.
+
+### Conformance harness
+
+- `LlmProvider`: 3 tests
+  1. `complete` with `Text` schema returns non-empty string.
+  2. `complete` with `Json` schema returns valid JSON matching the schema.
+  3. `complete` with malformed schema-required output errors with `LlmError::InvalidSchema`.
+
+- `NotesGenerator` (end-to-end with `MockLlm`):
+  1. Given the slice 03 fixture transcript (`multi_speaker_60s.json`) + 12 screenshot fixtures + canned LLM responses, produce `StructuredNotes` matching `tests/fixtures/notes/multi_speaker_60s.expected.json` (bit-exact except for `generated_at`).
+
+- `NotesExporter`:
+  1. Given the canned `StructuredNotes`, produce markdown bit-exactly matching `tests/fixtures/notes/multi_speaker_60s.expected.md` (frontmatter normalised: `panops_version: "TESTING"`, `generated_at: "2026-05-01T00:00:00Z"`).
+  2. Both dialects produce different output (`NotionEnhanced` contains a `<callout` token; `Basic` does not).
+
+### Real-LLM integration test (gated)
+
+`crates/panops-portable/tests/conformance_genai_llm.rs` runs against a real provider. Skipped unless `PANOPS_RUN_LLM_TESTS=1` and at least one of `OLLAMA_HOST` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` is set. CI does not run this; documented in tests/fixtures/README.md.
+
+### Property tests (deferred)
+
+Topic segmentation invariants (sections cover the full transcript without gaps or overlaps; section boundaries fall on segment boundaries) → slice 04.5.
+
+## Acceptance criteria
+
+A slice is done when:
+
+1. `cargo test --workspace --locked` passes on macOS (linux compile-only, per slice 02).
+2. `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
+3. `cargo run -p panops-engine -- notes tests/fixtures/audio/multi_speaker_60s.wav --screenshots tests/fixtures/screenshots --out /tmp/notes-test --dialect notion-enhanced --llm-provider ollama --llm-model gemma3:4b` produces a `notes.md` file (manual smoke; CI uses `MockLlm`).
+4. Conformance harness with `MockLlm` produces bit-exact match against `tests/fixtures/notes/multi_speaker_60s.expected.md`.
+5. Both `NotionEnhanced` and `Basic` outputs differ in expected ways.
+6. `--no-diarize` flag still works in `notes` mode (sections collapse to 1 if no speaker info).
+7. Frontmatter is valid YAML; `serde_yaml::from_str` round-trips.
+
+## Out of scope (deferred to later slices)
+
+- Speaker-name resolution (slice 04.5).
+- Verifier / grounding pass that checks attributions against transcript (slice 04.5).
+- Slack summary section (slice 04.5).
+- Transcription corrections table (slice 04.5).
+- LLM-driven topic clustering (slice 04.5).
+- Cross-meeting context lookup (slice 08+; needs the cross-meeting registry from slice 5/6).
+- Blank/low-info screenshot filtering (slice 04.5).
+- Apple FoundationModels sidecar (slice 06; mac-shell slice).
+- Notion exporter (post-v0.1).
+- Output-language override (slice 04.5).
+- Ensemble voting across multiple small models (slice 04.5+).
+- Live notes streaming (slice 07).
+
+## Risks
+
+1. **Prompt quality**. Slice 04 baseline prompts will produce shallow notes. Acceptable: this slice locks architecture, not quality. Quality work fits cleanly on top.
+2. **rust-genai version drift**. The `rust-genai` crate is pre-1.0 (0.4 as of 2026-05-01). Pin tightly; the adapter is small, churn cost is low.
+3. **Local model availability**. Slice 04 manual smoke assumes Ollama is running with `gemma3:4b`. If it isn't, the smoke test fails. CI is unaffected (uses `MockLlm`). Documented in fixture README.
+4. **Schema-constrained JSON not universally supported**. Some `rust-genai` providers (OpenAI, Anthropic) support structured-output / JSON mode; Ollama supports `format: json`. The adapter should request structured output when possible and fall back to "extract JSON from text" parsing when not. Adapter handles it; pipeline sees a clean `LlmResponse::Json`.
+5. **Long meetings blow context window**. Slice 04 doesn't chunk per-section calls beyond what topic segmentation produces. A 90-minute single-section meeting (no gaps) would exceed 8k context on small models. Acceptable for slice 04 (fixtures are 60s); revisit when real meetings come in.
+
+## Decisions made this slice
+
+- **Structured-IR pipeline over single mega-prompt**: documented above.
+- **`MockLlm` is the conformance fake, not a separate `FakeLlm` trait impl**: prompt-fingerprint table = simplest deterministic mock that catches prompt drift loudly.
+- **Topic segmentation is rule-based in slice 04**: gap + speaker-shift + min-length. No LLM calls. Cheap, fast, good enough for the fixture.
+- **Render is deterministic**: LLM produces narrative_md per section; the file structure (frontmatter, headings, separators, screenshot embeds) is Rust-emitted. This bounds LLM output and makes goldens stable.
+- **Screenshot embedding is "append at section end" in slice 04**: not inline-by-paragraph. Inline placement is a prompt-engineering problem better solved when we have real meeting data.
+- **`NotesGenerator` is concrete, not a trait**: only one impl planned; YAGNI on the trait.
+- **Real-LLM tests are gated, not run in CI**: cost + flakiness; manual smoke only.
+- **Default Ollama model = `gemma3:4b`**: small, fast, runs on any laptop with 8GB+ RAM, matches "fast LLMs prompted differently" intuition. Users can override.
+
+## Open questions
+
+None blocking slice 04. Tracked for future slices:
+- How to surface LLM cost / latency to the user (slice 06 UI concern)?
+- Cross-meeting context: keyword lookup vs. embedding similarity vs. LLM-driven retrieval (slice 08+)?
+- When to trigger notes regeneration (after each meeting, on-demand, both)?

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,3 +21,11 @@ commit-msg:
     length:
       run: |
         head -1 "{1}" | awk 'length > 72 { exit 1 }'
+
+post-commit:
+  commands:
+    extract-conversations:
+      # Snapshot Claude Code session jsonl files into docs/superpowers/conversations/
+      # (gitignored). Thin extraction: user/assistant turns only, large code blocks
+      # collapsed. Idempotent via source-mtime check.
+      run: python3 scripts/extract-conversations.py

--- a/scripts/extract-conversations.py
+++ b/scripts/extract-conversations.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Extract thin user/assistant conversation history from Claude Code session logs.
+
+Reads jsonl files from ~/.claude/projects/-Users-fran-Code-panops/ and
+~/.claude/projects/-Users-fran-Code/ (only sessions mentioning "panops"),
+extracts user messages + assistant text turns, drops tool calls / tool results
+/ system reminders / large code blocks, and writes one markdown file per
+session to docs/superpowers/conversations/.
+
+Idempotent: skips sessions whose source mtime hasn't changed since the last
+extraction (recorded inline in the output's frontmatter).
+
+Run manually or via the lefthook post-commit hook.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+OUT_DIR = HERE / "docs" / "superpowers" / "conversations"
+
+CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+SOURCE_DIRS = [
+    CLAUDE_PROJECTS / "-Users-fran-Code-panops",
+    CLAUDE_PROJECTS / "-Users-fran-Code",
+]
+
+# Skip sessions in -Users-fran-Code that don't mention panops.
+PANOPS_FILTER_DIRS = {CLAUDE_PROJECTS / "-Users-fran-Code"}
+
+CODE_BLOCK_THRESHOLD_LINES = 30  # collapse code blocks longer than this
+LONG_TEXT_THRESHOLD_CHARS = 6000  # collapse very long single text blocks
+
+SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+LOCAL_COMMAND_RE = re.compile(r"<local-command-caveat>.*?</local-command-caveat>", re.DOTALL)
+COMMAND_NAME_RE = re.compile(r"<command-name>.*?</command-name>", re.DOTALL)
+COMMAND_MESSAGE_RE = re.compile(r"<command-message>.*?</command-message>", re.DOTALL)
+COMMAND_ARGS_RE = re.compile(r"<command-args>.*?</command-args>", re.DOTALL)
+
+
+@dataclass
+class Turn:
+    role: str  # "user" or "assistant"
+    text: str
+    timestamp: str | None
+
+
+def clean_text(s: str) -> str:
+    s = SYSTEM_REMINDER_RE.sub("", s)
+    s = LOCAL_COMMAND_RE.sub("", s)
+    s = COMMAND_NAME_RE.sub("", s)
+    s = COMMAND_MESSAGE_RE.sub("", s)
+    s = COMMAND_ARGS_RE.sub("", s)
+    s = re.sub(r"\n{3,}", "\n\n", s)
+    return s.strip()
+
+
+def collapse_long_code(text: str) -> str:
+    """Replace fenced code blocks longer than threshold with a one-line note."""
+    out = []
+    in_block = False
+    block_lines: list[str] = []
+    fence: str | None = None
+    for line in text.split("\n"):
+        stripped = line.lstrip()
+        if not in_block:
+            m = re.match(r"^(```+|~~~+)([^\s]*)?", stripped)
+            if m:
+                in_block = True
+                fence = m.group(1)
+                block_lines = [line]
+                continue
+            out.append(line)
+        else:
+            block_lines.append(line)
+            if fence is not None and stripped.startswith(fence):
+                if len(block_lines) > CODE_BLOCK_THRESHOLD_LINES:
+                    head = "\n".join(block_lines[:3])
+                    out.append(head)
+                    out.append(f"... ({len(block_lines) - 4} lines elided) ...")
+                    out.append(block_lines[-1])
+                else:
+                    out.extend(block_lines)
+                in_block = False
+                fence = None
+                block_lines = []
+    if in_block:
+        out.extend(block_lines)
+    return "\n".join(out)
+
+
+def extract_text_from_content(content) -> str:
+    """Pull text out of an Anthropic message content list, dropping tool_use / tool_result."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for b in content:
+        if not isinstance(b, dict):
+            continue
+        t = b.get("type")
+        if t == "text":
+            parts.append(b.get("text", ""))
+        # tool_use, tool_result, image: skip
+    return "\n".join(parts)
+
+
+def session_mentions_panops(path: Path) -> bool:
+    """Stream the file in chunks; the keyword may appear late."""
+    try:
+        with open(path, "rb") as f:
+            tail = b""
+            while True:
+                chunk = f.read(1 << 20)
+                if not chunk:
+                    return False
+                if b"panops" in (tail + chunk).lower():
+                    return True
+                tail = chunk[-7:]  # carry across chunk boundary (len("panops") = 6)
+    except Exception:
+        return False
+
+
+def parse_session(path: Path) -> tuple[list[Turn], str | None]:
+    """Return (turns, started_at_iso)."""
+    turns: list[Turn] = []
+    started_at: str | None = None
+    for line in path.open():
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        ts = r.get("timestamp")
+        if ts and started_at is None:
+            started_at = ts
+        rtype = r.get("type")
+        if rtype not in ("user", "assistant"):
+            continue
+        msg = r.get("message", {})
+        text = extract_text_from_content(msg.get("content"))
+        text = clean_text(text)
+        if not text:
+            continue
+        if rtype == "user":
+            # Skip user turns that are pure tool_result envelopes (caught above)
+            # Skip slash-command invocations that are just system payloads.
+            if text.startswith("<") and text.endswith(">"):
+                continue
+            if "tool_use_id" in text[:200]:
+                continue
+        text = collapse_long_code(text)
+        if len(text) > LONG_TEXT_THRESHOLD_CHARS:
+            text = text[:LONG_TEXT_THRESHOLD_CHARS] + f"\n\n... ({len(text) - LONG_TEXT_THRESHOLD_CHARS} chars elided) ..."
+        turns.append(Turn(role=rtype, text=text, timestamp=ts))
+    return turns, started_at
+
+
+def output_path_for(session_id: str, started_at: str | None) -> Path:
+    if started_at:
+        try:
+            dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            date = dt.strftime("%Y-%m-%d")
+        except Exception:
+            date = "unknown-date"
+    else:
+        date = "unknown-date"
+    short = session_id.split("-")[0]
+    return OUT_DIR / f"{date}-{short}.md"
+
+
+def render(turns: list[Turn], session_id: str, source_path: Path, started_at: str | None) -> str:
+    lines = [
+        "---",
+        f"session_id: {session_id}",
+        f"source: {source_path}",
+        f"source_mtime: {datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc).isoformat()}",
+        f"started_at: {started_at or 'unknown'}",
+        f"turns: {len(turns)}",
+        "---",
+        "",
+    ]
+    for t in turns:
+        ts = (t.timestamp or "")[:19]
+        marker = "**user**" if t.role == "user" else "**assistant**"
+        prefix = f"### {marker}  {ts}".rstrip()
+        lines.append(prefix)
+        lines.append("")
+        lines.append(t.text)
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def existing_source_mtime(out_path: Path) -> str | None:
+    if not out_path.exists():
+        return None
+    seen_first_fence = False
+    with out_path.open() as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped == "---":
+                if seen_first_fence:
+                    return None  # end of frontmatter, not found
+                seen_first_fence = True
+                continue
+            if not seen_first_fence:
+                continue
+            if line.startswith("source_mtime:"):
+                return line.split(":", 1)[1].strip()
+    return None
+
+
+def main() -> int:
+    if not OUT_DIR.exists():
+        OUT_DIR.mkdir(parents=True)
+    written = skipped = scanned = 0
+    for src_dir in SOURCE_DIRS:
+        if not src_dir.exists():
+            continue
+        for jsonl in sorted(src_dir.glob("*.jsonl")):
+            scanned += 1
+            if src_dir in PANOPS_FILTER_DIRS and not session_mentions_panops(jsonl):
+                continue
+            session_id = jsonl.stem
+            turns, started_at = parse_session(jsonl)
+            if not turns:
+                continue
+            out = output_path_for(session_id, started_at)
+            current_mtime = datetime.fromtimestamp(
+                jsonl.stat().st_mtime, tz=timezone.utc
+            ).isoformat()
+            prev = existing_source_mtime(out)
+            if prev == current_mtime:
+                skipped += 1
+                continue
+            out.write_text(render(turns, session_id, jsonl, started_at))
+            written += 1
+    print(f"extract-conversations: scanned={scanned} written={written} skipped={skipped} -> {OUT_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two related changes:

**1. Public roadmap.** Track `AGENTS.md`, `CLAUDE.md`, `docs/superpowers/specs/`, and `docs/research/` so the project's workflow rules and architecture are visible to anyone reading the repo. Plans, sessions, and conversations stay private.

- `AGENTS.md` (132 lines) is the workflow contract — sources of truth, slice sequence, execution discipline, debt rule, don'ts.
- `CLAUDE.md` imports `AGENTS.md` and adds Claude Code addenda (plan mode, skill usage).
- `docs/superpowers/specs/` holds the main design + per-slice specs (4 files).
- `docs/research/2026-04-30-market-scan.md` holds the verified library + pattern picks.
- `docs/superpowers/{plans,sessions,conversations}/` remain gitignored.
- `*.local.md` remain gitignored for personal additions.

**2. Local conversation extractor.** `scripts/extract-conversations.py` reads Claude Code session jsonl files from `~/.claude/projects/`, filters for ones mentioning panops, and writes thin user/assistant-only markdown to `docs/superpowers/conversations/` (gitignored). Tool calls, tool results, and large code blocks are dropped or collapsed. Idempotent via source-mtime check. Wired into `lefthook.yml` as a `post-commit` hook.

`_typos.toml` added to allowlist `ANE` (Apple Neural Engine) and `ture` (table-cell artifact) so the existing typos pre-commit hook accepts the specs.

## Test plan
- [x] `python3 scripts/extract-conversations.py` runs clean, produces 2 panops conversation files.
- [x] Re-running is idempotent (skipped=2 on second invocation).
- [x] Post-commit hook fires after a real commit and updates extracted files.
- [x] `cargo fmt`/`clippy`/`deny`/`typos` pre-commit gates pass.
- [ ] Open the repo in a fresh Claude Code session and confirm `AGENTS.md` loads via `/memory`.