### PR TITLE
ratify OnceLock terminal-state and domain-error no-Serialize rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Mac app build commands land in slice 06.
 - **MUST** write a conformance fn per port. Every adapter passes the same harness.
 - **MUST** keep one slice = one PR = the maintainer's review gate. **NEVER** start slice N+1 until slice N's PR is merged.
 - **MUST** scope plans per-slice. **NEVER** write whole-project step lists.
+- **MUST** drive `OnceLock` / `OnceCell` (or any once-init slot a handler can observe) to a terminal state on every path — success, error, or panic. Wrap initializing closures in `std::panic::catch_unwind` and convert panic payloads to `Err` so the slot never stays permanently `None`. Precedent: commit `02559a3` (heavy-init panic recovery).
+- **MUST NOT** derive `serde::Serialize` on domain error types (`AsrError`, `DiarError`, `LlmError`, `NotesError`, …). IPC transport types in `crates/panops-protocol` convert from them at the boundary so domain errors stay platform-agnostic and free to evolve.
 
 ## Methodology — solo dev with agents
 


### PR DESCRIPTION
## Summary

Folds the two conventions codified in `.github/copilot-instructions.md` (PR #94) into `AGENTS.md` so the bot isn't enforcing un-ratified rules.

- **`OnceLock` / `OnceCell` terminal-state** — must reach success / error / panic on every path; init closures wrap in `std::panic::catch_unwind` so the slot never stays permanently `None`. Precedent: commit `02559a3`.
- **Domain errors don't derive `serde::Serialize`** — `AsrError`, `DiarError`, `LlmError`, `NotesError`, etc. stay platform-agnostic; `crates/panops-protocol` converts at the IPC boundary.

Both rules live under "Execution discipline (MUST follow)" so they sit alongside the existing port + slice + plan rules.

## Test plan

- [ ] Confirm wording matches the corresponding bullets in `.github/copilot-instructions.md`.
- [ ] No code change; CI just runs lint/format/typos.