### PR TITLE
Add tracing crate across workspace; init subscriber in engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1460,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -1453,6 +1472,8 @@ dependencies = [
  "panops-core",
  "panops-portable",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1472,6 +1493,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
  "whisper-rs",
 ]
 
@@ -2133,6 +2155,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "sherpa-rs"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2589,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2632,6 +2702,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-ext"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,15 +1402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,7 +1451,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -2589,18 +2579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -2610,15 +2588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -2702,12 +2677,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-ext"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Hexagonal Rust core engine + SwiftUI macOS shell + Swift sidecars (WhisperKit + 
 
 Pre-alpha. Slice 01 (skeleton) lands the Cargo workspace and test fixtures. Subsequent slices land the headless CLI, post-pass + diarization, notes generation, IPC, the SwiftUI shell, and live capture.
 
+## Logging
+
+`panops-engine` writes structured logs to stderr via `tracing`. Default level is `info` (model downloads, "wrote notes"); set `RUST_LOG` to override — e.g. `RUST_LOG=debug` for more detail, `RUST_LOG=off` to silence. Stdout in default mode is reserved for the JSON transcript and stays clean regardless of `RUST_LOG`.
+
 ## Name
 
 From Argus Panoptes, the hundred-eyed giant in Greek myth. *Pan* (all) + *ops* (seeing). Fits the wedge: panops watches the screen, captures system audio, and stitches the recording into screenshot-anchored notes you can navigate later. The chevron inside the `o` of the wordmark is the visual cue.

--- a/crates/panops-core/Cargo.toml
+++ b/crates/panops-core/Cargo.toml
@@ -15,4 +15,3 @@ serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 rayon = "1.10"
-tracing = "0.1"

--- a/crates/panops-core/Cargo.toml
+++ b/crates/panops-core/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 rayon = "1.10"
+tracing = "0.1"

--- a/crates/panops-engine/Cargo.toml
+++ b/crates/panops-engine/Cargo.toml
@@ -18,4 +18,4 @@ clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/crates/panops-engine/Cargo.toml
+++ b/crates/panops-engine/Cargo.toml
@@ -17,3 +17,5 @@ panops-portable = { path = "../panops-portable" }
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -81,6 +81,7 @@ impl From<DialectArg> for MarkdownDialect {
 }
 
 fn main() -> ExitCode {
+    init_tracing();
     let cli = Cli::parse();
     let res = match cli.cmd {
         None => run_default(cli.audio, cli.model, cli.language, cli.no_diarize),
@@ -113,6 +114,15 @@ fn main() -> ExitCode {
             ExitCode::from(code)
         }
     }
+}
+
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
 }
 
 fn run_default(
@@ -208,7 +218,7 @@ fn run_notes(
     let art = MarkdownExporter
         .export(&notes, &out_dir)
         .map_err(|e| (2, e.to_string()))?;
-    eprintln!("wrote {:?} ({} assets)", art.primary_file, art.assets.len());
+    tracing::info!(file = ?art.primary_file, assets = art.assets.len(), "wrote notes");
     Ok(())
 }
 

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -82,6 +82,10 @@ impl From<DialectArg> for MarkdownDialect {
 
 fn main() -> ExitCode {
     init_tracing();
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        "panops-engine starting"
+    );
     let cli = Cli::parse();
     let res = match cli.cmd {
         None => run_default(cli.audio, cli.model, cli.language, cli.no_diarize),
@@ -118,10 +122,26 @@ fn main() -> ExitCode {
 
 fn init_tracing() {
     use tracing_subscriber::EnvFilter;
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // Default `info` so model-download progress and "wrote notes" surface
+    // without requiring RUST_LOG; runs can take minutes and silent waits get
+    // filed as bugs. Third-party HTTP crates are pinned to `warn` to prevent
+    // RUST_LOG=trace from leaking API keys via hyper/reqwest/h2 request
+    // logging — genai sends Anthropic/OpenAI Authorization headers there.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info")
+            .add_directive("hyper=warn".parse().expect("static directive"))
+            .add_directive("reqwest=warn".parse().expect("static directive"))
+            .add_directive("h2=warn".parse().expect("static directive"))
+            .add_directive("rustls=warn".parse().expect("static directive"))
+    });
+    // try_init: in tests cargo may already have wired a subscriber; main()
+    // runs once per process so this can't double-init in production.
+    // with_ansi(false): stderr is often piped (CI capture, `2>err`); ANSI
+    // escapes break grep/awk and the cli_logging.rs assertions.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
+        .with_ansi(false)
         .try_init();
 }
 

--- a/crates/panops-engine/tests/cli_logging.rs
+++ b/crates/panops-engine/tests/cli_logging.rs
@@ -1,0 +1,65 @@
+//! Verifies the `tracing` subscriber initialized in `main()`:
+//! - emits structured logs to stderr at the chosen level
+//! - does NOT pollute stdout (default-mode JSON contract must remain bit-clean)
+//!
+//! Uses `PANOPS_FAKE_ASR=1` so we don't need a real Whisper model.
+
+use std::process::Command;
+
+fn engine_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_panops-engine"))
+}
+
+fn fixtures_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|p| p.join("tests/fixtures/audio").is_dir())
+        .unwrap()
+        .join("tests/fixtures")
+}
+
+#[test]
+fn default_mode_stdout_is_pure_json_with_rust_log_set() {
+    // RUST_LOG=debug must NOT taint the stdout JSON contract.
+    let audio = fixtures_dir().join("audio").join("en_30s.wav");
+    let out = Command::new(engine_bin())
+        .arg(&audio)
+        .arg("--no-diarize")
+        .env("PANOPS_FAKE_ASR", "1")
+        .env("RUST_LOG", "debug")
+        .output()
+        .expect("run engine");
+
+    assert!(
+        out.status.success(),
+        "engine exited with {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Stdout must be bit-clean valid JSON.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let _: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout is not valid JSON; tracing leaked into it");
+}
+
+#[test]
+fn rust_log_off_silences_info_and_debug() {
+    // RUST_LOG=off should suppress info/debug/warn on the success path.
+    // (Error-level suppression and the `eprintln!` error path are not asserted
+    // here — those go through plain stderr writes, not tracing.)
+    let audio = fixtures_dir().join("audio").join("en_30s.wav");
+    let out = Command::new(engine_bin())
+        .arg(&audio)
+        .arg("--no-diarize")
+        .env("PANOPS_FAKE_ASR", "1")
+        .env("RUST_LOG", "off")
+        .output()
+        .expect("run engine");
+    assert!(out.status.success(), "engine should succeed");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("INFO") && !stderr.contains("DEBUG") && !stderr.contains("WARN"),
+        "RUST_LOG=off should suppress info/debug/warn; got stderr:\n{stderr}"
+    );
+}

--- a/crates/panops-engine/tests/cli_logging.rs
+++ b/crates/panops-engine/tests/cli_logging.rs
@@ -44,6 +44,34 @@ fn default_mode_stdout_is_pure_json_with_rust_log_set() {
 }
 
 #[test]
+fn rust_log_info_actually_emits_tracing_lines() {
+    // Positive control: prove init_tracing actually wires a subscriber.
+    // If init silently no-ops (e.g. try_init fails or filter rejects),
+    // this test fails — preventing a green CI on a logging regression.
+    let audio = fixtures_dir().join("audio").join("en_30s.wav");
+    let out = Command::new(engine_bin())
+        .arg(&audio)
+        .arg("--no-diarize")
+        .env("PANOPS_FAKE_ASR", "1")
+        .env("RUST_LOG", "info")
+        .output()
+        .expect("run engine");
+    assert!(
+        out.status.success(),
+        "engine exited with {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // Default subscriber format prefixes each line with the level. With_ansi
+    // is forced off in init_tracing so this is plain bytes, not escape-coded.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(" INFO "),
+        "RUST_LOG=info should produce at least one ' INFO ' line on stderr; got:\n{stderr}"
+    );
+}
+
+#[test]
 fn rust_log_off_silences_info_and_debug() {
     // RUST_LOG=off should suppress info/debug/warn on the success path.
     // (Error-level suppression and the `eprintln!` error path are not asserted

--- a/crates/panops-portable/Cargo.toml
+++ b/crates/panops-portable/Cargo.toml
@@ -20,6 +20,7 @@ bzip2 = "0.6"
 genai = "=0.5.3"
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -176,9 +176,11 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         }
         return Ok(dest.to_path_buf());
     }
-    eprintln!(
-        "Downloading {} (~{} MB) from {}...",
-        info.name, info.approx_size_mb, info.url
+    tracing::info!(
+        name = info.name,
+        approx_mb = info.approx_size_mb,
+        url = info.url,
+        "downloading model"
     );
     let client = http_client()?;
     let n = download(&client, info.url, dest)?;
@@ -188,7 +190,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         let _ = fs::remove_file(dest);
         return Err(e);
     }
-    eprintln!("Downloaded {n} bytes to {dest:?}");
+    tracing::info!(bytes = n, dest = ?dest, "model download complete");
     Ok(dest.to_path_buf())
 }
 
@@ -207,9 +209,10 @@ pub fn ensure_diar_models() -> Result<(PathBuf, PathBuf), AsrError> {
         if let Some(parent) = emb.parent() {
             fs::create_dir_all(parent)?;
         }
-        eprintln!(
-            "Downloading {} (~{} MB)...",
-            emb_info.name, emb_info.approx_size_mb
+        tracing::info!(
+            name = emb_info.name,
+            approx_mb = emb_info.approx_size_mb,
+            "downloading diar embedding model"
         );
         let client = http_client()?;
         download(&client, emb_info.url, &emb)?;
@@ -244,9 +247,10 @@ pub fn ensure_diar_models() -> Result<(PathBuf, PathBuf), AsrError> {
         let tar_path = dir.join("sherpa-onnx-pyannote-segmentation-3-0.tar.bz2");
         let tar_existed_before = tar_path.exists();
         if !tar_existed_before {
-            eprintln!(
-                "Downloading {} (~{} MB)...",
-                seg_info.name, seg_info.approx_size_mb
+            tracing::info!(
+                name = seg_info.name,
+                approx_mb = seg_info.approx_size_mb,
+                "downloading diar segmentation model"
             );
             let client = http_client()?;
             download(&client, seg_info.url, &tar_path)?;


### PR DESCRIPTION
## Summary

Closes #16. Wires \`tracing\` into \`panops-portable\` and \`panops-engine\` and initializes a hardened \`tracing-subscriber\` in the binary's \`main()\`. Replaces 5 diagnostic \`eprintln!\` calls with structured \`tracing::info!\`. Stdout JSON contract preserved and asserted.

**Preserved:**
- \`println!(json)\` at \`main.rs\` — default-mode stdout JSON contract is bit-clean.
- \`eprintln!("error: {msg}")\` final user-facing error path (not converted; pre-tracing seam).

## Changes

- \`crates/{panops-portable, panops-engine}/Cargo.toml\` — add \`tracing = "0.1"\`. \`panops-core\` does NOT add the dep (no call sites — YAGNI/DIP per audit).
- \`crates/panops-engine/Cargo.toml\` — \`tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }\`. Default features off drops \`nu-ansi-term\`.
- \`crates/panops-engine/src/main.rs\`:
  - \`init_tracing()\` — RUST_LOG-driven, default \`info\`, **third-party HTTP crates pinned to \`warn\`** (\`hyper\`, \`reqwest\`, \`h2\`, \`rustls\`) to prevent API-key leakage when users run \`RUST_LOG=trace\` (genai sends Authorization headers via reqwest/hyper).
  - \`with_ansi(false)\` — stderr is often piped (CI capture, \`2>err\`); keeps log output deterministic.
  - \`try_init()\` — tolerates the case where cargo's test harness pre-installed a subscriber.
  - Bootstrap event \`"panops-engine starting"\` right after init — gives 3am-debugger a positive signal that init ran.
- \`crates/panops-portable/src/model.rs\` — 4 \`eprintln!\` → \`tracing::info!\` with structured fields.
- \`crates/panops-engine/tests/cli_logging.rs\` (new) — three integration tests:
  1. \`default_mode_stdout_is_pure_json_with_rust_log_set\` — guards stdout JSON contract under \`RUST_LOG=debug\`.
  2. \`rust_log_info_actually_emits_tracing_lines\` — **positive control**: proves the subscriber is wired (catches silent \`try_init\` failures).
  3. \`rust_log_off_silences_info_and_debug\` — negative control under \`RUST_LOG=off\`.
- \`README.md\` — new "Logging" section documenting RUST_LOG.

## Review process

Ran \`mcp__claude-review__audit_pr\` (3 focuses) + 13 adversarial reviewer personas (security, resilience, slop, portability, SOLID, testing, DX, 3am, UNIX, cold-reader, adversarial, long-term, dep-minimalist) in parallel. Consolidated findings:

**Applied:**
- Drop \`tracing\` from \`panops-core\` (Slop, SOLID, Long-term, Dep minimalist consensus)
- \`default-features = false\` on tracing-subscriber + \`with_ansi(false)\` (SOLID, UNIX, Dep minimalist)
- Scope HTTP crates in default filter (Security Auditor — concrete API-key leak vector)
- Add positive-control test (Testing, Adversarial)
- Inline rationale comments in init_tracing (Long-term, Cold Reader)
- README logging section (DX)

**Filed as follow-up issues:**
- #63 — Model download progress heartbeat (3am Responder, Resilience)
- #64 — Lift init_tracing into shared crate when slice 06 sidecars land (Long-term)

**Rejected with rationale:**
- PANOPS_LOG dual support — RUST_LOG is the Rust ecosystem convention; deviating creates surprise.
- Reverting to eprintln entirely — supersedes user direction; the whole point of this PR.

## Test plan

- [x] \`cargo build --workspace --locked\`
- [x] \`cargo test --workspace --locked\` — all green (3 new tests in \`cli_logging.rs\`)
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] Existing \`cli_default.rs\` regression — stdout JSON still bit-clean