### PR TITLE
ci: trigger CI on ready_for_review event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 6 * * 1"
 


### PR DESCRIPTION
Closes #59.

GitHub's default \`pull_request\` trigger types are \`[opened, synchronize, reopened]\`. \`ready_for_review\` is excluded, so promoting a draft PR to ready does not fire CI — workaround in past sessions has been a close-reopen dance (e.g. PRs #49, #56). Adding the explicit type list fixes the workflow.

## Test plan

- [x] One-line YAML change; structurally valid (indentation matches existing list-style trigger types).
- Will validate end-to-end on next draft→ready transition.