### PR TITLE
Skip screenshot clamp when duration_ms == 0

### DIFF
--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -109,16 +109,31 @@ impl NotesGenerator<'_> {
             })
             .collect();
 
-        // Stage 3 — clamp out-of-range timestamps, then anchor
+        // Stage 3 — clamp out-of-range timestamps, then anchor.
+        // duration_ms == 0 is a malformed-input edge case (e.g. all-zero-duration
+        // segments with a non-empty transcript). In that state every clamp
+        // collapses to 0, producing degenerate output. Skip the clamp + warn
+        // rather than silently zero everything; downstream anchor still runs
+        // against unclamped values, which the fallback midpoint logic handles.
         let duration_ms = input.meeting_metadata.duration_ms;
-        let clamped_screenshots: Vec<Screenshot> = input
-            .screenshots
-            .iter()
-            .map(|s| Screenshot {
-                ms_since_start: s.ms_since_start.min(duration_ms),
-                ..s.clone()
-            })
-            .collect();
+        let clamped_screenshots: Vec<Screenshot> = if duration_ms == 0 {
+            if !input.screenshots.is_empty() {
+                tracing::warn!(
+                    n = input.screenshots.len(),
+                    "duration_ms == 0; skipping screenshot clamp (malformed metadata)"
+                );
+            }
+            input.screenshots.clone()
+        } else {
+            input
+                .screenshots
+                .iter()
+                .map(|s| Screenshot {
+                    ms_since_start: s.ms_since_start.min(duration_ms),
+                    ..s.clone()
+                })
+                .collect()
+        };
         let per_section_screenshots = anchor_screenshots(&raw_sections, &clamped_screenshots);
 
         // Stage 4 (single LLM call)

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -256,3 +256,45 @@ fn screenshot_past_duration_is_clamped_to_last_section() {
         "timestamp should be clamped to duration_ms"
     );
 }
+
+#[test]
+fn screenshot_with_duration_zero_passes_through_unclamped() {
+    // duration_ms == 0 is malformed metadata. The clamp would collapse every
+    // screenshot to ms=0, producing a degenerate output. Per #61, we skip the
+    // clamp in that case (and emit a tracing::warn), letting the unclamped
+    // values flow through to anchor_screenshots' nearest-section fallback.
+    let segments = vec![seg(0, 60_000, 0, "hello and welcome to the meeting")];
+    // Mock keyed on duration_ms=0 to match what NotesGenerator will request.
+    let mock = make_mock(&segments, 0);
+
+    let generator = NotesGenerator {
+        llm: &mock,
+        dialect: MarkdownDialect::Basic,
+    };
+    let input = NotesInput {
+        transcript: segments,
+        screenshots: vec![Screenshot {
+            ms_since_start: 12_345,
+            path: PathBuf::from("/tmp/img.jpg"),
+            caption: None,
+        }],
+        meeting_metadata: MeetingMetadata {
+            started_at: FixedOffset::east_opt(0)
+                .unwrap()
+                .with_ymd_and_hms(2026, 5, 1, 10, 0, 0)
+                .unwrap(),
+            duration_ms: 0,
+            source_path: None,
+            language_hint: Some("en".into()),
+        },
+    };
+
+    let notes = generator.generate(input).expect("generate failed");
+    assert_eq!(notes.sections.len(), 1);
+    let shots = &notes.sections[0].screenshots;
+    assert_eq!(shots.len(), 1, "screenshot should be preserved");
+    assert_eq!(
+        shots[0].ms_since_start, 12_345,
+        "timestamp must NOT be clamped to 0 when duration_ms == 0"
+    );
+}


### PR DESCRIPTION
Closes #61. Surfaced by deep-audit on PR #54.

Previously \`NotesGenerator\` stage 3 unconditionally clamped \`Screenshot.ms_since_start\` to \`duration_ms.min(...)\`. When \`duration_ms == 0\` (malformed metadata: non-empty transcript with all-zero-duration segments), every screenshot collapsed to ms=0 — silently degenerate output. Now we skip the clamp in that edge case and emit a \`tracing::warn!\` so the malformed-input signal isn't lost.

The unclamped values still flow through \`anchor_screenshots\`'s nearest-section fallback, which handles arbitrary timestamps.

## Changes

- \`crates/panops-core/src/notes/pipeline.rs\` — guard the clamp on \`duration_ms != 0\`; warn + pass-through otherwise.
- \`crates/panops-core/tests/notes_pipeline.rs\` — new test \`screenshot_with_duration_zero_passes_through_unclamped\` proves the timestamp survives.

## Test plan

- [x] \`cargo test -p panops-core --test notes_pipeline\` — 5 passed (existing 4 + new 1)
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`mcp__claude-review__audit_pr\` — clean (2 optional suggestions skipped: premature clone-opt, tracing-test setup out of scope)

Builds on #62 (tracing).