### PR TITLE
Include truncated model output in JSON parse error

### DIFF
--- a/crates/panops-portable/src/genai_llm.rs
+++ b/crates/panops-portable/src/genai_llm.rs
@@ -86,7 +86,7 @@ impl LlmProvider for GenaiLlm {
                 Ok(v) => Ok(LlmResponse::Json(v)),
                 Err(e) => Err(LlmError::InvalidSchema {
                     expected: "json object".into(),
-                    got: format!("text ({e})"),
+                    got: format!("text ({e}); preview: {}", preview_for_error(json_text)),
                 }),
             }
         } else {
@@ -104,6 +104,22 @@ fn strip_markdown_fences(s: &str) -> &str {
     // Use strip_suffix (single match) rather than trim_end_matches (greedy) so
     // a JSON value containing literal triple-backticks isn't corrupted.
     trimmed.strip_suffix("```").unwrap_or(trimmed).trim()
+}
+
+/// Truncates a string for inclusion in an error message. Splits at a char
+/// boundary (so we never panic on UTF-8) and appends an ellipsis marker plus
+/// the dropped byte count when truncation occurred. Used when the LLM emits
+/// non-JSON and we need a self-describing failure without dumping kilobytes.
+fn preview_for_error(s: &str) -> String {
+    const MAX: usize = 200;
+    if s.len() <= MAX {
+        return s.to_string();
+    }
+    let mut end = MAX;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…[+{} bytes]", &s[..end], s.len() - end)
 }
 
 #[cfg(test)]
@@ -147,5 +163,36 @@ mod tests {
         // fence is removed once; the JSON content is preserved.
         let input = "```json\n{\"text\":\"```code```\"}\n```";
         assert_eq!(strip_markdown_fences(input), "{\"text\":\"```code```\"}");
+    }
+
+    #[test]
+    fn preview_short_input_is_unchanged() {
+        assert_eq!(preview_for_error("hello world"), "hello world");
+    }
+
+    #[test]
+    fn preview_input_exactly_at_max_is_unchanged() {
+        // <= MAX is the inclusive boundary — verify the off-by-one.
+        let s = "a".repeat(200);
+        assert_eq!(preview_for_error(&s), s);
+    }
+
+    #[test]
+    fn preview_long_input_is_truncated_with_byte_count() {
+        let s = "a".repeat(500);
+        let p = preview_for_error(&s);
+        assert!(p.starts_with(&"a".repeat(200)));
+        assert!(p.ends_with("…[+300 bytes]"));
+    }
+
+    #[test]
+    fn preview_handles_multibyte_at_truncation_boundary() {
+        // 199 ASCII bytes + a 4-byte emoji = 203 bytes. MAX=200 lands inside
+        // the emoji's UTF-8 sequence, so the function must back off to byte
+        // 199 (the last char boundary) and report the dropped 4 bytes.
+        let s = format!("{}🦀", "a".repeat(199));
+        let p = preview_for_error(&s);
+        assert!(p.starts_with(&"a".repeat(199)));
+        assert!(p.ends_with("…[+4 bytes]"));
     }
 }


### PR DESCRIPTION
Closes #58.

Previously when the LLM returned non-JSON, \`GenaiLlm::complete\` produced an error message like \`text (expected value at line 1 column 1)\` — only the serde parse error, no actual model output. Debugging required re-running with \`RUST_LOG=trace\`.

Now the error includes a UTF-8-safe preview of the first **200 bytes** plus a dropped-byte count when the model output is longer. Bytes (not chars) is the right unit here — the truncation logic operates on UTF-8 byte boundaries and the error message reports what was actually dropped, not what the user might count as a "character" (which is ambiguous for combining chars / emoji).

## Changes

- \`crates/panops-portable/src/genai_llm.rs\`:
  - \`preview_for_error()\` helper — char-boundary-safe truncation at byte index 200, append \`…[+N bytes]\` marker.
  - Use it in the \`InvalidSchema { got: ... }\` arm of the JSON parse path.
  - 4 new unit tests: short input unchanged, exactly-at-boundary unchanged, long input truncated with byte count, multibyte-at-boundary backs off correctly (4-byte 🦀 case).

## Test plan

- [x] \`cargo test -p panops-portable --lib genai_llm\` — 10 passed (6 pre-existing + 4 new)
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`mcp__claude-review__audit_pr\` — caught the chars/bytes label mismatch; both label and tests now use bytes consistently.