### PR TITLE
fix #74: real adapters in serve via eager-after-bind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ GEMINI.md
 docs/superpowers/plans/
 docs/superpowers/sessions/
 docs/superpowers/conversations/
+docs/superpowers/reviews/
 docs/internal/
 
 # ----- Rust -----

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,24 @@
 
 Open-source local-first macOS recorder with screenshot-anchored meeting notes. Hexagonal Rust core + SwiftUI Mac shell + Swift sidecars (WhisperKit/FluidAudio for ASR, Apple FoundationModels for LLM).
 
-This file IS the workflow contract. Every rule here is enforced. If a rule is unclear or you (the agent) disagree with it, raise it with the maintainer before acting — don't reinterpret silently.
+This file IS the workflow contract. Every rule here is enforced. The methodology assumes **solo development with autonomous agents** — the human is *framework designer, not active monitor*. Per-decision gating is the failure mode; constraints up front + scheduled drift detection is the working mode. If a rule is unclear or you (the agent) disagree with it, raise it with the maintainer before acting — don't reinterpret silently.
+
+For project goal + v0.1 acceptance criteria, see `docs/north-star.md`. For methodology rationale, see `docs/superpowers/reviews/2026-05-02-solo-agent-methodology.md`.
 
 ## Sources of truth
 
 | Surface | What it owns | Where |
 |---|---|---|
-| **GitHub Project board** | Open work, status, severity, slice ownership. **Lead with this.** | https://github.com/users/vfmatzkin/projects/1 (linked at https://github.com/vfmatzkin/panops/projects) |
+| **North Star** | Project goal + v0.1 acceptance criteria. The thing every slice must serve. Amend only at major-milestone boundaries. | `docs/north-star.md` |
+| **GitHub Project board** | Open work, status, severity, slice ownership. **Lead with this for in-flight state.** | https://github.com/users/vfmatzkin/projects/1 (linked at https://github.com/vfmatzkin/panops/projects) |
 | **Design spec** | Architecture (locked). Don't restructure ports/adapters without revising. | `docs/superpowers/specs/2026-04-30-panops-design.md` |
 | **Slice spec** | The active slice's design (locked once approved). | `docs/superpowers/specs/<latest>-slice-NN-*.md` |
 | **Slice plan** (private) | Step-by-step checklist for the active slice. Checkbox state IS progress. | `docs/superpowers/plans/<latest>.md` (not in `done/`) |
 | **Session log** (private) | Journal of what happened in each work block. | `docs/superpowers/sessions/NNN-YYYY-MM-DD-<slug>.md` |
+| **Alignment audit** (private) | Drift findings from the audit ritual. Latest one is the canonical drift state. | `docs/superpowers/reviews/YYYY-MM-DD-*-audit.md` |
 | **Market scan** | Verified library + pattern picks (April 2026). | `docs/research/2026-04-30-market-scan.md` |
 
-When the project board and a markdown artifact disagree, the project board wins.
+Priority when sources disagree: **north-star > active slice spec > design spec > slice plan**. North star is the goal; everything below is a translation. Project board wins for in-flight state (who's blocked, what's open).
 
 ## Repo conventions
 
@@ -49,29 +53,144 @@ Mac app build commands land in slice 06.
 - **MUST** keep one slice = one PR = the maintainer's review gate. **NEVER** start slice N+1 until slice N's PR is merged.
 - **MUST** scope plans per-slice. **NEVER** write whole-project step lists.
 
-## Slice sequence
+## Methodology — solo dev with agents
+
+Per-decision gating is the failure mode; constraints up front + scheduled drift detection is the working mode. Built on Anthropic's *Effective harnesses for long-running agents* (humans-as-framework-designers), Harper Reed's spec → plan → execute pattern, Addy Osmani's three-tier boundaries, and Swarmia's autonomy levels.
+
+### Autonomy levels
+
+- **L2 — collaborative**: brainstorming, slice spec writing, architectural calls, library choice, PR review. Agent proposes; maintainer picks. **Never let an agent lock architecture autonomously.**
+- **L3 — task agent**: slice plan execution. Agent runs the plan to PR; tests + diff are the gate; maintainer reviews PR, not steps. **Default for implementation work inside an approved slice.**
+- **L4 — autonomous teammate**: only for genuinely recurring work (Dependabot, lint sweeps). Currently unused; experiment cautiously before adopting.
+
+Architectural decisions = L2. Slice implementation = L3. Maintenance = L4. **NEVER** mix levels mid-slice without explicit agreement.
+
+### Three-tier boundaries (every slice spec MUST define them)
+
+Each slice spec includes a section listing, with verbs:
+
+- ✅ **Always do** — actions agents take without asking (e.g., "run `cargo fmt`", "open issues for deferred items", "commit per task in the slice plan").
+- ⚠️ **Ask first** — actions warranting a pause + brief confirmation (e.g., "rename a public type", "drop a CI check", "change a test threshold").
+- 🚫 **Never do** — hard stops (e.g., "introduce a trait without a real impl + fake", "phone home", "open or merge a PR autonomously").
+
+If a category can't be written upfront, it can't be decided upfront — escalate before the brainstorm finishes. Per Addy Osmani: *clearer constraints grant more independence*.
+
+### Alignment-audit ritual
+
+Drift detection runs **continuously, with automatic triggers** — the harness fires it; the maintainer doesn't have to remember. Three tiers:
+
+#### Lightweight audit (frequent, context-rot driven)
+
+Triggered when context is at risk:
+- At SessionStart when the active session log is >24h old or the conversation has >100 turns since the last audit.
+- After any `/compact` or auto-compaction event.
+- Before opening any PR.
+- After dispatching >5 subagents in one session (fan-out can drift on its own).
+- Whenever the maintainer types "audit", "are we on track", or invokes `/ultrathink` review.
+
+Procedure (≤5 min):
+1. Re-read `docs/north-star.md`.
+2. Re-read the active slice spec's three-tier boundaries.
+3. Run `mcp__claude-review__research_project` with: *"Has the active slice's shipped state diverged from `docs/north-star.md` and the slice spec? Cite drifts with file:line."*
+4. If drifts surface, post a one-line warning to the maintainer + file follow-up debt issues.
+
+This is the context-rot mitigation. Run it without asking.
+
+#### Slice-boundary audit (heavy, automatic post-merge)
+
+Triggered when a slice's PR merges. Procedure (MCP-first per Tool routing):
+1. `mcp__claude-review__audit_pr` against the merged commit range with `focus: all` — risk + style + tests passes.
+2. `mcp__claude-review__inspect_transcript` against the slice's main session `.jsonl`. Extract user words vs shipped state.
+3. `mcp__claude-review__research_project` for any topic the audit_pr surfaces but doesn't fully ground.
+4. **Only if MCP can't reach the depth needed**: dispatch ONE `Task` subagent for a specific cross-cutting synthesis — never a parallel fan-out, never as the default.
+5. Write findings to `docs/superpowers/reviews/YYYY-MM-DD-slice-NN-audit.md`. List drifts. File debt for non-trivial.
+6. If a drift conflicts with `docs/north-star.md`, treat as **blocking** — fix or amend the north-star before the next slice's brainstorm.
+
+#### Maintainer-triggered audit (on demand)
+
+When the maintainer asks for a deep audit ("review alignment", `/ultrathink` review, "are we still building the right thing"). Same procedure as slice-boundary; output to `docs/superpowers/reviews/`. Heavy.
+
+### Tool routing — MCP for derived work, Task for synthesis only
+
+`Task`/`Agent` subagents start with **zero cache and are billed against the maintainer's primary Claude budget**. The `claude-review` MCP runs against `claudea` (a Qwen-backed Claude-CLI clone) on a separate path that is **free for the maintainer**. **Default to MCP for any read-only / research / audit task.** Reserve `Task` for work that genuinely requires:
+
+- Code synthesis with Claude-quality output (e.g., implementing a task from an approved slice plan).
+- Multi-file editing or write-back to the repo (`Task` can write; MCP tools are read-only).
+- Decisions where Claude's specific reasoning is the asset (architectural calls, brainstorm partner work).
+
+Routing rules:
+
+| Task | Tool |
+|---|---|
+| Read a large file and answer a focused question | `mcp__claude-review__read_with_question` |
+| Research a question across the codebase | `mcp__claude-review__research_project` |
+| Find code examples by pattern / intent | `mcp__claude-review__find_examples_of` |
+| Audit a PR diff against the spec | `mcp__claude-review__audit_pr` |
+| Trace a feature through git history | `mcp__claude-review__code_archaeology` |
+| Compare two files | `mcp__claude-review__compare_files` |
+| Read a past conversation `.jsonl` | `mcp__claude-review__inspect_transcript` |
+| Implement task N from a slice plan | `Task(subagent_type="general-purpose", ...)` |
+| Two-stage review during SDD | `Task` (per `superpowers:subagent-driven-development`) |
+| Brainstorm an architectural decision | direct Claude in plan mode (no subagent) |
+
+If unsure: **try MCP first**. If the MCP tool returns shallow or wrong results, escalate to `Task`. **NEVER** default to `Task` for read-only work — you spend the maintainer's primary budget on something the free tier can do.
+
+### MCP drift-detection toolkit
+
+Three of the MCP tools above carry fixed roles in the audit ritual:
+
+- `mcp__claude-review__audit_pr` — adversarial diff review against the locked spec. **Post-merge.**
+- `mcp__claude-review__research_project` — codebase-wide question against north-star + design. **Lightweight audits + ad-hoc drift checks.**
+- `mcp__claude-review__inspect_transcript` — extracts human/assistant words from `.jsonl`, stripped of tool noise. **Post-merge** to verify shipped state matches user-stated intent (not just spec).
+
+When Copilot reviewer is rate-limited (or absent), the trio above replaces the second-opinion gate per the PR merge rule.
+
+## Trajectory and anchors
+
+The path to v0.1 is **not** a fixed cascade. Slices are plot points that get added, reordered, or split as alignment audits surface drift. Two **anchors** are non-negotiable for v0.1:
+
+- **Anchor A — Mac shell + ASR sidecar.** First time the product is usable in app form. SwiftUI app under `apps/Panops/`, sidecars `apps/panops-asr-mac/` and `apps/panops-llm-mac/`.
+- **Anchor B — Live capture.** ScreenCaptureKit + audio + screenshot sampling. Risk-last surface.
+
+Everything else is composable trajectory toward v0.1, decided slice-by-slice. **NEVER** treat the trajectory list below as commitment — it's current best understanding, amendable at every audit.
+
+### Shipped (history)
 
 1. Skeleton — Cargo workspace, fixtures (audio, video, screenshots).
-2. Headless CLI — `AsrProvider` trait + `whisper-rs` adapter, JSON segments to stdout.
+2. Headless CLI — `AsrProvider` + whisper-rs adapter, JSON segments to stdout.
 3. Post-pass + diarization — pyannote via sherpa-rs adapter, speaker labels merged.
-4. Notes generation — `LlmProvider` port + `NotesGenerator` pipeline + `MarkdownExporter`.
-5. IPC — JSON-RPC + WebSocket over Unix socket, exercised by Rust test client.
-6. SwiftUI shell + ASR sidecar — WhisperKit + FluidAudio sidecar.
-7. Live ScreenCaptureKit capture — risk-last, real audio + screen + screenshots.
+4. Notes generation — `LlmProvider` + `NotesGenerator` + `MarkdownExporter`.
+5. IPC — JSON-RPC + WebSocket over UDS, Rust test client.
 
-Slices 1–3 shipped. Active slice: see project board milestones (`slice-04-notes-generation` etc.).
+### Current trajectory toward v0.1 (amendable)
+
+- **#74 fix** — real adapters in `panops-engine serve` (eager-after-bind or lazy ctor). Blocks Anchor A.
+- **#17 SQLite persistence** — `Storage` port + per-meeting + cross-meeting registry. Blocks Anchor A AND v0.1 acceptance #4.
+- **Real-meeting calibration** — #14 ASR threshold, #18 model fallback, #19 diar coverage. Run on a real bilingual meeting. Blocks v0.1 acceptance #5.
+- **Anchor A — Mac shell + ASR sidecar.**
+- **Anchor B — Live capture.**
+- **Real-meeting smoke** — end-to-end real bilingual meeting. Inevitably surfaces issues. Don't pre-empt.
+- **Package + sign + notarize** — `scripts/package.sh`, code signing, notarization. v0.1 acceptance #6.
+- **v0.1 release** — tag, release notes, public README polish.
+
+The fixed 7-slice cascade in `docs/superpowers/specs/2026-04-30-panops-design.md` is **historical**. This section is the live trajectory; the design spec is locked architecture, not a project plan.
+
+Active slice: see project board milestones.
 
 ## Session rituals
 
 ### Pickup ritual (run at the START of every session)
 
-1. Run `git status` and `git log -10 --oneline`.
-2. Open the project board. Find the active slice milestone (issues with `Status: In Progress`, or the slice the latest session log is working on).
-3. Read the most recent file in `docs/superpowers/sessions/` for context.
-4. Read the active plan in `docs/superpowers/plans/` (latest file not in `done/`).
-5. Identify next action: top-severity open issue in the active milestone with `Status: Todo` and no blocker, OR next unchecked step in the active plan.
-6. State explicitly: `"Slice 0N is X/Y done. Last session: <slug>. Next: <issue #N or step>. Blockers: <list or 'none'>."`
-7. **MUST** wait for the maintainer's "go" before resuming code changes.
+1. Read `docs/north-star.md`. Confirm the active slice serves it.
+2. Run `git status` and `git log -10 --oneline`.
+3. Open the project board. Find the active slice milestone.
+4. Read the most recent file in `docs/superpowers/sessions/` for context.
+5. Read the active plan in `docs/superpowers/plans/` (latest file not in `done/`).
+6. Read the most recent alignment audit in `docs/superpowers/reviews/`. Note any open drift items.
+7. **If the session log is >24h old OR a `/compact` happened recently OR ANY of the lightweight-audit triggers fired**: run a lightweight alignment audit (Methodology → Alignment-audit ritual → Lightweight) before proceeding.
+8. Identify next action: top-severity open issue in the active milestone with `Status: Todo` and no blocker, OR next unchecked step in the active plan.
+9. State explicitly: `"Slice 0N is X/Y done. Last session: <slug>. Next: <issue #N or step>. Drift items open: <count or 'none'>. Blockers: <list or 'none'>."`
+10. **MUST** wait for the maintainer's "go" before resuming code changes.
 
 ### Handoff ritual (run when STOPPING for the session)
 
@@ -87,8 +206,11 @@ Slices 1–3 shipped. Active slice: see project board milestones (`slice-04-note
 
 1. Move `docs/superpowers/plans/<slice>.md` into `docs/superpowers/plans/done/`.
 2. Close the slice's milestone on the project board (`gh api -X PATCH repos/vfmatzkin/panops/milestones/<n> -f state=closed`).
-3. Brainstorm the next slice via the `superpowers:brainstorming` skill, then `superpowers:writing-plans`. **NEVER** queue multiple slice plans ahead.
-4. Open a slice tracking issue for the new milestone (label `type:feature`, milestone = new slice's). Body links to spec + plan + key tasks.
+3. **Run the slice-boundary alignment audit** (Methodology → Alignment-audit ritual → Slice-boundary). Write findings to `docs/superpowers/reviews/`. This is **non-skippable**.
+4. **Re-read `docs/north-star.md`.** If shipped state diverged from it, amend or file blocking debt before queueing the next slice.
+5. **Re-read the trajectory list.** Add / remove / reorder slices based on what the audit surfaced. The trajectory is amendable; this is when to amend it.
+6. Brainstorm the next trajectory item via the `superpowers:brainstorming` skill, then `superpowers:writing-plans`. **NEVER** queue multiple slice plans ahead.
+7. Open a slice tracking issue for the new milestone (label `type:feature`).
 
 ### PR merge rule (MUST follow)
 
@@ -125,19 +247,23 @@ Issue templates live at `.github/ISSUE_TEMPLATE/`.
 
 ## Don'ts (NEVER do these)
 
-- **NEVER** propose live-capture work or native API bindings before slice 6/7.
+- **NEVER** propose work outside the active anchor's surface area without a brainstorm. (Live capture before Anchor B is reached, native API bindings before Anchor A, etc.)
+- **NEVER** treat the trajectory list as a fixed cascade. Slices iterate; reorder/add/split as alignment audits surface drift.
 - **NEVER** add features beyond the active slice's plan.
 - **NEVER** pre-trait. One trait when needed, one real impl, one fake.
-- **NEVER** auto-commit or push. The maintainer commits when they want.
+- **NEVER** open or merge a PR autonomously. The maintainer opens PRs and merges them. (Commits within an approved slice plan are part of L3 work and don't need per-commit approval — they're bounded by the plan's checklist.)
+- **NEVER** skip a scheduled alignment audit (lightweight, slice-boundary, or maintainer-triggered). Drift detection is non-optional.
 - **NEVER** give time estimates (no "ships in weeks", "X-day project", schedule framing). Compare options on capability/risk/cleanliness.
 - **NEVER** phone home. Zero telemetry, ever, even opt-in.
-- **NEVER** delete or rewrite files in `docs/superpowers/{specs,plans,sessions}/` or `docs/research/` without explicit instruction. They're history.
+- **NEVER** delete or rewrite files in `docs/superpowers/{specs,plans,sessions,reviews}/` or `docs/research/` without explicit instruction. They're history.
 - **NEVER** leave a "deferred" item only in markdown — file it as an issue (see Debt rule).
 - **NEVER** mark an issue as "wontfix" via label. Close as "not planned" with a comment instead.
 
 ## When in doubt
 
-Re-read the design spec. Architecture is locked. Slice plans iterate; the design doesn't.
+Priority: **`docs/north-star.md` > active slice spec > design spec > slice plan**. North star is the goal; design and specs are translations; plans iterate. If they disagree, escalate before deciding.
+
+If still unclear after reading the priority chain, run a lightweight alignment audit (Methodology) to surface what's drifted.
 
 ## Local additions
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,6 +2,8 @@
 ANE = "ANE"     # Apple Neural Engine
 
 [files]
+# Private workflow ephemera (gitignored), often containing verbatim
+# user quotes from chat transcripts. Don't second-guess the quotes.
 extend-exclude = [
     "docs/superpowers/reviews/",
     "docs/superpowers/conversations/",

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -162,10 +162,39 @@ impl IpcServer for IpcImpl {
 /// domain errors (`AsrError`, `DiarError`, `LlmError`, `NotesError`,
 /// `ExportError`) map to `IpcError` via the `domain-conversions`
 /// feature on `panops-protocol`.
-fn run_notes_pipeline(
+///
+/// Readiness gate (eager-after-bind, closes #74): heavy adapters live
+/// in `services.heavy` (see `EngineServices::pending`). Until the
+/// background init task fills that lock, this function returns
+/// `IpcError::ProviderUnavailable` so clients get an explicit "warming
+/// up" signal instead of a 20-second silent stall. Tests build via
+/// `EngineServices::ready` which pre-fills the lock, so the gate is a
+/// no-op for them.
+pub(super) fn run_notes_pipeline(
     services: &crate::server::EngineServices,
     params: &NotesGenerateParams,
 ) -> Result<NotesGenerateResult, IpcError> {
+    // Warmup gate first. The CLI `serve` path uses
+    // `EngineServices::pending(llm)` and fills `heavy` from a
+    // `spawn_blocking` task that runs concurrent with the accept
+    // loop — until it sets the lock, return `ProviderUnavailable` so
+    // the client can retry. Test paths use `EngineServices::ready`
+    // which pre-fills with `Ok(...)`, skipping the wait entirely.
+    let heavy = match services.heavy.get() {
+        Some(Ok(h)) => h,
+        Some(Err(msg)) => {
+            tracing::error!(error = %msg, "heavy adapter init reported failure");
+            return Err(IpcError::Internal {
+                message: format!("adapter init failed: {msg}"),
+            });
+        }
+        None => {
+            return Err(IpcError::ProviderUnavailable {
+                message: "engine warming up; retry shortly".into(),
+            });
+        }
+    };
+
     // Reject empty audio strings outright — `PathBuf::from("")` is
     // technically valid but canonicalize-on-empty depends on platform
     // and gives unhelpful errors. Empty/blank input is a validation
@@ -204,14 +233,14 @@ fn run_notes_pipeline(
         }
     })?;
 
-    let mut transcript = services
+    let mut transcript = heavy
         .asr
         .transcribe_full(&audio_path, params.language.as_deref())
         .map_err(IpcError::from)?;
 
     let no_diarize = params.no_diarize.unwrap_or(false);
     if !no_diarize {
-        let turns = services.diar.diarize(&audio_path).map_err(IpcError::from)?;
+        let turns = heavy.diar.diarize(&audio_path).map_err(IpcError::from)?;
         transcript.segments = merge_speaker_turns(transcript.segments, &turns);
         transcript.diarized = true;
     }
@@ -238,6 +267,7 @@ fn run_notes_pipeline(
         dialect,
     };
     let notes = generator.generate(input).map_err(IpcError::from)?;
+    let exporter = heavy.exporter.clone();
 
     // Output dir convention matches CLI `run_notes`: `<audio_stem>-notes`
     // alongside the audio file. Falls back to `./notes` if the parent
@@ -267,7 +297,7 @@ fn run_notes_pipeline(
         })?;
     }
 
-    let artifact = services.exporter.export(&notes, &out_dir).map_err(|e| {
+    let artifact = exporter.export(&notes, &out_dir).map_err(|e| {
         // Domain-to-wire mapping lives in `panops-protocol` (gated by
         // `domain-conversions`); we still log the full error here so
         // the operator sees template / FS detail that the wire-side
@@ -299,4 +329,71 @@ fn run_notes_pipeline(
 pub(super) fn ipc_error_to_obj(e: IpcError) -> ErrorObjectOwned {
     let data = serde_json::to_value(&e).expect("IpcError serialise");
     ErrorObjectOwned::owned(-32000, e.to_string(), Some(data))
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    //! Tests for the warmup gate added by #74 (eager-after-bind).
+    //!
+    //! These exercise `run_notes_pipeline` directly because the gate
+    //! is a synchronous early-return — no need to spin up the full
+    //! jsonrpsee server. Integration tests use `EngineServices::ready`
+    //! which pre-fills the `OnceLock`, so they don't see this path.
+
+    use super::*;
+    use panops_core::conformance::fakes::MockLlm;
+    use panops_core::llm::LlmProvider;
+
+    fn dummy_params() -> NotesGenerateParams {
+        NotesGenerateParams {
+            audio: "/tmp/whatever.wav".into(),
+            dialect: None,
+            llm_provider: None,
+            llm_model: None,
+            no_diarize: None,
+            language: None,
+        }
+    }
+
+    #[test]
+    fn pending_services_yield_provider_unavailable_during_warmup() {
+        let llm: Arc<dyn LlmProvider + Send + Sync> = Arc::new(MockLlm::default());
+        let (services, _heavy_lock) = crate::server::EngineServices::pending(llm);
+        let err = run_notes_pipeline(&services, &dummy_params()).expect_err("warmup must error");
+        match err {
+            IpcError::ProviderUnavailable { message } => {
+                assert!(
+                    message.contains("warming up"),
+                    "expected warming-up message, got: {message}"
+                );
+            }
+            other => panic!("expected ProviderUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_services_yield_internal_when_init_failed() {
+        let llm: Arc<dyn LlmProvider + Send + Sync> = Arc::new(MockLlm::default());
+        let (services, heavy_lock) = crate::server::EngineServices::pending(llm);
+        // Simulate init failure (e.g., model download blew up).
+        heavy_lock
+            .set(Err("simulated whisper init failure".to_string()))
+            .map_err(|_| ())
+            .expect("set OnceLock");
+        let err =
+            run_notes_pipeline(&services, &dummy_params()).expect_err("init failure must surface");
+        match err {
+            IpcError::Internal { message } => {
+                assert!(
+                    message.contains("adapter init failed"),
+                    "expected init-failed prefix, got: {message}"
+                );
+                assert!(
+                    message.contains("simulated whisper init failure"),
+                    "expected wrapped error, got: {message}"
+                );
+            }
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
 }

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -196,13 +196,32 @@ fn build_llm(handle: tokio::runtime::Handle) -> Arc<dyn LlmProvider + Send + Syn
 /// of an indefinite "warming up" hang.
 fn spawn_heavy_init(heavy_lock: Arc<OnceLock<Result<HeavyAdapters, String>>>) {
     tokio::task::spawn_blocking(move || {
-        let result = init_heavy_adapters();
+        // Catch panics so the OnceLock always reaches a terminal state.
+        // Without this, a panic in a model-loader (e.g. unwrap inside
+        // WhisperRsAsr::new) would leave the slot None forever, and
+        // notes.generate would loop returning ProviderUnavailable
+        // ("warming up; retry shortly") indefinitely.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(init_heavy_adapters))
+            .unwrap_or_else(|payload| {
+                let msg = panic_message(&payload);
+                Err(format!("heavy adapter init panicked: {msg}"))
+            });
         match &result {
             Ok(_) => tracing::info!("heavy adapters ready"),
             Err(msg) => tracing::error!(error = %msg, "heavy adapter init failed"),
         }
         let _ = heavy_lock.set(result);
     });
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else {
+        "unknown panic payload".to_string()
+    }
 }
 
 /// Construct the real heavy adapter trio. Mirrors `panops-engine`'s
@@ -434,4 +453,32 @@ fn install_signal_handler(shutdown: watch::Sender<bool>) -> std::io::Result<()> 
         let _ = shutdown.send(true);
     });
     Ok(())
+}
+
+#[cfg(test)]
+mod panic_message_tests {
+    use super::panic_message;
+    use std::any::Any;
+
+    fn payload<T: Any + Send>(v: T) -> Box<dyn Any + Send> {
+        Box::new(v)
+    }
+
+    #[test]
+    fn extracts_string_payload() {
+        let p = payload("boom".to_string());
+        assert_eq!(panic_message(&p), "boom");
+    }
+
+    #[test]
+    fn extracts_static_str_payload() {
+        let p = payload("static boom");
+        assert_eq!(panic_message(&p), "static boom");
+    }
+
+    #[test]
+    fn falls_back_for_unknown_payload() {
+        let p = payload(42_u64);
+        assert_eq!(panic_message(&p), "unknown panic payload");
+    }
 }

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -1,14 +1,21 @@
 //! IPC server entry point. Owns the tokio runtimes and binds the UDS.
 //!
-//! Wave 4I: per-connection jsonrpsee serve over `tokio::net::UnixListener`.
-//! Two control methods (`notes.generate`, `meeting.list`) and one
+//! Per-connection jsonrpsee serve over `tokio::net::UnixListener`. Two
+//! control methods (`notes.generate`, `meeting.list`) and one
 //! subscription (`events.subscribe`) are registered. `notes.generate`
-//! is a stub until Wave 5K wires the pipeline + broadcast channel.
+//! routes through `spawn_blocking` to the rayon-driven pipeline; the
+//! result emits as a `JobDone` / `JobError` event over WebSocket.
 //!
 //! Runtime topology (see slice 05 spec §"Runtime topology"): two
 //! tokio runtimes — Runtime A drives jsonrpsee accept + dispatch,
-//! Runtime B drives outbound LLM HTTP. Wave 5K's `spawn_blocking`
-//! pipeline calls reach Runtime B via the stored `Handle`.
+//! Runtime B drives outbound LLM HTTP. Heavy adapter init
+//! (`WhisperRsAsr`, `SherpaDiarizer`) takes ~20s and runs in a
+//! `spawn_blocking` task on Runtime A *concurrent with* the accept
+//! loop — see [`EngineServices::pending`] and [`init_heavy_adapters`].
+//! Until init completes, `notes.generate` returns
+//! `IpcError::ProviderUnavailable { message: "engine warming up; retry shortly" }`;
+//! `meeting.list` is unaffected (returns `[]`, no heavy adapters
+//! needed). This is the eager-after-bind shape that closes #74.
 
 mod events;
 mod handlers;
@@ -16,8 +23,8 @@ mod socket;
 
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use futures_util::FutureExt;
 use jsonrpsee::Methods;
@@ -34,17 +41,77 @@ use tokio::sync::watch;
 
 use crate::server::handlers::{IpcImpl, IpcServer};
 
-/// Wiring point for slice-05 server tests AND the production CLI `serve`
-/// path. Tests construct an `EngineServices` with fakes (`MockLlm`,
-/// `TranscriptFileFake`, `KnownTurnsFake`, `FakeNotesExporter`); the CLI
-/// wires adapters via [`temporary_stub_services_issue_74`] — still
-/// fakes today (issue #74 tracks the real-adapter wiring deferred from
-/// Wave 5K).
+/// Heavy adapter trio loaded together — bundled so the `OnceLock` swap
+/// is atomic (one set, all three present) and so `notes.generate`'s
+/// readiness check is one branch instead of three.
+pub(super) struct HeavyAdapters {
+    pub(super) asr: Arc<dyn AsrProvider + Send + Sync>,
+    pub(super) diar: Arc<dyn Diarizer + Send + Sync>,
+    pub(super) exporter: Arc<dyn NotesExporter + Send + Sync>,
+}
+
+/// Wiring point for the IPC server. Two construction paths.
+///
+/// [`EngineServices::ready`] is synchronous: all adapters present at
+/// return. Used by tests (`MockLlm` + `TranscriptFileFake` +
+/// `KnownTurnsFake` + `FakeNotesExporter`) and by any caller that
+/// already has the heavy trio constructed.
+///
+/// [`EngineServices::pending`] is for `serve`, where the heavy adapter
+/// trio (`WhisperRsAsr`, `SherpaDiarizer`, `MarkdownExporter`) loads
+/// multi-hundred-MB Whisper + diarization models and would push past
+/// the integration test's 5s "socket appears" budget. Returns the
+/// `OnceLock` handle so the background init task can fill it
+/// concurrent with the accept loop coming up.
+///
+/// `llm` is exposed directly because `GenaiLlm::with_handle` is
+/// instant (no model download); the heavy trio is hidden behind the
+/// `OnceLock` so the readiness gate is a single `services.heavy.get()`
+/// in `run_notes_pipeline`.
 pub struct EngineServices {
     pub llm: Arc<dyn LlmProvider + Send + Sync>,
-    pub asr: Arc<dyn AsrProvider + Send + Sync>,
-    pub diar: Arc<dyn Diarizer + Send + Sync>,
-    pub exporter: Arc<dyn NotesExporter + Send + Sync>,
+    pub(super) heavy: Arc<OnceLock<Result<HeavyAdapters, String>>>,
+}
+
+impl EngineServices {
+    /// Construct with all adapters present. Pre-fills the `OnceLock` so
+    /// `notes.generate` skips the warmup gate immediately. This is the
+    /// shape every integration test uses.
+    pub fn ready(
+        llm: Arc<dyn LlmProvider + Send + Sync>,
+        asr: Arc<dyn AsrProvider + Send + Sync>,
+        diar: Arc<dyn Diarizer + Send + Sync>,
+        exporter: Arc<dyn NotesExporter + Send + Sync>,
+    ) -> Self {
+        let heavy = Arc::new(OnceLock::new());
+        let _ = heavy.set(Ok(HeavyAdapters {
+            asr,
+            diar,
+            exporter,
+        }));
+        Self { llm, heavy }
+    }
+
+    /// Construct with only the (cheap) LLM adapter. Returns the
+    /// `OnceLock` handle so the caller can spawn a background init
+    /// task that resolves the heavy trio and fills the lock. Until
+    /// the lock is set, `notes.generate` returns
+    /// `IpcError::ProviderUnavailable`.
+    ///
+    /// `pub(crate)` — only `run_serve` (same crate) needs to construct
+    /// the pending shape. Integration tests use [`Self::ready`].
+    /// `HeavyAdapters` stays `pub(super)` so it can't leak out of
+    /// `server::*`.
+    pub(crate) fn pending(
+        llm: Arc<dyn LlmProvider + Send + Sync>,
+    ) -> (Self, Arc<OnceLock<Result<HeavyAdapters, String>>>) {
+        let heavy = Arc::new(OnceLock::new());
+        let services = Self {
+            llm,
+            heavy: heavy.clone(),
+        };
+        (services, heavy)
+    }
 }
 
 /// CLI entry point — owns both tokio runtimes and the signal handler.
@@ -55,7 +122,7 @@ pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
     };
 
     // Runtime B: outbound LLM HTTP. Built first so its handle can be
-    // cloned into the LLM factory before Runtime A starts polling RPC.
+    // cloned into the LLM adapter before Runtime A starts polling RPC.
     let llm_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("panops-llm-http")
@@ -63,7 +130,7 @@ pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
         .map_err(|e| (3, format!("build llm runtime: {e}")))?;
     let llm_handle = llm_rt.handle().clone();
 
-    // Runtime A: jsonrpsee + UDS accept.
+    // Runtime A: jsonrpsee + UDS accept + heavy-adapter init.
     let rpc_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("panops-rpc")
@@ -71,27 +138,104 @@ pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
         .map_err(|e| (3, format!("build rpc runtime: {e}")))?;
 
     let result = rpc_rt.block_on(async move {
-        // Slice 05 Wave 5K: still using a *minimal* `EngineServices` so
-        // the socket binds within the 5s budget that
-        // `ipc_server_starts_and_binds` enforces. Real Whisper-large
-        // load is ~20s and would blow that. The CLI smoke is manual
-        // anyway; the in-process integration tests inject real adapters
-        // directly through `run_serve_in_process`. Tracking real-adapter
-        // wiring (lazy `OnceLock` or eager-after-bind) as issue #74.
-        let services = temporary_stub_services_issue_74(llm_handle);
-        // No external shutdown: `run_serve_in_process` installs its
-        // own signal handler before bind, so the SIGTERM-between-
-        // bind-and-handler window from earlier waves is gone.
+        // Build the LIGHT services first — just the LLM adapter (cheap,
+        // instant). The heavy trio (Whisper / Sherpa / MarkdownExporter)
+        // is filled by a `spawn_blocking` task that runs concurrent
+        // with the accept loop, so the socket binds within the 5s
+        // budget and `notes.generate` is gated with
+        // `ProviderUnavailable` until the trio is ready.
+        let llm = build_llm(llm_handle);
+        let (services, heavy_lock) = EngineServices::pending(llm);
+        spawn_heavy_init(heavy_lock);
         run_serve_in_process(&path, services, None).await
     });
     drop(llm_rt);
-    result
+
+    // Force exit. The heavy-init `spawn_blocking` task may still be
+    // running (Whisper/Sherpa model-load syscalls aren't cancellable);
+    // tokio's blocking pool can't interrupt them, so without
+    // `process::exit` the process stays alive past shutdown until the
+    // load finishes. SIGTERM-to-exit must stay under the integration
+    // test's 5s budget. Buffered tracing lines may be lost; that's
+    // acceptable on shutdown.
+    let exit_code = match result {
+        Ok(()) => 0u8,
+        Err((code, msg)) => {
+            eprintln!("error: {msg}");
+            code
+        }
+    };
+    std::process::exit(i32::from(exit_code));
 }
 
-/// Async test entry point. Tests inject fakes via `services` and
-/// trigger shutdown via the optional `external_shutdown` watch
-/// receiver. When `external_shutdown` is `None` the server installs
-/// its own SIGINT/SIGTERM handler and runs until signalled.
+/// LLM adapter for `serve` mode. Picks a model based on environment
+/// (mirrors `GenaiLlm::auto`'s precedence) and wires it to Runtime B
+/// via `with_handle`. We don't delegate to `GenaiLlm::auto` directly
+/// because `auto` uses the lazy shared CLI runtime — `serve` mode
+/// must route outbound HTTP through Runtime B, not the CLI runtime.
+/// Provider precedence stays in sync with `auto`; both should collapse
+/// when `panops-portable::genai_llm` grows a `auto_with_handle` helper.
+fn build_llm(handle: tokio::runtime::Handle) -> Arc<dyn LlmProvider + Send + Sync> {
+    use panops_portable::genai_llm::GenaiLlm;
+    let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        "claude-haiku-4-5-20251001"
+    } else if std::env::var("OPENAI_API_KEY").is_ok() {
+        "gpt-4o-mini"
+    } else {
+        "gemma3:4b"
+    };
+    Arc::new(GenaiLlm::with_handle(model, handle))
+}
+
+/// Spawn the heavy-adapter init task. Runs on tokio's blocking pool
+/// because `WhisperRsAsr::new` and `SherpaDiarizer::new` perform sync
+/// I/O + model load + graph compile — sync work that mustn't land on
+/// the RPC accept thread. On success the `OnceLock` holds
+/// `Ok(HeavyAdapters)`; on failure it holds `Err(message)` so
+/// `notes.generate` surfaces an explicit `IpcError::Internal` instead
+/// of an indefinite "warming up" hang.
+fn spawn_heavy_init(heavy_lock: Arc<OnceLock<Result<HeavyAdapters, String>>>) {
+    tokio::task::spawn_blocking(move || {
+        let result = init_heavy_adapters();
+        match &result {
+            Ok(_) => tracing::info!("heavy adapters ready"),
+            Err(msg) => tracing::error!(error = %msg, "heavy adapter init failed"),
+        }
+        let _ = heavy_lock.set(result);
+    });
+}
+
+/// Construct the real heavy adapter trio. Mirrors `panops-engine`'s
+/// CLI default-mode + notes-mode wiring (`WhisperRsAsr`,
+/// `SherpaDiarizer`, `MarkdownExporter`). String error type so the
+/// failure can survive being stored in the `OnceLock` and surface as
+/// `IpcError::Internal` to the wire — the operator still sees the
+/// full detail via `tracing::error!` in [`spawn_heavy_init`].
+fn init_heavy_adapters() -> Result<HeavyAdapters, String> {
+    use panops_portable::markdown_exporter::MarkdownExporter;
+    use panops_portable::model::{
+        DEFAULT_MODEL_NAME, default_model_path, ensure_diar_models, ensure_model,
+    };
+    use panops_portable::{SherpaDiarizer, WhisperRsAsr};
+
+    let model_path = default_model_path().map_err(|e| e.to_string())?;
+    let model_path = ensure_model(DEFAULT_MODEL_NAME, &model_path).map_err(|e| e.to_string())?;
+    let asr = WhisperRsAsr::new(model_path).map_err(|e| e.to_string())?;
+    let (seg, emb) = ensure_diar_models().map_err(|e| e.to_string())?;
+    let diar = SherpaDiarizer::new(seg, emb).map_err(|e| e.to_string())?;
+
+    Ok(HeavyAdapters {
+        asr: Arc::new(asr),
+        diar: Arc::new(diar),
+        exporter: Arc::new(MarkdownExporter),
+    })
+}
+
+/// Async test entry point. Tests inject fakes via `services` (built
+/// with [`EngineServices::ready`]) and trigger shutdown via the
+/// optional `external_shutdown` watch receiver. When `external_shutdown`
+/// is `None` the server installs its own SIGINT/SIGTERM handler and
+/// runs until signalled.
 ///
 /// Shutdown is a `tokio::sync::watch::channel(bool)` end-to-end:
 /// `watch` stores its current value, so even a receiver subscribed
@@ -183,7 +327,7 @@ pub async fn run_serve_in_process(
     // the per-request handler responds with HTTP 429 (`too_many_requests`)
     // rather than stalling — keeps a runaway client from exhausting the
     // accept loop. Revisit alongside the DoS bound on `notes.generate`
-    // (file as `severity:high area:ipc` debt).
+    // (filed as issue #85, severity:high).
     let conn_guard = Arc::new(ConnectionGuard::new(100));
 
     let cleanup_path = path.to_path_buf();
@@ -266,50 +410,6 @@ pub async fn run_serve_in_process(
     tracing::info!("removing socket file and exiting run_serve_in_process");
     let _ = std::fs::remove_file(&cleanup_path);
     Ok(())
-}
-
-/// DO NOT SHIP THIS TO USERS. Slice 05 stand-in for `EngineServices`
-/// — `notes.generate` against this build runs on FAKE ASR / diar /
-/// exporter adapters that emit canned data, so users hitting `serve`
-/// would get garbage notes silently.
-///
-/// Why this exists: real `WhisperRsAsr` / `SherpaDiarizer` constructors
-/// load multi-hundred-MB models eagerly, which would push `serve` past
-/// the 5-second "socket appears" budget the integration tests rely on.
-/// Issue #74 tracks the proper follow-up — eager-after-bind path
-/// (background-task adapter init) or per-call lazy factories.
-///
-/// The function name is deliberately verbose so that `git grep` for it
-/// surfaces this scaffold immediately, and so accidentally calling it
-/// from a non-stub code path would scream in review. Slice 06 must
-/// delete this function as part of wiring real sidecars.
-///
-/// LLM wiring deviates from `GenaiLlm::auto` on purpose: `auto` returns
-/// a `Result` and uses the lazy shared CLI runtime, while server mode
-/// must (a) bind outbound HTTP to Runtime B via `with_handle`, and
-/// (b) pick a non-failing default so `serve` always boots even with
-/// no provider configured (the fake ASR/diar pipeline never reaches
-/// the LLM in slice 05's smoke). Provider precedence still mirrors
-/// `auto` — keep them in sync until #74 collapses both paths.
-fn temporary_stub_services_issue_74(llm_handle: tokio::runtime::Handle) -> EngineServices {
-    use panops_core::conformance::fakes::{FakeNotesExporter, KnownTurnsFake, TranscriptFileFake};
-    use panops_portable::genai_llm::GenaiLlm;
-
-    let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-        "claude-haiku-4-5-20251001"
-    } else if std::env::var("OPENAI_API_KEY").is_ok() {
-        "gpt-4o-mini"
-    } else {
-        "gemma3:4b"
-    };
-    let llm = GenaiLlm::with_handle(model, llm_handle);
-
-    EngineServices {
-        llm: Arc::new(llm),
-        asr: Arc::new(TranscriptFileFake),
-        diar: Arc::new(KnownTurnsFake),
-        exporter: Arc::new(FakeNotesExporter),
-    }
 }
 
 /// Register OS-level SIGINT/SIGTERM handlers and spawn the waiter

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -173,15 +173,21 @@ pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
 /// via `with_handle`. We don't delegate to `GenaiLlm::auto` directly
 /// because `auto` uses the lazy shared CLI runtime — `serve` mode
 /// must route outbound HTTP through Runtime B, not the CLI runtime.
-/// Provider precedence stays in sync with `auto`; both should collapse
-/// when `panops-portable::genai_llm` grows a `auto_with_handle` helper.
+/// Provider precedence stays in sync with `GenaiLlm::auto`'s order
+/// (ANTHROPIC_API_KEY → OPENAI_API_KEY → OLLAMA_HOST → default).
+/// Both should collapse when `panops-portable::genai_llm` grows an
+/// `auto_with_handle` helper.
 fn build_llm(handle: tokio::runtime::Handle) -> Arc<dyn LlmProvider + Send + Sync> {
     use panops_portable::genai_llm::GenaiLlm;
     let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
         "claude-haiku-4-5-20251001"
     } else if std::env::var("OPENAI_API_KEY").is_ok() {
         "gpt-4o-mini"
+    } else if std::env::var("OLLAMA_HOST").is_ok() {
+        "gemma3:4b"
     } else {
+        // Last-resort default. Matches `GenaiLlm::auto` so the IPC
+        // server is no more restrictive than the CLI's auto mode.
         "gemma3:4b"
     };
     Arc::new(GenaiLlm::with_handle(model, handle))

--- a/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
+++ b/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
@@ -30,12 +30,12 @@ async fn notes_generate_emits_job_error_with_input_not_found_kind() {
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let services = EngineServices {
-        llm: Arc::new(MockLlm::default()),
-        asr: Arc::new(TranscriptFileFake),
-        diar: Arc::new(KnownTurnsFake),
-        exporter: Arc::new(FakeNotesExporter),
-    };
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
 
     let server_socket = socket.clone();
     let server_shutdown = shutdown_rx.clone();

--- a/crates/panops-engine/tests/ipc_meeting_list_returns_empty.rs
+++ b/crates/panops-engine/tests/ipc_meeting_list_returns_empty.rs
@@ -22,12 +22,12 @@ async fn meeting_list_returns_empty_array() {
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let services = EngineServices {
-        llm: Arc::new(MockLlm::default()),
-        asr: Arc::new(TranscriptFileFake),
-        diar: Arc::new(KnownTurnsFake),
-        exporter: Arc::new(FakeNotesExporter),
-    };
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
 
     let server_socket = socket.clone();
     let server_shutdown = shutdown_rx.clone();

--- a/crates/panops-engine/tests/ipc_method_not_found_carries_jsonrpc_error.rs
+++ b/crates/panops-engine/tests/ipc_method_not_found_carries_jsonrpc_error.rs
@@ -21,12 +21,12 @@ async fn unknown_method_returns_method_not_found() {
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let services = EngineServices {
-        llm: Arc::new(MockLlm::default()),
-        asr: Arc::new(TranscriptFileFake),
-        diar: Arc::new(KnownTurnsFake),
-        exporter: Arc::new(FakeNotesExporter),
-    };
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
 
     let server_socket = socket.clone();
     let server_shutdown = shutdown_rx.clone();

--- a/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
@@ -190,12 +190,12 @@ async fn notes_generate_round_trip_emits_job_done() {
     let audio_path = audio_dir.path().join("multi_speaker_60s.wav");
     std::fs::write(&audio_path, b"placeholder").unwrap();
 
-    let services = EngineServices {
-        llm: Arc::new(build_mock_llm(MarkdownDialect::Basic)),
-        asr: Arc::new(DeterministicAsr),
-        diar: Arc::new(DeterministicDiar),
-        exporter: Arc::new(MarkdownExporter),
-    };
+    let services = EngineServices::ready(
+        Arc::new(build_mock_llm(MarkdownDialect::Basic)),
+        Arc::new(DeterministicAsr),
+        Arc::new(DeterministicDiar),
+        Arc::new(MarkdownExporter),
+    );
 
     let server_socket = socket.clone();
     let server_shutdown = shutdown_rx.clone();

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -1,0 +1,68 @@
+# panops — North Star
+
+**Status**: Append-only. Amended only at major-milestone boundaries (v0.1 → v0.2, etc.) with explicit maintainer decision. Never edited mid-slice.
+
+## What panops is
+
+> Open-source local-first macOS recorder with screenshot-anchored, multilingual meeting notes. Native Mac UI + portable backend. Zero telemetry. MIT licensed. Hex/screaming arch. SOLID/DRY.
+
+That sentence is a compressed restatement of the maintainer's genesis charter (verbatim source: `docs/superpowers/conversations/2026-04-30-f0690f89.md:53`). It is the highest-priority source of truth in the repo, above any spec, plan, or AGENTS.md rule.
+
+## Why it exists
+
+- **For the maintainer first.** A tool he'll actually use for his own bilingual (EN/ES) meetings, on his own Mac. Dogfooding is the validation.
+- **For other devs second.** A reference for hex-arch Rust + Mac-native sidecars + portable adapters. The CLI is a dev/CI surface, not the product.
+- **Open-source.** No monetisation, no telemetry, no phoning home. MIT.
+
+## v0.1 acceptance criteria
+
+v0.1 is **not** "all 7 slices shipped." It's **a Mac app the maintainer would actually use for his next meeting.** Six observable criteria:
+
+1. ☐ Open the Mac app, hit "record", run a real bilingual meeting → audio + screenshots captured.
+2. ☐ Stop recording → diarized transcript appears in the app.
+3. ☐ "Generate notes" → markdown file with frontmatter, sections with screenshots, action items, no narrative/key-points duplication.
+4. ☐ Notes file persists across app restarts (SQLite + on-disk markdown).
+5. ☐ Output passes the maintainer's *"would I actually use this for my next meeting?"* test on a real bilingual meeting.
+6. ☐ Build + sign + notarize the `.app`; runs on a clean Mac with no dev tools installed.
+
+Criterion #5 is the only one not mechanically verifiable — it's the gate that prevents shipping technically-passing-but-actually-bad notes. The maintainer runs a real meeting, reads the output, and decides.
+
+## What v0.1 is NOT
+
+- Not multi-user.
+- Not cloud-synced.
+- Not Notion/Slack/Obsidian export (filed as debt; future).
+- Not Linux or Windows.
+- Not iOS / iPad.
+- Not real-time streaming UI (live transcript shows during recording is fine; live partials are bonus, not required).
+- Not a Notion-style enhanced-markdown viewer (the markdown gets WRITTEN as `NotionEnhanced` dialect by default; opening it elsewhere is the user's problem).
+
+## Anchors (non-negotiable for v0.1)
+
+Two architectural surfaces that must exist for v0.1 to be v0.1:
+
+- **Anchor A — Mac shell + ASR sidecar.** SwiftUI app + WhisperKit / FluidAudio sidecars. Without this, panops is a CLI for devs, not a product.
+- **Anchor B — Live capture.** ScreenCaptureKit + audio + screenshot sampling. Without this, criteria #1-2 are unmet.
+
+Anchors block v0.1. Trajectory slices toward them are amendable (see `AGENTS.md` → Trajectory and anchors).
+
+## Constraints inherited from the genesis charter
+
+These are absolute. They apply to every slice. Any drift away from them is a north-star violation.
+
+- **Multilingual day 1**, with a per-meeting language toggle. Bilingual EN/ES is the canonical test.
+- **Native Mac UI** (SwiftUI) + **portable backend** (Rust hex). Not Tauri, not Electron.
+- **Zero telemetry** ever, even opt-in.
+- **Hex / screaming architecture.** `panops-core` has no platform deps; `panops-mac` is `#[cfg(target_os="macos")]`; `panops-portable` holds the Rust adapters; `panops-protocol` holds wire types.
+- **SOLID / DRY.** Visible in port/adapter discipline, fixture-as-adapter, conformance harness per port.
+- **One trait at a time + one real + one fake.** Never pre-trait.
+- **MIT** licensed. No co-author attribution on commits.
+- **No env vars for user config.** Auto-detect via macOS; env vars are last-resort dev/CI escape hatches and must be flagged in the spec.
+
+## How this doc gets amended
+
+- **At v0.1 ship**: rewrite the v0.1 acceptance section as v0.1-shipped (timestamped) and add a v0.2 acceptance section.
+- **If a slice surfaces a constraint that conflicts with a north-star item**: that's a *blocking* alignment-audit finding. Amendment requires a maintainer decision recorded in this file with a date stamp. Mid-slice silent amendments are forbidden.
+- **If trajectory shifts** (a slice gets added/removed/reordered): amend `AGENTS.md` → Trajectory and anchors, NOT this file. Trajectory is amendable; the goal isn't.
+
+Last amended: 2026-05-02 (initial).


### PR DESCRIPTION
## Summary

Replaces the `stub_services()` placeholder in `panops-engine serve` (introduced as a slice-05 deferred-debt item) with the real adapter set: `WhisperRsAsr`, `SherpaOnnxDiarizer`, and `MarkdownExporter`. Audio→notes now actually works end-to-end from the shell, not just from in-process tests.

## How

**Eager-after-bind.** Bind the UDS first (cheap, milliseconds), then spawn heavy adapter init on a blocking thread. Stored in `Arc<OnceLock<Result<HeavyAdapters, String>>>` for atomic publish.

- `EngineServices::ready(...)` — synchronous constructor for tests (pre-fills the OnceLock)
- `EngineServices::pending(llm)` — server-side constructor; returns the slot to fill
- `notes.generate` handler gates on `services.heavy.get()`:
  - `Some(Ok)` → run pipeline
  - `Some(Err)` → `IpcError::Internal { ... }`
  - `None` → `IpcError::ProviderUnavailable { message: "engine warming up; retry shortly" }`
- `run_serve` calls `std::process::exit` after shutdown so SIGTERM cleanup beats blocking init that can't be cancelled.

Also includes the framework/methodology doc updates (north-star, AGENTS.md trajectory + tool-routing rules) that landed alongside this work.

## Test plan

- [x] `cargo test --workspace --locked` — 100+ tests pass
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] 4 IPC integration tests updated from `EngineServices { ... }` literal to `EngineServices::ready(...)`
- [x] 2 new readiness tests in `handlers.rs` cover the warmup gate (`None` → ProviderUnavailable, `Some(Err)` → Internal)
- [ ] Manual smoke: `panops-engine serve &; ipc-call ipc.notes.generate {audio:...}` returns notes (not stubs)

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)