### PR TITLE
cancel in-flight claude-code-review on new push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,11 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Cancel any in-flight review for this PR when a new push lands.
+concurrency:
+  group: claude-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip forked PRs: repository secrets are not exposed to fork workflows,


### PR DESCRIPTION
Adds `concurrency: cancel-in-progress: true` to `claude-code-review.yml` so a new push to a PR cancels any earlier review still running for the same PR. Same pattern `ci.yml` already uses.

Skipped `claude.yml` deliberately — it fires on `@claude` mentions, which are intentional user requests; cancelling earlier ones on new ones would silently drop work the user asked for.

Skipped `dependabot-auto-merge.yml` — only fires on dependabot PRs, low-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)