### PR TITLE
Fix #34: build.rs adds LC_RPATH for sister dylibs (macos)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
  "panops-core",
  "panops-portable",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/panops-engine/Cargo.toml
+++ b/crates/panops-engine/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 publish = false
+build = "build.rs"
 
 [[bin]]
 name = "panops-engine"
@@ -19,3 +20,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/panops-engine/build.rs
+++ b/crates/panops-engine/build.rs
@@ -1,0 +1,28 @@
+//! Add `LC_RPATH` entries to the macOS binary so it can locate its
+//! sister dylibs (`libonnxruntime.*.dylib`, `libsherpa-onnx-c-api.dylib`)
+//! at runtime without requiring `DYLD_LIBRARY_PATH` to be set.
+//!
+//! Today (issue #34) the binary references those dylibs via `@rpath/...`
+//! (set by `sherpa-rs-sys`'s build) but has no rpath search list, so
+//! distributing the binary fails at startup with
+//! `Library not loaded: @rpath/libonnxruntime.1.17.1.dylib`.
+//!
+//! Strategy: emit two rpath search entries.
+//!   1. `@executable_path` — covers `cargo run`, `cargo install`, and a
+//!      flat layout where dylibs sit next to the binary.
+//!   2. `@executable_path/../lib` — covers app-bundle layouts (`bin/` +
+//!      `lib/`) which we'll use in slice 06 packaging.
+//!
+//! The script is gated on `cfg(target_os = "macos")` so Linux/Windows
+//! builds are unaffected. `cargo install`'s known limitation: this rpath
+//! does not bundle the dylibs themselves, so a user who `cargo install`s
+//! the engine still needs the dylibs on their `DYLD_FALLBACK_LIBRARY_PATH`
+//! or copied next to the installed binary. Slice 06 packaging will fix
+//! that end-to-end.
+
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../lib");
+    }
+}

--- a/crates/panops-engine/tests/dylib_smoke.rs
+++ b/crates/panops-engine/tests/dylib_smoke.rs
@@ -1,0 +1,99 @@
+//! End-to-end smoke test for issue #34 — proves the engine binary can find
+//! its sister dylibs (`libonnxruntime.*.dylib`, `libsherpa-onnx-c-api.dylib`)
+//! at runtime via the `LC_RPATH` entries set by `build.rs`.
+//!
+//! Without the rpath fix, copying the binary anywhere outside `target/debug`
+//! fails at startup with `Library not loaded: @rpath/libonnxruntime.*`.
+//! This test reproduces that failure surface (binary in a fresh directory,
+//! no `DYLD_LIBRARY_PATH`) and asserts success.
+//!
+//! macOS-only: the rpath build.rs is gated on `cfg(target_os = "macos")`
+//! and Linux/Windows have different shared-library resolution rules.
+
+#![cfg(target_os = "macos")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn engine_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_panops-engine"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|p| p.join("tests/fixtures/audio").is_dir())
+        .expect("workspace tests/fixtures/audio not found; run from a panops checkout")
+        .join("tests/fixtures")
+}
+
+/// Copies the engine binary and its sister dylibs into a fresh temp dir,
+/// then runs the binary from there with `PANOPS_FAKE_ASR=1` so we don't
+/// need a real Whisper model. Confirms dylibs load via the rpath fix.
+#[test]
+fn engine_loads_sister_dylibs_via_rpath() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = engine_bin();
+    let bin_dir = bin.parent().expect("binary has parent dir");
+
+    // Copy the binary itself.
+    let dst_bin = tmp.path().join("panops-engine");
+    std::fs::copy(&bin, &dst_bin).expect("copy binary");
+    let mut perms = std::fs::metadata(&dst_bin)
+        .expect("stat dst binary")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&dst_bin, perms).expect("chmod dst binary");
+
+    // Copy every sherpa/onnxruntime dylib living next to the binary.
+    let mut copied_dylibs = 0usize;
+    for entry in std::fs::read_dir(bin_dir)
+        .expect("read target dir")
+        .flatten()
+    {
+        let name = entry.file_name();
+        let name_s = name.to_string_lossy();
+        if name_s.starts_with("libonnxruntime") || name_s.starts_with("libsherpa-onnx") {
+            let dst = tmp.path().join(&name);
+            std::fs::copy(entry.path(), &dst).expect("copy dylib");
+            copied_dylibs += 1;
+        }
+    }
+    if copied_dylibs == 0 {
+        // No sister dylibs in target/<profile>/ — likely a vendored or
+        // system-linked ONNXRuntime build (e.g. ONNXRUNTIME_DIR set). The
+        // rpath fix is still valid; this test just can't exercise it
+        // because there's nothing to copy. Skip rather than fail.
+        eprintln!("skipping engine_loads_sister_dylibs_via_rpath: no sister dylibs in {bin_dir:?}");
+        return;
+    }
+
+    // Run from the temp dir with no DYLD_* hints — only the rpath should
+    // make this work.
+    let audio = fixtures_dir().join("audio").join("en_30s.wav");
+    let out = Command::new(&dst_bin)
+        .arg(&audio)
+        .arg("--no-diarize")
+        .env("PANOPS_FAKE_ASR", "1")
+        // Strip any inherited DYLD_LIBRARY_PATH so we exercise pure rpath
+        // resolution. Empty string is treated by dyld as unset.
+        .env("DYLD_LIBRARY_PATH", "")
+        .env("DYLD_FALLBACK_LIBRARY_PATH", "")
+        .output()
+        .expect("run engine from tempdir");
+
+    assert!(
+        out.status.success(),
+        "engine failed to start from {:?}\nstatus: {}\nstderr: {}",
+        tmp.path(),
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Stdout must still be the bit-clean JSON contract.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("stdout is not valid JSON; binary started but produced garbage");
+    assert_eq!(v["schema_version"], 2, "unexpected schema_version");
+}


### PR DESCRIPTION
## Summary

Closes #34. Embeds two \`LC_RPATH\` entries into the macOS \`panops-engine\` binary so it can locate \`libonnxruntime.*.dylib\` and \`libsherpa-onnx-c-api.dylib\` at runtime without requiring \`DYLD_LIBRARY_PATH\` to be set.

**Before this PR**: \`otool -l target/debug/panops-engine | grep LC_RPATH\` returns nothing. The binary references the dylibs as \`@rpath/...\` but has no rpath search list, so copying it anywhere outside \`target/<profile>/\` fails at startup with \`Library not loaded: @rpath/libonnxruntime.1.17.1.dylib\`. \`cargo run\` happens to work today only because the dylibs and the binary share \`target/<profile>/\` and macOS dyld falls back to the current directory in dev contexts.

**After this PR**: two rpath entries embedded, covering the two layouts panops will ship in:
1. \`@executable_path\` — flat layout (\`bin/panops-engine\` + sibling \`*.dylib\`s); also covers \`cargo install\` once dylibs are bundled.
2. \`@executable_path/../lib\` — app-bundle layout (\`bin/\` + \`lib/\`) used in slice-06 packaging.

## Changes

- \`crates/panops-engine/build.rs\` (new) — emits \`cargo:rustc-link-arg=-Wl,-rpath,@executable_path\` and \`@executable_path/../lib\`. Gated on \`cfg(target_os = "macos")\`; Linux/Windows untouched.
- \`crates/panops-engine/Cargo.toml\` — \`build = "build.rs"\` and \`tempfile\` as a dev-dep.
- \`crates/panops-engine/tests/dylib_smoke.rs\` (new) — macOS-only integration test that copies the binary + sister dylibs to a fresh temp dir, strips \`DYLD_LIBRARY_PATH\` and \`DYLD_FALLBACK_LIBRARY_PATH\` (so only rpath resolution can save it), and runs \`PANOPS_FAKE_ASR=1 panops-engine <wav> --no-diarize\`. Asserts exit 0 and bit-clean JSON stdout. Gracefully skips when no sister dylibs exist (vendored/system-linked builds).

## Test plan

- [x] \`otool -l target/debug/panops-engine | grep -A2 LC_RPATH\` shows both entries
- [x] Manual smoke: copy binary + dylibs to \`/tmp/panops-rpath-smoke\`, run with \`PANOPS_FAKE_ASR=1\`; exit 0 and stdout is valid JSON.
- [x] \`cargo test -p panops-engine --test dylib_smoke\` — passes
- [x] \`cargo test --workspace --locked\` — all green
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`mcp__claude-review__audit_pr\` — addressed: dropped redundant \`rerun-if-changed\`, moved \`use\` to top of file, switched the \`copied_dylibs\` hard-fail to a skip-with-message for vendored builds.

## Out of scope

- Bundling the dylibs themselves alongside the binary in \`cargo install\` outputs. The rpath fix lets a properly-laid-out distribution work; bundling is a slice-06 packaging concern.
- The \`@executable_path/../lib\` rpath is not exercised by tests today; slice-06 will land a real bin+lib layout that does.