### PR TITLE
Log frontmatter LLM fallback via tracing

### DIFF
--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -133,7 +133,16 @@ impl NotesGenerator<'_> {
             build_frontmatter_prompt(&summaries, &language, input.meeting_metadata.duration_ms);
         let (title, tags) = match self.llm.complete(fm_req) {
             Ok(LlmResponse::Json(v)) => extract_frontmatter(v),
-            Ok(LlmResponse::Text(_)) | Err(_) => ("Untitled meeting".to_string(), Vec::new()),
+            Ok(LlmResponse::Text(_)) => {
+                tracing::warn!(
+                    "frontmatter LLM call returned text instead of JSON; using defaults"
+                );
+                ("Untitled meeting".to_string(), Vec::new())
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "frontmatter LLM call failed; using defaults");
+                ("Untitled meeting".to_string(), Vec::new())
+            }
         };
 
         let speakers = collect_speakers(&input.transcript);


### PR DESCRIPTION
Closes #60. Builds on #62 (tracing infrastructure landed in PR-A of the debt burndown).

Previously \`NotesGenerator\`'s frontmatter fallback at \`pipeline.rs:136\` swallowed errors silently — \`Untitled meeting\` would appear with no signal as to why. Now both branches (text-instead-of-JSON, network/provider error) emit \`tracing::warn!\` with the reason.

## Changes

- \`crates/panops-core/src/notes/pipeline.rs\` — split the combined match arm into two; each emits a \`tracing::warn!\` before returning the fallback tuple. Error case includes the displayed error message via \`%e\`.

## Test plan

- [x] \`cargo test -p panops-core --test notes_pipeline\` — 4 passed (existing \`frontmatter_llm_failure_falls_back_to_untitled\` still works since it asserts on the output, not the absence of logs).
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`

## Audit

claude-review audit deferred to post-CI; localized 2-arm match split with a tracing call each. Risk surface is minimal.