### PR TITLE
Add code-side verifier for LLM speaker attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/panops-core/Cargo.toml
+++ b/crates/panops-core/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 rayon = "1.10"
+tracing = "0.1"

--- a/crates/panops-core/src/notes/mod.rs
+++ b/crates/panops-core/src/notes/mod.rs
@@ -6,3 +6,4 @@ pub mod pipeline;
 pub mod prompts;
 pub mod screenshot_anchoring;
 pub mod topic_segmentation;
+pub mod verifier;

--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -27,6 +27,7 @@ use crate::notes::prompts::{
 };
 use crate::notes::screenshot_anchoring::anchor_screenshots;
 use crate::notes::topic_segmentation::{TopicSegmentationConfig, segment_topics};
+use crate::notes::verifier;
 
 pub struct NotesGenerator<'a> {
     pub llm: &'a (dyn LlmProvider + 'a),
@@ -48,6 +49,13 @@ impl NotesGenerator<'_> {
         // Stage 1
         let raw_sections = segment_topics(&input.transcript, &TopicSegmentationConfig::default());
 
+        // Build the allowed-speaker set once for the verifier (Stage 2).
+        let allowed_speakers: HashSet<u32> = input
+            .transcript
+            .iter()
+            .filter_map(|s| s.speaker_id)
+            .collect();
+
         // Stage 2 (parallel)
         let section_drafts: Vec<SectionDraft> = raw_sections
             .par_iter()
@@ -59,7 +67,32 @@ impl NotesGenerator<'_> {
                     .collect();
                 let req = build_section_narrative_prompt(&segs, self.dialect, &language);
                 match self.llm.complete(req) {
-                    Ok(LlmResponse::Json(v)) => SectionDraft::from_json(raw.time_range_ms, segs, v),
+                    Ok(LlmResponse::Json(v)) => {
+                        let draft = SectionDraft::from_json(raw.time_range_ms, segs.clone(), v);
+                        // Verifier gate: if the LLM attributed speech to an
+                        // ID not present in the transcript, drop the draft
+                        // and fall back to a deterministic transcript dump.
+                        match verifier::verify_section_attribution(
+                            &draft.narrative_md,
+                            &draft.action_items,
+                            &allowed_speakers,
+                        ) {
+                            verifier::VerifierReport::Ok => draft,
+                            verifier::VerifierReport::DisallowedSpeakers(ids) => {
+                                tracing::warn!(
+                                    section_ms = ?raw.time_range_ms,
+                                    disallowed = ?ids,
+                                    "section narrative referenced speakers not in transcript; using fallback"
+                                );
+                                SectionDraft::fallback(
+                                    raw.time_range_ms,
+                                    segs,
+                                    "verifier: disallowed speaker reference",
+                                    self.dialect,
+                                )
+                            }
+                        }
+                    }
                     Ok(LlmResponse::Text(_)) => SectionDraft::fallback(
                         raw.time_range_ms,
                         segs,

--- a/crates/panops-core/src/notes/verifier.rs
+++ b/crates/panops-core/src/notes/verifier.rs
@@ -1,0 +1,204 @@
+//! Post-LLM verifier for section attribution. Enforces the speaker-attribution
+//! rule that today only lives in the prompt (`prompts.rs:51-52`):
+//!
+//! > Speaker attribution rule (STRICT): never attribute a quote to a speaker_id
+//! > that does not appear in the transcript.
+//!
+//! Verifies LLM-emitted `narrative_md` and `action_items[].owner` reference
+//! only allowed `speaker_<u32>` IDs. Returns `VerifierReport::Ok` for valid
+//! output and `VerifierReport::DisallowedSpeakers(set)` when at least one
+//! reference falls outside the allowed set. The pipeline reacts by falling
+//! back to a deterministic transcript dump for that section.
+//!
+//! Only ID-form references (`speaker_42`) are validated — invented names
+//! ("Alex") aren't in scope; speaker-name resolution is a later slice (#21).
+//! Frontmatter title verification is also out of scope for this pass.
+
+use std::collections::HashSet;
+
+use crate::notes::ir::ActionItem;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifierReport {
+    Ok,
+    DisallowedSpeakers(HashSet<u32>),
+}
+
+/// Verifies a section's narrative + action items reference only allowed
+/// `speaker_<u32>` IDs. Allowed IDs are typically `collect_speakers`'s set
+/// derived from transcript segments.
+pub fn verify_section_attribution(
+    narrative_md: &str,
+    action_items: &[ActionItem],
+    allowed_speakers: &HashSet<u32>,
+) -> VerifierReport {
+    let mut disallowed: HashSet<u32> = HashSet::new();
+
+    for id in scan_speaker_ids(narrative_md) {
+        if !allowed_speakers.contains(&id) {
+            disallowed.insert(id);
+        }
+    }
+
+    for item in action_items {
+        if let Some(owner) = item.owner.as_deref() {
+            if let Some(id) = parse_speaker_id(owner) {
+                if !allowed_speakers.contains(&id) {
+                    disallowed.insert(id);
+                }
+            }
+            // Non-`speaker_N` owner strings (e.g. "Alex") are not validated
+            // here — see #21 for speaker-name resolution.
+        }
+    }
+
+    if disallowed.is_empty() {
+        VerifierReport::Ok
+    } else {
+        VerifierReport::DisallowedSpeakers(disallowed)
+    }
+}
+
+/// Yields every `speaker_<u32>` ID found in the input, anchored on a word
+/// boundary so substrings like `thespeaker_42` aren't matched. Tolerates
+/// surrounding markdown (bold/italic markers, colons, parens) — those are
+/// non-alphanumeric and treated as boundaries.
+fn scan_speaker_ids(s: &str) -> impl Iterator<Item = u32> + '_ {
+    s.match_indices("speaker_").filter_map(move |(start, _)| {
+        // Require word boundary before the match: start-of-string or a
+        // non-(alphanumeric|underscore) char.
+        let preceded_by_word_char = s[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+        if preceded_by_word_char {
+            return None;
+        }
+        let rest = &s[start + "speaker_".len()..];
+        let digit_end = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        if digit_end == 0 {
+            None
+        } else {
+            rest[..digit_end].parse::<u32>().ok()
+        }
+    })
+}
+
+/// Parses exactly `speaker_<u32>` (with optional surrounding whitespace).
+/// Returns `None` if the input is shaped differently — those are not
+/// considered ID references and are passed through verbatim.
+fn parse_speaker_id(s: &str) -> Option<u32> {
+    let trimmed = s.trim();
+    let rest = trimmed.strip_prefix("speaker_")?;
+    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    rest.parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowed(ids: &[u32]) -> HashSet<u32> {
+        ids.iter().copied().collect()
+    }
+
+    fn item(desc: &str, owner: Option<&str>) -> ActionItem {
+        ActionItem {
+            description: desc.to_string(),
+            owner: owner.map(String::from),
+            due: None,
+        }
+    }
+
+    #[test]
+    fn ok_when_only_allowed_speakers_appear() {
+        let narrative = "**speaker_0:** opened. **speaker_1:** asked.";
+        let items = vec![item("draft", Some("speaker_1")), item("review", None)];
+        assert_eq!(
+            verify_section_attribution(narrative, &items, &allowed(&[0, 1])),
+            VerifierReport::Ok
+        );
+    }
+
+    #[test]
+    fn flags_disallowed_speaker_in_narrative() {
+        let narrative = "**speaker_99:** said something they did not say.";
+        let report = verify_section_attribution(narrative, &[], &allowed(&[0, 1]));
+        match report {
+            VerifierReport::DisallowedSpeakers(s) => {
+                assert!(s.contains(&99));
+                assert_eq!(s.len(), 1);
+            }
+            VerifierReport::Ok => panic!("expected violation"),
+        }
+    }
+
+    #[test]
+    fn flags_disallowed_owner_in_action_item() {
+        let items = vec![item("ship", Some("speaker_42"))];
+        let report = verify_section_attribution("benign body", &items, &allowed(&[0, 1]));
+        match report {
+            VerifierReport::DisallowedSpeakers(s) => assert!(s.contains(&42)),
+            VerifierReport::Ok => panic!("expected violation"),
+        }
+    }
+
+    #[test]
+    fn passes_through_non_id_owner_strings() {
+        // "Alex" is not a speaker_ID form; verifier doesn't flag invented names.
+        // Speaker-name resolution lives in a later slice (#21).
+        let items = vec![item("draft", Some("Alex"))];
+        assert_eq!(
+            verify_section_attribution("clean body", &items, &allowed(&[0])),
+            VerifierReport::Ok
+        );
+    }
+
+    #[test]
+    fn passive_voice_with_no_speaker_prefix_passes() {
+        let narrative = "The agenda was reviewed and the team agreed on next steps.";
+        assert_eq!(
+            verify_section_attribution(narrative, &[], &allowed(&[0])),
+            VerifierReport::Ok
+        );
+    }
+
+    #[test]
+    fn collects_multiple_disallowed_speakers() {
+        let narrative = "speaker_99 and speaker_88 both spoke; speaker_0 nodded.";
+        let report = verify_section_attribution(narrative, &[], &allowed(&[0]));
+        match report {
+            VerifierReport::DisallowedSpeakers(s) => {
+                assert!(s.contains(&88));
+                assert!(s.contains(&99));
+                assert!(!s.contains(&0));
+            }
+            VerifierReport::Ok => panic!("expected violations"),
+        }
+    }
+
+    #[test]
+    fn ignores_non_digit_suffix_after_speaker_prefix() {
+        // "speaker_" without trailing digits should not yield any ID.
+        let narrative = "speaker_? unknown citation; speaker_0 was clear.";
+        assert_eq!(
+            verify_section_attribution(narrative, &[], &allowed(&[0])),
+            VerifierReport::Ok
+        );
+    }
+
+    #[test]
+    fn word_boundary_skips_substring_matches() {
+        // `thespeaker_99` and `notaspeaker_42` are *not* speaker references;
+        // verifier should ignore them.
+        let narrative = "thespeaker_99 ate the notaspeaker_42 cake. speaker_0 saw it.";
+        assert_eq!(
+            verify_section_attribution(narrative, &[], &allowed(&[0])),
+            VerifierReport::Ok
+        );
+    }
+}

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -89,6 +89,71 @@ fn one_section_pipeline_produces_structured_notes() {
 }
 
 #[test]
+fn verifier_replaces_section_narrative_when_llm_invents_speaker_id() {
+    // Transcript only has speaker_0. LLM hallucinates speaker_99.
+    // Verifier must catch the violation and the pipeline falls back to a
+    // deterministic transcript dump for that section instead of shipping
+    // the bogus narrative.
+    let segments = vec![seg(0, 60_000, 0, "hello and welcome to the meeting")];
+
+    let section_prompt = build_section_narrative_prompt(&segments, MarkdownDialect::Basic, "en");
+    let frontmatter_prompt = build_frontmatter_prompt(
+        &[SectionSummary {
+            title: "Section".into(),
+            key_points: vec![],
+        }],
+        "en",
+        60_000,
+    );
+    let mock = MockLlm::default()
+        .with_response_for(
+            section_prompt.system.as_deref(),
+            &section_prompt.user,
+            LlmResponse::Json(serde_json::json!({
+                "title": "Welcome",
+                "narrative_md": "**speaker_99:** said something they did not say.",
+                "key_points": [],
+                "action_items": []
+            })),
+        )
+        .with_response_for(
+            frontmatter_prompt.system.as_deref(),
+            &frontmatter_prompt.user,
+            LlmResponse::Json(serde_json::json!({"title": "Meeting", "tags": []})),
+        );
+
+    let generator = NotesGenerator {
+        llm: &mock,
+        dialect: MarkdownDialect::Basic,
+    };
+    let input = NotesInput {
+        transcript: segments,
+        screenshots: vec![],
+        meeting_metadata: MeetingMetadata {
+            started_at: FixedOffset::east_opt(0)
+                .unwrap()
+                .with_ymd_and_hms(2026, 5, 1, 10, 0, 0)
+                .unwrap(),
+            duration_ms: 60_000,
+            source_path: None,
+            language_hint: Some("en".into()),
+        },
+    };
+
+    let notes = generator.generate(input).expect("generate failed");
+    assert_eq!(notes.sections.len(), 1);
+    let body = &notes.sections[0].narrative_md;
+    assert!(
+        !body.contains("speaker_99"),
+        "verifier should have stripped the bogus speaker; got: {body}"
+    );
+    assert!(
+        body.contains("verifier:") || body.contains("speaker_0:"),
+        "fallback should emit a verifier marker and/or transcript dump; got: {body}"
+    );
+}
+
+#[test]
 fn frontmatter_llm_failure_falls_back_to_untitled() {
     let segments = vec![seg(0, 60_000, 0, "hello and welcome to the meeting")];
 


### PR DESCRIPTION
## Summary

Closes #15. Adds a deterministic post-LLM verifier that enforces the speaker-attribution rule that today only lives in the prompt (\`prompts.rs:51-52\`):

> never attribute a quote to a speaker_id that does not appear in the transcript

When the LLM hallucinates a speaker (e.g. \`speaker_99\` in narrative or owner of an action item where the transcript only has \`speaker_0\`), the pipeline now drops that section's draft and falls back to a deterministic transcript dump for that section. The pipeline does not abort; other sections are unaffected.

## Changes

- New \`crates/panops-core/src/notes/verifier.rs\` — \`verify_section_attribution(narrative_md, action_items, allowed_speakers) -> VerifierReport\`. Word-boundary anchored speaker-ID scanner; ignores invented names ("Alex" — speaker-name resolution is #21).
- \`crates/panops-core/src/notes/pipeline.rs\` — wraps \`SectionDraft::from_json\` result with the verifier; on violation: \`tracing::warn!\` (uses the tracing infrastructure from #62) + fallback to deterministic transcript dump.
- \`crates/panops-core/Cargo.toml\` — re-adds \`tracing = "0.1"\` (now has a real call site).
- \`crates/panops-core/tests/notes_pipeline.rs\` — new integration test \`verifier_replaces_section_narrative_when_llm_invents_speaker_id\` proves the verifier wires end-to-end.
- 8 unit tests in \`verifier.rs\`: valid pass-through, narrative violation, owner violation, passive voice, multiple violations, non-digit suffix, non-ID owner ("Alex" passes), word-boundary substring rejection.

## Scope (deliberate)

- ID-form references only (\`speaker_<u32>\`). Invented names not validated — that's #21.
- Section narrative + action_items[].owner. Frontmatter title is out of scope (file separately if found leaking).
- Strict mode: violation → fallback. Lenient substitution can be added later if strict proves too aggressive.

## Test plan

- [x] \`cargo test -p panops-core --lib notes::verifier\` — 8 passed
- [x] \`cargo test -p panops-core --test notes_pipeline\` — 4 passed (incl. new integration test)
- [x] \`cargo test --workspace --locked\` — all green
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`mcp__claude-review__audit_pr\` (focus=risk) + \`find_examples_of\` — addressed all 3 suggestions:
  - word-boundary anchor on scanner (added \`word_boundary_skips_substring_matches\` test)
  - dropped unused \`is_ok()\` helper
  - renamed test \`handles_speaker_prefix_inside_other_words\` → \`ignores_non_digit_suffix_after_speaker_prefix\` (was misleading)
  - switched \`super::ir::ActionItem\` → \`crate::notes::ir::ActionItem\` for refactor robustness

## Why "drop the section" vs "rewrite"

Strict-fallback is safer for slice-04 cleanup: regex-rewriting LLM markdown is brittle, and a section produced from the deterministic transcript dump is always honest about what was said. If lenient substitution becomes desirable, file as follow-up.

Builds on #62 (tracing wired) — the verifier's \`tracing::warn!\` would have been an \`eprintln!\` otherwise.