### PR TITLE
fix GenaiLlm JSON parsing and wire --llm-provider ollama

### DIFF
--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -159,7 +159,11 @@ fn run_notes(
         other => {
             return Err((
                 1,
-                format!("--llm-provider {other:?} is not supported; use \"auto\" or \"ollama\""),
+                format!(
+                    "--llm-provider {other:?} not supported. Use \"auto\" (detects from \
+                     ANTHROPIC_API_KEY / OPENAI_API_KEY / OLLAMA_HOST) or \"ollama\" \
+                     (defaults to model gemma3:4b on http://localhost:11434)."
+                ),
             ));
         }
     };

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -152,12 +152,14 @@ fn run_notes(
             Some(m) => GenaiLlm::new(m).map_err(|e| (3, e.to_string()))?,
             None => GenaiLlm::auto().map_err(|e| (3, e.to_string()))?,
         },
+        "ollama" => {
+            let model = llm_model.unwrap_or_else(|| "gemma3:4b".to_string());
+            GenaiLlm::new(model).map_err(|e| (3, e.to_string()))?
+        }
         other => {
             return Err((
                 1,
-                format!(
-                    "--llm-provider {other:?} is not yet wired through; only \"auto\" is supported in slice 04. Set provider env vars (ANTHROPIC_API_KEY / OPENAI_API_KEY / OLLAMA_HOST) to control detection."
-                ),
+                format!("--llm-provider {other:?} is not supported; use \"auto\" or \"ollama\""),
             ));
         }
     };

--- a/crates/panops-portable/src/genai_llm.rs
+++ b/crates/panops-portable/src/genai_llm.rs
@@ -44,7 +44,7 @@ impl GenaiLlm {
 
 impl LlmProvider for GenaiLlm {
     fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
-        use genai::chat::{ChatMessage, ChatRequest};
+        use genai::chat::{ChatMessage, ChatOptions, ChatRequest};
 
         let mut messages: Vec<ChatMessage> = Vec::new();
         if let Some(sys) = req.system.clone() {
@@ -54,11 +54,15 @@ impl LlmProvider for GenaiLlm {
 
         let chat_req = ChatRequest::new(messages);
 
+        let options = ChatOptions::default()
+            .with_temperature(req.temperature as f64)
+            .with_max_tokens(req.max_tokens);
+
         let client = self.client.clone();
         let model = self.model.clone();
         let resp = self.rt.block_on(async move {
             client
-                .exec_chat(&model, chat_req, None)
+                .exec_chat(&model, chat_req, Some(&options))
                 .await
                 .map_err(|e| LlmError::Provider(e.to_string()))
         })?;
@@ -70,7 +74,8 @@ impl LlmProvider for GenaiLlm {
             .to_string();
 
         if req.schema.is_some() {
-            match serde_json::from_str::<serde_json::Value>(&text) {
+            let json_text = strip_markdown_fences(&text);
+            match serde_json::from_str::<serde_json::Value>(json_text) {
                 Ok(v) => Ok(LlmResponse::Json(v)),
                 Err(e) => Err(LlmError::InvalidSchema {
                     expected: "json object".into(),
@@ -80,5 +85,14 @@ impl LlmProvider for GenaiLlm {
         } else {
             Ok(LlmResponse::Text(text))
         }
+    }
+}
+
+fn strip_markdown_fences(s: &str) -> &str {
+    let s = s.trim();
+    if let Some(inner) = s.strip_prefix("```json").or_else(|| s.strip_prefix("```")) {
+        inner.trim_end_matches("```").trim()
+    } else {
+        s
     }
 }

--- a/crates/panops-portable/src/genai_llm.rs
+++ b/crates/panops-portable/src/genai_llm.rs
@@ -97,11 +97,13 @@ impl LlmProvider for GenaiLlm {
 
 fn strip_markdown_fences(s: &str) -> &str {
     let s = s.trim();
-    if let Some(inner) = s.strip_prefix("```json").or_else(|| s.strip_prefix("```")) {
-        inner.trim_end_matches("```").trim()
-    } else {
-        s
-    }
+    let Some(inner) = s.strip_prefix("```json").or_else(|| s.strip_prefix("```")) else {
+        return s;
+    };
+    let trimmed = inner.trim();
+    // Use strip_suffix (single match) rather than trim_end_matches (greedy) so
+    // a JSON value containing literal triple-backticks isn't corrupted.
+    trimmed.strip_suffix("```").unwrap_or(trimmed).trim()
 }
 
 #[cfg(test)]
@@ -130,5 +132,20 @@ mod tests {
     fn strip_fences_handles_trailing_whitespace_inside_block() {
         let input = "  ```json\n{\"k\":1}\n```  ";
         assert_eq!(strip_markdown_fences(input), "{\"k\":1}");
+    }
+
+    #[test]
+    fn strip_fences_does_not_eat_literal_backticks_inside_json_strings() {
+        // Bare JSON whose value contains a triple-backtick token must round-trip.
+        let input = "{\"text\":\"```code```\"}";
+        assert_eq!(strip_markdown_fences(input), "{\"text\":\"```code```\"}");
+    }
+
+    #[test]
+    fn strip_fences_only_strips_one_trailing_fence_inside_block() {
+        // A fenced block whose JSON value itself contains ```. The closing
+        // fence is removed once; the JSON content is preserved.
+        let input = "```json\n{\"text\":\"```code```\"}\n```";
+        assert_eq!(strip_markdown_fences(input), "{\"text\":\"```code```\"}");
     }
 }

--- a/crates/panops-portable/src/genai_llm.rs
+++ b/crates/panops-portable/src/genai_llm.rs
@@ -74,6 +74,13 @@ impl LlmProvider for GenaiLlm {
             .to_string();
 
         if req.schema.is_some() {
+            // We do NOT request `ChatResponseFormat::JsonMode`. Tested via
+            // genai 0.5.3 against Ollama's OpenAI-compat `/v1/chat/completions`
+            // endpoint with gemma3:4b: JsonMode causes the model to return an
+            // empty `{}` regardless of prompt. The native Ollama `/api/chat`
+            // endpoint honors `format: "json"` correctly, but genai doesn't
+            // route there. Until that lands upstream, we let the model emit
+            // its natural fenced output and strip the fences.
             let json_text = strip_markdown_fences(&text);
             match serde_json::from_str::<serde_json::Value>(json_text) {
                 Ok(v) => Ok(LlmResponse::Json(v)),
@@ -94,5 +101,34 @@ fn strip_markdown_fences(s: &str) -> &str {
         inner.trim_end_matches("```").trim()
     } else {
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_fences_passes_through_bare_json() {
+        assert_eq!(strip_markdown_fences("{\"k\":1}"), "{\"k\":1}");
+        assert_eq!(strip_markdown_fences("  {\"k\":1}  "), "{\"k\":1}");
+    }
+
+    #[test]
+    fn strip_fences_unwraps_json_tagged_block() {
+        let input = "```json\n{\"k\":1}\n```";
+        assert_eq!(strip_markdown_fences(input), "{\"k\":1}");
+    }
+
+    #[test]
+    fn strip_fences_unwraps_plain_block() {
+        let input = "```\n{\"k\":1}\n```";
+        assert_eq!(strip_markdown_fences(input), "{\"k\":1}");
+    }
+
+    #[test]
+    fn strip_fences_handles_trailing_whitespace_inside_block() {
+        let input = "  ```json\n{\"k\":1}\n```  ";
+        assert_eq!(strip_markdown_fences(input), "{\"k\":1}");
     }
 }


### PR DESCRIPTION
## Summary

- `genai_llm.rs`: strip markdown code fences before parsing JSON responses. Models like gemma3:4b wrap their JSON output in ` ```json ``` ` blocks even when prompted not to; the original code passed the raw text to `serde_json` and got `expected value at line 1 column 1`.
- `genai_llm.rs`: forward `temperature` and `max_tokens` from `LlmRequest` to `ChatOptions`. These were silently dropped, leaving the LLM at provider defaults.
- `genai_llm.rs`: do NOT use `ChatResponseFormat::JsonMode` (via Ollama's OpenAI-compat `/v1/` endpoint). Investigated and confirmed that gemma3:4b returns `{}` (empty object) when json_object mode is active through the compat layer; the native `/api/chat` endpoint works correctly but genai doesn't use it.
- `main.rs`: wire `--llm-provider ollama` — it previously returned "not yet wired through" immediately after transcription.

## Smoke test

Verified end-to-end with gemma3:4b on a local Ollama instance:

```
PANOPS_MODEL=~/Downloads/ggml-base-q5_1.bin \
  cargo run -p panops-engine --release -- notes \
    tests/fixtures/audio/multi_speaker_60s.wav \
    --screenshots tests/fixtures/screenshots \
    --out /tmp/panops-smoke \
    --dialect notion-enhanced \
    --llm-provider ollama --llm-model gemma3:4b
```

Output: full narrative + key points + action items + screenshot gallery. Conformance suite (3 golden tests) still passes.

## Related

Supersedes #51 (Copilot's JsonMode approach causes empty `{}` responses with Ollama/gemma3).