### PR TITLE
Stop narrative_md from restating key_points

### DIFF
--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -50,8 +50,22 @@ pub fn build_section_narrative_prompt(
          Output language: {language}\n\n\
          Speaker attribution rule (STRICT): never attribute a quote to a speaker_id\n\
          that does not appear in the transcript. When in doubt, use passive voice.\n\n\
+         Non-duplication rule (STRICT): `narrative_md`, `key_points`, and `action_items`\n\
+         must NOT restate the same facts in different shapes. They are three\n\
+         distinct views of the section:\n\
+         - `narrative_md`: connective prose — context, who arrived/left, how the\n\
+           conversation moved, transitions between topics, mood/tone where it\n\
+           matters. NO bullet lists. NO embedded \"Key points:\" or \"Action items:\"\n\
+           sections. Do NOT restate the bullets in prose form.\n\
+         - `key_points`: durable takeaways the reader scans for later — facts,\n\
+           numbers, decisions, named outcomes. Punchy and self-contained. Each\n\
+           bullet is a fact that does NOT appear (in any paraphrase) in\n\
+           `narrative_md`.\n\
+         - `action_items`: explicit commitments — \"who will do what by when\".\n\
+           A commitment that is also a key takeaway belongs HERE, not in\n\
+           `key_points`. Owner is a speaker_id (or null when unassigned).\n\n\
          Return JSON matching exactly:\n\
-         {{\n  \"title\": \"string (descriptive, <80 chars)\",\n  \"narrative_md\": \"string (markdown body in the dialect above; 100–600 words)\",\n  \"key_points\": [\"string\", ...] (0–6 short bullets),\n  \"action_items\": [{{\"description\": \"string\", \"owner\": \"speaker_0\"}}] or [{{\"description\": \"string\", \"owner\": null}}]\n}}"
+         {{\n  \"title\": \"string (descriptive, <80 chars)\",\n  \"narrative_md\": \"string (prose only — no bullets — in the dialect above; up to 400 words, scaled to section length)\",\n  \"key_points\": [\"string\", ...] (0–6 short bullets, each a fact NOT in narrative_md),\n  \"action_items\": [{{\"description\": \"string\", \"owner\": \"speaker_0\"}}] or [{{\"description\": \"string\", \"owner\": null}}]\n}}"
     );
     LlmRequest {
         system: Some(SECTION_NARRATIVE_SYSTEM.to_string()),
@@ -185,6 +199,16 @@ mod tests {
         assert!(p.user.contains("speaker_1"));
         assert!(p.user.contains("hello"));
         assert!(p.user.contains("hi"));
+    }
+
+    #[test]
+    fn section_narrative_prompt_includes_non_duplication_rule() {
+        let segs = vec![seg(0, 5000, Some(0), "hello")];
+        let p = build_section_narrative_prompt(&segs, MarkdownDialect::Basic, "en");
+        assert!(p.user.contains("Non-duplication rule"));
+        assert!(p.user.contains("must NOT restate the same facts"));
+        assert!(p.user.contains("NO bullet lists"));
+        assert!(p.user.contains("NOT in narrative_md"));
     }
 
     #[test]

--- a/crates/panops-portable/tests/conformance_markdown_exporter.rs
+++ b/crates/panops-portable/tests/conformance_markdown_exporter.rs
@@ -217,24 +217,26 @@ fn regenerate_multi_speaker_60s_goldens() {
     let summaries = vec![SectionSummary {
         title: "Meeting kickoff and quarterly budget review".into(),
         key_points: vec![
-            "Agenda includes budget review for next quarter".into(),
-            "Spending plan needs approval before end of week".into(),
-            "Review covers marketing, engineering, and operations line items".into(),
+            "Budget review scoped to next quarter only".into(),
+            "Review sequence: marketing, engineering, operations".into(),
         ],
     }];
     let frontmatter_prompt = build_frontmatter_prompt(&summaries, "en", 60_000);
 
+    // Goldens demonstrate the non-duplication rule (#35):
+    // - `narrative_md` is connective prose: who arrived, how the conversation
+    //   moved, transitions. Carries no facts that also appear in key_points.
+    // - `key_points` are durable takeaways NOT restated in narrative_md.
+    // - `action_items` carry the commitment (NOT also in key_points).
     let canned_section = serde_json::json!({
         "title": "Meeting kickoff and quarterly budget review",
-        "narrative_md": "The meeting opened with a welcome and agenda overview \
-            covering the next sixty minutes. The first item was a budget review \
-            for next quarter, with approval required before week's end. The \
-            review walks through marketing line items first, then engineering, \
-            then any remaining operations expenses.",
+        "narrative_md": "The session opened with a welcome and a brief handoff \
+            into the agenda. The first agenda item framed the rest of the \
+            meeting, with the discussion organising the review into a clear \
+            sequence so each functional area would get its own slot.",
         "key_points": [
-            "Agenda includes budget review for next quarter",
-            "Spending plan needs approval before end of week",
-            "Review covers marketing, engineering, and operations line items"
+            "Budget review scoped to next quarter only",
+            "Review sequence: marketing, engineering, operations"
         ],
         "action_items": [
             {"description": "Approve quarterly spending plan before end of week", "owner": null}

--- a/crates/panops-portable/tests/conformance_notes_generator.rs
+++ b/crates/panops-portable/tests/conformance_notes_generator.rs
@@ -65,12 +65,14 @@ fn fixture_segments() -> Vec<Segment> {
 fn canned_mock(dialect: MarkdownDialect) -> MockLlm {
     let segments = fixture_segments();
     let section_prompt = build_section_narrative_prompt(&segments, dialect, "en");
+    // Mirrors the canonical canned response in conformance_markdown_exporter.rs
+    // (#35 non-duplication: narrative is connective prose; key_points are
+    // distinct facts; action_items hold the commitment).
     let summaries = vec![SectionSummary {
         title: "Meeting kickoff and quarterly budget review".into(),
         key_points: vec![
-            "Agenda includes budget review for next quarter".into(),
-            "Spending plan needs approval before end of week".into(),
-            "Review covers marketing, engineering, and operations line items".into(),
+            "Budget review scoped to next quarter only".into(),
+            "Review sequence: marketing, engineering, operations".into(),
         ],
     }];
     let frontmatter_prompt = build_frontmatter_prompt(&summaries, "en", 60_000);
@@ -80,15 +82,13 @@ fn canned_mock(dialect: MarkdownDialect) -> MockLlm {
             &section_prompt.user,
             LlmResponse::Json(serde_json::json!({
                 "title": "Meeting kickoff and quarterly budget review",
-                "narrative_md": "The meeting opened with a welcome and agenda overview \
-                    covering the next sixty minutes. The first item was a budget review \
-                    for next quarter, with approval required before week's end. The \
-                    review walks through marketing line items first, then engineering, \
-                    then any remaining operations expenses.",
+                "narrative_md": "The session opened with a welcome and a brief \
+                    handoff into the agenda. The first agenda item framed the rest \
+                    of the meeting, with the discussion organising the review into \
+                    a clear sequence so each functional area would get its own slot.",
                 "key_points": [
-                    "Agenda includes budget review for next quarter",
-                    "Spending plan needs approval before end of week",
-                    "Review covers marketing, engineering, and operations line items"
+                    "Budget review scoped to next quarter only",
+                    "Review sequence: marketing, engineering, operations"
                 ],
                 "action_items": [
                     {"description": "Approve quarterly spending plan before end of week", "owner": null}
@@ -166,4 +166,33 @@ fn rendered_markdown_matches_basic_golden() {
     )
     .unwrap();
     assert_eq!(actual.trim(), expected.trim(), "basic markdown drift");
+}
+
+/// Per #35 — narrative_md and key_points must be distinct views; a key_point
+/// must NOT appear (verbatim or by substring trigram) inside narrative_md.
+/// Same for action_items[].description. Heuristic: lower-case both, look for
+/// any bullet's content as a substring of the narrative.
+#[test]
+fn narrative_does_not_restate_key_points_or_action_items() {
+    let notes = run_pipeline(MarkdownDialect::NotionEnhanced);
+    for sec in &notes.sections {
+        let narrative = sec.narrative_md.to_lowercase();
+        for kp in &sec.key_points {
+            let kp_low = kp.to_lowercase();
+            assert!(
+                !narrative.contains(&kp_low),
+                "narrative restates key_point verbatim:\n  kp: {kp:?}\n  narrative: {:?}",
+                sec.narrative_md
+            );
+        }
+        for ai in &sec.action_items {
+            let d_low = ai.description.to_lowercase();
+            assert!(
+                !narrative.contains(&d_low),
+                "narrative restates action_item.description:\n  desc: {:?}\n  narrative: {:?}",
+                ai.description,
+                sec.narrative_md
+            );
+        }
+    }
 }

--- a/tests/fixtures/notes/multi_speaker_60s.expected.basic.md
+++ b/tests/fixtures/notes/multi_speaker_60s.expected.basic.md
@@ -21,12 +21,11 @@ source_audio: tests/fixtures/audio/multi_speaker_60s.wav
 
 *[0:00 – 1:00]*
 
-The meeting opened with a welcome and agenda overview covering the next sixty minutes. The first item was a budget review for next quarter, with approval required before week's end. The review walks through marketing line items first, then engineering, then any remaining operations expenses.
+The session opened with a welcome and a brief handoff into the agenda. The first agenda item framed the rest of the meeting, with the discussion organising the review into a clear sequence so each functional area would get its own slot.
 
 **Key points:**
-- Agenda includes budget review for next quarter
-- Spending plan needs approval before end of week
-- Review covers marketing, engineering, and operations line items
+- Budget review scoped to next quarter only
+- Review sequence: marketing, engineering, operations
 
 **Action items:**
 - Approve quarterly spending plan before end of week (owner: owner TBD)

--- a/tests/fixtures/notes/multi_speaker_60s.expected.json
+++ b/tests/fixtures/notes/multi_speaker_60s.expected.json
@@ -27,11 +27,10 @@
         0,
         60000
       ],
-      "narrative_md": "The meeting opened with a welcome and agenda overview covering the next sixty minutes. The first item was a budget review for next quarter, with approval required before week's end. The review walks through marketing line items first, then engineering, then any remaining operations expenses.",
+      "narrative_md": "The session opened with a welcome and a brief handoff into the agenda. The first agenda item framed the rest of the meeting, with the discussion organising the review into a clear sequence so each functional area would get its own slot.",
       "key_points": [
-        "Agenda includes budget review for next quarter",
-        "Spending plan needs approval before end of week",
-        "Review covers marketing, engineering, and operations line items"
+        "Budget review scoped to next quarter only",
+        "Review sequence: marketing, engineering, operations"
       ],
       "action_items": [
         {

--- a/tests/fixtures/notes/multi_speaker_60s.expected.notion.md
+++ b/tests/fixtures/notes/multi_speaker_60s.expected.notion.md
@@ -21,12 +21,11 @@ source_audio: tests/fixtures/audio/multi_speaker_60s.wav
 
 *[0:00 – 1:00]*
 
-The meeting opened with a welcome and agenda overview covering the next sixty minutes. The first item was a budget review for next quarter, with approval required before week's end. The review walks through marketing line items first, then engineering, then any remaining operations expenses.
+The session opened with a welcome and a brief handoff into the agenda. The first agenda item framed the rest of the meeting, with the discussion organising the review into a clear sequence so each functional area would get its own slot.
 
 **Key points:**
-- Agenda includes budget review for next quarter
-- Spending plan needs approval before end of week
-- Review covers marketing, engineering, and operations line items
+- Budget review scoped to next quarter only
+- Review sequence: marketing, engineering, operations
 
 **Action items:**
 - Approve quarterly spending plan before end of week (owner: owner TBD)


### PR DESCRIPTION
Closes #35. v0.1 quality blocker.

The committed goldens demonstrated the bug: the section narrative restated the same three facts that were also rendered as the **Key points:** bullet list, in different shape but same content. Surfaced via \`mcp__claude-review__research_project\` audit.

## Root cause

Section-narrative prompt (\`crates/panops-core/src/notes/prompts.rs\`) asked the model to populate four JSON fields (\`title\`, \`narrative_md\`, \`key_points\`, \`action_items\`) but never told it the fields were **distinct views**. The model dutifully wrote prose-version + bullet-version of the same facts. Exporter rendered both unconditionally → duplication in the user-facing markdown.

Fix is at the prompt, not the exporter — the duplication was *content*, not *syntactic* (no embedded markdown bullets to strip).

## Changes

- \`crates/panops-core/src/notes/prompts.rs\`:
  - **New non-duplication rule** clearly distinguishing the three views: \`narrative_md\` = connective prose (flow, transitions, mood; no bullets); \`key_points\` = scannable durable facts NOT in narrative; \`action_items\` = commitments (and not duplicated in key_points).
  - Word-count range loosened to "up to 400 words, scaled to section length" — the prior floor of 80–100 words conflicted with short fixtures (audit caught this).
  - New unit test asserting the prompt contains the new rule.
- \`crates/panops-portable/tests/conformance_markdown_exporter.rs\` and \`conformance_notes_generator.rs\`: canned LLM responses rewritten to demonstrate the desired pattern (narrative = flow prose; 2 key_points = facts not in narrative; 1 action_item = commitment).
- \`tests/fixtures/notes/multi_speaker_60s.expected.{json,notion.md,basic.md}\`: regenerated goldens. **No more content duplication** — narrative now talks about the *flow* of the session; key_points carry the *takeaways*; action_items carry the *commitment*.
- New conformance test \`narrative_does_not_restate_key_points_or_action_items\` — heuristic substring guard against verbatim regression. (Won't catch paraphrase-level overlap, but blocks the literal regression.)

## Test plan

- [x] \`cargo test --workspace --locked\` — all green
- [x] \`cargo test -p panops-portable --test conformance_notes_generator\` — 4 passed (3 pre-existing + 1 new non-duplication guard)
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`mcp__claude-review__research_project\` (root-cause investigation) + \`audit_pr\` (post-fix review) — both clean. Word-count floor mismatch caught and fixed.

## Why this matters for v0.1

This was the most user-visible quality bug in the notes pipeline — every meeting Notes output had the same issue. Without this fix, v0.1 is unshippable.