### PR TITLE
slice 06: SQLite storage + meeting lifecycle (#17 + #75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +660,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +930,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -918,6 +951,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1548,6 +1590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1773,7 @@ dependencies = [
  "panops-core",
  "panops-portable",
  "panops-protocol",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1740,6 +1794,7 @@ dependencies = [
  "hound",
  "panops-core",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde_json",
  "sha2",
  "sherpa-rs",
@@ -2226,6 +2281,20 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -3183,6 +3252,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -180,3 +180,183 @@ impl crate::exporter::NotesExporter for FakeNotesExporter {
         })
     }
 }
+
+// === InMemoryStorage ============================================
+
+use chrono::Utc;
+
+use crate::storage::{
+    Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError,
+};
+
+/// In-process `Storage` fake. Used by `panops-core`'s own tests and
+/// by `panops-engine`'s IPC integration tests where opening a real
+/// SQLite DB on every run would be unnecessary friction.
+pub struct InMemoryStorage {
+    inner: Mutex<InMemoryInner>,
+}
+
+struct InMemoryInner {
+    meetings: HashMap<String, Meeting>,
+    notes: HashMap<String, Note>,
+}
+
+impl Default for InMemoryStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(InMemoryInner {
+                meetings: HashMap::new(),
+                notes: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl Storage for InMemoryStorage {
+    fn create_meeting(&self, d: MeetingDraft) -> Result<Meeting, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.meetings.contains_key(&d.id) {
+            return Err(StorageError::AlreadyExists {
+                id: d.id,
+                kind: "meeting",
+            });
+        }
+        let m = Meeting {
+            id: d.id.clone(),
+            title: d.title,
+            started_at: d.started_at,
+            ended_at: None,
+            duration_ms: None,
+            language: d.language,
+            dir_path: d.dir_path,
+        };
+        inner.meetings.insert(d.id, m.clone());
+        Ok(m)
+    }
+
+    fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .meetings
+            .get(id)
+            .cloned()
+            .ok_or_else(|| StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            })
+    }
+
+    fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        let mut rows: Vec<MeetingSummary> = inner
+            .meetings
+            .values()
+            .map(|m| MeetingSummary {
+                id: m.id.clone(),
+                title: m.title.clone(),
+                started_at: m.started_at.clone(),
+                duration_ms: m.duration_ms.unwrap_or(0),
+            })
+            .collect();
+        rows.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(rows)
+    }
+
+    fn update_meeting_ended(
+        &self,
+        id: &str,
+        ended_at: &str,
+        duration_ms: u64,
+    ) -> Result<Meeting, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        let m = inner
+            .meetings
+            .get_mut(id)
+            .ok_or_else(|| StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            })?;
+        m.ended_at = Some(ended_at.into());
+        m.duration_ms = Some(duration_ms);
+        Ok(m.clone())
+    }
+
+    fn update_meeting_language(&self, id: &str, language: &str) -> Result<Meeting, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        let m = inner
+            .meetings
+            .get_mut(id)
+            .ok_or_else(|| StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            })?;
+        m.language = language.into();
+        Ok(m.clone())
+    }
+
+    fn delete_meeting(&self, id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.meetings.remove(id).is_none() {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            });
+        }
+        // FK cascade simulation.
+        inner.notes.retain(|_, n| n.meeting_id != id);
+        Ok(())
+    }
+
+    fn create_note(&self, d: NoteDraft) -> Result<Note, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if !inner.meetings.contains_key(&d.meeting_id) {
+            return Err(StorageError::NotFound {
+                id: d.meeting_id,
+                kind: "meeting",
+            });
+        }
+        if inner.notes.contains_key(&d.id) {
+            return Err(StorageError::AlreadyExists {
+                id: d.id,
+                kind: "note",
+            });
+        }
+        let n = Note {
+            id: d.id.clone(),
+            meeting_id: d.meeting_id,
+            dialect: d.dialect,
+            content_md: d.content_md,
+            primary_path: d.primary_path,
+            created_at: Utc::now().to_rfc3339(),
+        };
+        inner.notes.insert(d.id, n.clone());
+        Ok(n)
+    }
+
+    fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        Ok(inner
+            .notes
+            .values()
+            .filter(|n| n.meeting_id == meeting_id)
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod storage_fake_tests {
+    use super::InMemoryStorage;
+    use crate::conformance::storage::run_suite;
+
+    #[test]
+    fn in_memory_storage_passes_conformance() {
+        run_suite(&InMemoryStorage::new());
+    }
+}

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -227,6 +227,17 @@ impl Storage for InMemoryStorage {
                 kind: "meeting",
             });
         }
+        // Mirror the schema's `dir_path TEXT NOT NULL UNIQUE` so the
+        // fake and real adapter behave identically. Without this,
+        // tests that pass against the fake could break against the
+        // real adapter on a dir_path collision.
+        if inner.meetings.values().any(|m| m.dir_path == d.dir_path) {
+            return Err(StorageError::UniqueConflict {
+                kind: "meeting",
+                field: "dir_path",
+                value: d.dir_path,
+            });
+        }
         let m = Meeting {
             id: d.id.clone(),
             title: d.title,
@@ -238,6 +249,70 @@ impl Storage for InMemoryStorage {
         };
         inner.meetings.insert(d.id, m.clone());
         Ok(m)
+    }
+
+    fn create_meeting_with_note(
+        &self,
+        meeting: MeetingDraft,
+        note: NoteDraft,
+        ended_at: Option<&str>,
+        duration_ms: Option<u64>,
+    ) -> Result<(Meeting, Note), StorageError> {
+        // Validate everything up front under a single lock so partial
+        // commits aren't visible. Real adapter (RusqliteStorage) does
+        // this with `BEGIN`/`COMMIT`; we fake atomicity here by holding
+        // the lock for the whole sequence and only mutating after all
+        // checks pass.
+        let mut inner = self.inner.lock().unwrap();
+        if inner.meetings.contains_key(&meeting.id) {
+            return Err(StorageError::AlreadyExists {
+                id: meeting.id,
+                kind: "meeting",
+            });
+        }
+        if inner
+            .meetings
+            .values()
+            .any(|m| m.dir_path == meeting.dir_path)
+        {
+            return Err(StorageError::UniqueConflict {
+                kind: "meeting",
+                field: "dir_path",
+                value: meeting.dir_path,
+            });
+        }
+        if note.meeting_id != meeting.id {
+            return Err(StorageError::Sql {
+                message: "create_meeting_with_note: note.meeting_id must match meeting.id".into(),
+            });
+        }
+        if inner.notes.contains_key(&note.id) {
+            return Err(StorageError::AlreadyExists {
+                id: note.id,
+                kind: "note",
+            });
+        }
+        // All checks passed — commit both rows.
+        let m = Meeting {
+            id: meeting.id.clone(),
+            title: meeting.title,
+            started_at: meeting.started_at,
+            ended_at: ended_at.map(str::to_owned),
+            duration_ms,
+            language: meeting.language,
+            dir_path: meeting.dir_path,
+        };
+        let n = Note {
+            id: note.id.clone(),
+            meeting_id: note.meeting_id,
+            dialect: note.dialect,
+            content_md: note.content_md,
+            primary_path: note.primary_path,
+            created_at: Utc::now().to_rfc3339(),
+        };
+        inner.meetings.insert(meeting.id, m.clone());
+        inner.notes.insert(note.id, n.clone());
+        Ok((m, n))
     }
 
     fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError> {

--- a/crates/panops-core/src/conformance/mod.rs
+++ b/crates/panops-core/src/conformance/mod.rs
@@ -8,3 +8,4 @@ pub mod diar;
 pub mod exporter;
 pub mod fakes;
 pub mod llm;
+pub mod storage;

--- a/crates/panops-core/src/conformance/storage.rs
+++ b/crates/panops-core/src/conformance/storage.rs
@@ -20,12 +20,15 @@ use crate::storage::{MeetingDraft, NoteDraft, Storage, StorageError};
 pub fn run_suite<S: Storage>(adapter: &S) {
     create_get_round_trip(adapter);
     create_duplicate_id_is_already_exists(adapter);
+    create_duplicate_dir_path_is_unique_conflict(adapter);
     get_unknown_id_is_not_found(adapter);
     list_returns_started_at_desc(adapter);
     update_meeting_ended_writes_duration(adapter);
     update_meeting_language_persists(adapter);
     delete_meeting_cascades_to_notes(adapter);
     create_and_list_notes_for_meeting(adapter);
+    create_meeting_with_note_atomic_happy_path(adapter);
+    create_meeting_with_note_rolls_back_on_note_collision(adapter);
 }
 
 fn create_get_round_trip<S: Storage>(adapter: &S) {
@@ -45,12 +48,26 @@ fn create_get_round_trip<S: Storage>(adapter: &S) {
 }
 
 fn create_duplicate_id_is_already_exists<S: Storage>(adapter: &S) {
+    // Same id, DIFFERENT dir_path — isolates the PK collision from
+    // the dir_path UNIQUE collision (which is its own test).
     let id = "m_dup";
     let _ = adapter
-        .create_meeting(draft(id, "Dup", "2026-05-05T10:00:00+00:00"))
+        .create_meeting(MeetingDraft {
+            id: id.into(),
+            title: "Dup".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "auto".into(),
+            dir_path: "/tmp/m_dup_first".into(),
+        })
         .expect("first create should succeed");
     let err = adapter
-        .create_meeting(draft(id, "Dup again", "2026-05-05T10:00:00+00:00"))
+        .create_meeting(MeetingDraft {
+            id: id.into(),
+            title: "Dup again".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "auto".into(),
+            dir_path: "/tmp/m_dup_second".into(),
+        })
         .expect_err("second create should fail");
     match err {
         StorageError::AlreadyExists { id: got, kind } => {
@@ -58,6 +75,41 @@ fn create_duplicate_id_is_already_exists<S: Storage>(adapter: &S) {
             assert_eq!(kind, "meeting");
         }
         other => panic!("expected AlreadyExists, got {other:?}"),
+    }
+}
+
+fn create_duplicate_dir_path_is_unique_conflict<S: Storage>(adapter: &S) {
+    // Two distinct meeting ids that share a `dir_path` must collide
+    // on the schema's UNIQUE constraint and surface as
+    // `UniqueConflict { field: "dir_path", value }`, NOT as
+    // `AlreadyExists` (which would misattribute the conflict to the
+    // newly-minted id).
+    let dir = "/tmp/share_this_dir_dup";
+    let _ = adapter
+        .create_meeting(MeetingDraft {
+            id: "m_dir_a".into(),
+            title: "A".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "auto".into(),
+            dir_path: dir.into(),
+        })
+        .expect("first create should succeed");
+    let err = adapter
+        .create_meeting(MeetingDraft {
+            id: "m_dir_b".into(),
+            title: "B".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "auto".into(),
+            dir_path: dir.into(),
+        })
+        .expect_err("second create with same dir_path should fail");
+    match err {
+        StorageError::UniqueConflict { kind, field, value } => {
+            assert_eq!(kind, "meeting");
+            assert_eq!(field, "dir_path");
+            assert_eq!(value, dir);
+        }
+        other => panic!("expected UniqueConflict on dir_path, got {other:?}"),
     }
 }
 
@@ -177,6 +229,100 @@ fn create_and_list_notes_for_meeting<S: Storage>(adapter: &S) {
         .expect("list_notes should succeed");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "n_one");
+}
+
+fn create_meeting_with_note_atomic_happy_path<S: Storage>(adapter: &S) {
+    let m_id = "m_atomic_ok";
+    let n_id = "n_atomic_ok";
+    let (m, n) = adapter
+        .create_meeting_with_note(
+            MeetingDraft {
+                id: m_id.into(),
+                title: "Atomic OK".into(),
+                started_at: "2026-05-05T10:00:00+00:00".into(),
+                language: "auto".into(),
+                dir_path: format!("/tmp/{m_id}"),
+            },
+            NoteDraft {
+                id: n_id.into(),
+                meeting_id: m_id.into(),
+                dialect: "basic".into(),
+                content_md: "# atomic".into(),
+                primary_path: format!("/tmp/{m_id}/notes.md"),
+            },
+            Some("2026-05-05T10:30:00+00:00"),
+            Some(1_800_000),
+        )
+        .expect("atomic create should succeed");
+    assert_eq!(m.id, m_id);
+    assert_eq!(m.ended_at.as_deref(), Some("2026-05-05T10:30:00+00:00"));
+    assert_eq!(m.duration_ms, Some(1_800_000));
+    assert_eq!(n.id, n_id);
+    assert_eq!(n.meeting_id, m_id);
+
+    let notes = adapter.list_notes_for_meeting(m_id).unwrap();
+    assert_eq!(notes.len(), 1);
+}
+
+fn create_meeting_with_note_rolls_back_on_note_collision<S: Storage>(adapter: &S) {
+    // Pre-seed a meeting + note. Then attempt to create_meeting_with_note
+    // using a fresh meeting id but the existing note id — note insert
+    // must fail AND the meeting insert must NOT have committed.
+    let pre_m = "m_atomic_pre";
+    let collide_n = "n_atomic_pre";
+    adapter
+        .create_meeting(MeetingDraft {
+            id: pre_m.into(),
+            title: "Pre".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "auto".into(),
+            dir_path: format!("/tmp/{pre_m}"),
+        })
+        .unwrap();
+    adapter
+        .create_note(NoteDraft {
+            id: collide_n.into(),
+            meeting_id: pre_m.into(),
+            dialect: "basic".into(),
+            content_md: "pre".into(),
+            primary_path: "/tmp/pre".into(),
+        })
+        .unwrap();
+
+    let new_m = "m_atomic_rollback";
+    let err = adapter
+        .create_meeting_with_note(
+            MeetingDraft {
+                id: new_m.into(),
+                title: "Rollback".into(),
+                started_at: "2026-05-05T10:00:00+00:00".into(),
+                language: "auto".into(),
+                dir_path: format!("/tmp/{new_m}"),
+            },
+            NoteDraft {
+                // Collides with the pre-seeded note id.
+                id: collide_n.into(),
+                meeting_id: new_m.into(),
+                dialect: "basic".into(),
+                content_md: "should not commit".into(),
+                primary_path: format!("/tmp/{new_m}/notes.md"),
+            },
+            None,
+            None,
+        )
+        .expect_err("note id collision must fail the combined insert");
+
+    assert!(
+        matches!(err, StorageError::AlreadyExists { kind: "note", .. }),
+        "expected AlreadyExists for the note, got {err:?}"
+    );
+
+    // The new meeting must NOT exist (rolled back).
+    let look = adapter.get_meeting(new_m);
+    assert!(
+        matches!(look, Err(StorageError::NotFound { .. })),
+        "expected new_m to be rolled back, got {look:?}"
+    );
 }
 
 fn draft(id: &str, title: &str, started_at: &str) -> MeetingDraft {

--- a/crates/panops-core/src/conformance/storage.rs
+++ b/crates/panops-core/src/conformance/storage.rs
@@ -1,0 +1,190 @@
+//! Conformance harness for [`crate::storage::Storage`] adapters.
+//!
+//! Every Storage impl (real `RusqliteStorage`, fake `InMemoryStorage`)
+//! must pass this same suite. The harness asserts the contract
+//! documented on the trait:
+//!
+//! - `create_meeting` returns the persisted row; round-trips via
+//!   `get_meeting`. A second create with the same id is `AlreadyExists`.
+//! - `get_meeting` of an unknown id is `NotFound { kind: "meeting" }`.
+//! - `list_meetings` returns rows in `started_at DESC` order.
+//! - `update_meeting_ended` populates `ended_at` + `duration_ms` and
+//!   the round-tripped row reflects the change.
+//! - `update_meeting_language` mutates language; round-trip confirms.
+//! - `delete_meeting` removes the row AND cascades note deletion.
+//! - `create_note` round-trips via `list_notes_for_meeting`.
+
+use crate::storage::{MeetingDraft, NoteDraft, Storage, StorageError};
+
+/// Run the full conformance suite against a `Storage` implementation.
+pub fn run_suite<S: Storage>(adapter: &S) {
+    create_get_round_trip(adapter);
+    create_duplicate_id_is_already_exists(adapter);
+    get_unknown_id_is_not_found(adapter);
+    list_returns_started_at_desc(adapter);
+    update_meeting_ended_writes_duration(adapter);
+    update_meeting_language_persists(adapter);
+    delete_meeting_cascades_to_notes(adapter);
+    create_and_list_notes_for_meeting(adapter);
+}
+
+fn create_get_round_trip<S: Storage>(adapter: &S) {
+    let id = "m_round_trip";
+    let m = adapter
+        .create_meeting(draft(id, "Round Trip", "2026-05-05T10:00:00+00:00"))
+        .expect("create_meeting should succeed");
+    assert_eq!(m.id, id);
+    assert_eq!(m.title, "Round Trip");
+    assert!(m.ended_at.is_none());
+    assert!(m.duration_ms.is_none());
+
+    let again = adapter
+        .get_meeting(id)
+        .expect("get_meeting should find the row");
+    assert_eq!(again, m);
+}
+
+fn create_duplicate_id_is_already_exists<S: Storage>(adapter: &S) {
+    let id = "m_dup";
+    let _ = adapter
+        .create_meeting(draft(id, "Dup", "2026-05-05T10:00:00+00:00"))
+        .expect("first create should succeed");
+    let err = adapter
+        .create_meeting(draft(id, "Dup again", "2026-05-05T10:00:00+00:00"))
+        .expect_err("second create should fail");
+    match err {
+        StorageError::AlreadyExists { id: got, kind } => {
+            assert_eq!(got, id);
+            assert_eq!(kind, "meeting");
+        }
+        other => panic!("expected AlreadyExists, got {other:?}"),
+    }
+}
+
+fn get_unknown_id_is_not_found<S: Storage>(adapter: &S) {
+    let err = adapter
+        .get_meeting("does-not-exist")
+        .expect_err("get of unknown id should fail");
+    match err {
+        StorageError::NotFound { id, kind } => {
+            assert_eq!(id, "does-not-exist");
+            assert_eq!(kind, "meeting");
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+fn list_returns_started_at_desc<S: Storage>(adapter: &S) {
+    let _ = adapter.create_meeting(draft("a", "A", "2026-05-01T10:00:00+00:00"));
+    let _ = adapter.create_meeting(draft("b", "B", "2026-05-03T10:00:00+00:00"));
+    let _ = adapter.create_meeting(draft("c", "C", "2026-05-02T10:00:00+00:00"));
+
+    let rows = adapter.list_meetings().expect("list should succeed");
+    let our: Vec<&str> = rows
+        .iter()
+        .map(|r| r.id.as_str())
+        .filter(|i| ["a", "b", "c"].contains(i))
+        .collect();
+    assert_eq!(
+        our,
+        vec!["b", "c", "a"],
+        "list_meetings should return started_at DESC; got {our:?}"
+    );
+}
+
+fn update_meeting_ended_writes_duration<S: Storage>(adapter: &S) {
+    let id = "m_end";
+    let _ = adapter
+        .create_meeting(draft(id, "End", "2026-05-05T10:00:00+00:00"))
+        .unwrap();
+    let updated = adapter
+        .update_meeting_ended(id, "2026-05-05T11:00:00+00:00", 3_600_000)
+        .expect("update_meeting_ended should succeed");
+    assert_eq!(
+        updated.ended_at.as_deref(),
+        Some("2026-05-05T11:00:00+00:00")
+    );
+    assert_eq!(updated.duration_ms, Some(3_600_000));
+
+    let round = adapter.get_meeting(id).unwrap();
+    assert_eq!(round.ended_at.as_deref(), Some("2026-05-05T11:00:00+00:00"));
+    assert_eq!(round.duration_ms, Some(3_600_000));
+}
+
+fn update_meeting_language_persists<S: Storage>(adapter: &S) {
+    let id = "m_lang";
+    let _ = adapter
+        .create_meeting(draft(id, "Lang", "2026-05-05T10:00:00+00:00"))
+        .unwrap();
+    let updated = adapter
+        .update_meeting_language(id, "es")
+        .expect("update_meeting_language should succeed");
+    assert_eq!(updated.language, "es");
+
+    let round = adapter.get_meeting(id).unwrap();
+    assert_eq!(round.language, "es");
+}
+
+fn delete_meeting_cascades_to_notes<S: Storage>(adapter: &S) {
+    let m = "m_del";
+    let n = "n_del";
+    let _ = adapter
+        .create_meeting(draft(m, "Del", "2026-05-05T10:00:00+00:00"))
+        .unwrap();
+    let _ = adapter
+        .create_note(NoteDraft {
+            id: n.into(),
+            meeting_id: m.into(),
+            dialect: "basic".into(),
+            content_md: "# hi".into(),
+            primary_path: "/tmp/notes.md".into(),
+        })
+        .unwrap();
+
+    adapter.delete_meeting(m).expect("delete should succeed");
+    let err = adapter.get_meeting(m).expect_err("meeting should be gone");
+    assert!(matches!(err, StorageError::NotFound { .. }));
+
+    // Notes for the deleted meeting must be gone too (FK cascade).
+    let notes = adapter
+        .list_notes_for_meeting(m)
+        .expect("list notes should not error on a deleted meeting");
+    assert!(
+        notes.is_empty(),
+        "expected zero notes after cascade, got {notes:?}"
+    );
+}
+
+fn create_and_list_notes_for_meeting<S: Storage>(adapter: &S) {
+    let m = "m_notes";
+    let _ = adapter
+        .create_meeting(draft(m, "Notes", "2026-05-05T10:00:00+00:00"))
+        .unwrap();
+    let n = adapter
+        .create_note(NoteDraft {
+            id: "n_one".into(),
+            meeting_id: m.into(),
+            dialect: "notion-enhanced".into(),
+            content_md: "# notes".into(),
+            primary_path: "/tmp/m_notes/notes.md".into(),
+        })
+        .expect("create_note should succeed");
+    assert_eq!(n.id, "n_one");
+    assert!(!n.created_at.is_empty(), "created_at should be set");
+
+    let rows = adapter
+        .list_notes_for_meeting(m)
+        .expect("list_notes should succeed");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "n_one");
+}
+
+fn draft(id: &str, title: &str, started_at: &str) -> MeetingDraft {
+    MeetingDraft {
+        id: id.into(),
+        title: title.into(),
+        started_at: started_at.into(),
+        language: "auto".into(),
+        dir_path: format!("/tmp/{id}"),
+    }
+}

--- a/crates/panops-core/src/lib.rs
+++ b/crates/panops-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod llm;
 pub mod merge;
 pub mod notes;
 pub mod segment;
+pub mod storage;
 pub mod wer;
 
 pub use asr::{AsrError, AsrProvider};
@@ -19,3 +20,4 @@ pub use notes::dialect::MarkdownDialect;
 pub use notes::error::NotesError;
 pub use notes::pipeline::NotesGenerator;
 pub use segment::{Segment, Transcript};
+pub use storage::{Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError};

--- a/crates/panops-core/src/notes/dialect.rs
+++ b/crates/panops-core/src/notes/dialect.rs
@@ -23,6 +23,18 @@ impl MarkdownDialect {
             Self::Basic => CHEAT_SHEET_BASIC,
         }
     }
+
+    /// Stable kebab-case wire / DB string for this dialect. Matches
+    /// the `#[serde(rename_all = "kebab-case")]` form. Single source
+    /// of truth — used by the IPC handler when persisting a `note`
+    /// row, by the CLI's notes registration, and by anywhere else
+    /// that needs the dialect as a string column.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotionEnhanced => "notion-enhanced",
+            Self::Basic => "basic",
+        }
+    }
 }
 
 const CHEAT_SHEET_NOTION_ENHANCED: &str = "\
@@ -77,5 +89,17 @@ mod tests {
     #[test]
     fn default_is_notion_enhanced() {
         assert_eq!(MarkdownDialect::default(), MarkdownDialect::NotionEnhanced);
+    }
+
+    #[test]
+    fn as_str_matches_serde_kebab_case() {
+        // Stay in lock-step with the wire form so `dialect` columns
+        // and JSON values agree.
+        assert_eq!(MarkdownDialect::NotionEnhanced.as_str(), "notion-enhanced");
+        assert_eq!(MarkdownDialect::Basic.as_str(), "basic");
+        assert_eq!(
+            serde_json::to_string(&MarkdownDialect::NotionEnhanced).unwrap(),
+            format!("\"{}\"", MarkdownDialect::NotionEnhanced.as_str())
+        );
     }
 }

--- a/crates/panops-core/src/storage.rs
+++ b/crates/panops-core/src/storage.rs
@@ -1,0 +1,143 @@
+//! Storage port. Real impl: `panops_portable::RusqliteStorage`.
+//! Fake: `panops_core::conformance::fakes::InMemoryStorage`.
+//!
+//! The trait is sync; async wrapping happens at the handler layer via
+//! `tokio::task::spawn_blocking`. This keeps `panops-core`
+//! async-runtime-free and matches the shape of the other ports
+//! (`AsrProvider`, `LlmProvider`, `Diarizer`, `NotesExporter`).
+
+use thiserror::Error;
+
+pub trait Storage: Send + Sync {
+    fn create_meeting(&self, draft: MeetingDraft) -> Result<Meeting, StorageError>;
+    fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError>;
+    fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError>;
+    fn update_meeting_ended(
+        &self,
+        id: &str,
+        ended_at: &str,
+        duration_ms: u64,
+    ) -> Result<Meeting, StorageError>;
+    fn update_meeting_language(&self, id: &str, language: &str) -> Result<Meeting, StorageError>;
+    fn delete_meeting(&self, id: &str) -> Result<(), StorageError>;
+    fn create_note(&self, draft: NoteDraft) -> Result<Note, StorageError>;
+    fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeetingDraft {
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub language: String,
+    pub dir_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Meeting {
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub language: String,
+    pub dir_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeetingSummary {
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteDraft {
+    pub id: String,
+    pub meeting_id: String,
+    pub dialect: String,
+    pub content_md: String,
+    pub primary_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    pub id: String,
+    pub meeting_id: String,
+    pub dialect: String,
+    pub content_md: String,
+    pub primary_path: String,
+    pub created_at: String,
+}
+
+/// Domain error. NEVER derive `Serialize` (per AGENTS.md: domain
+/// errors stay platform-agnostic; transport conversion lives in
+/// `panops-protocol` behind the `domain-conversions` feature).
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("{kind} not found: {id}")]
+    NotFound { id: String, kind: &'static str },
+    #[error("{kind} already exists: {id}")]
+    AlreadyExists { id: String, kind: &'static str },
+    #[error("storage schema mismatch: actual {actual}, expected {expected}")]
+    SchemaMismatch { actual: u32, expected: u32 },
+    #[error("io: {source}")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+    #[error("sql: {message}")]
+    Sql { message: String },
+}
+
+impl StorageError {
+    /// Construct a `Sql` variant from anything `Display`. Used by
+    /// `RusqliteStorage` to keep `panops-core` rusqlite-free.
+    pub fn sql<E: std::fmt::Display>(e: E) -> Self {
+        Self::Sql {
+            message: e.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meeting_draft_can_be_constructed() {
+        let d = MeetingDraft {
+            id: "m1".into(),
+            title: "Test".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            language: "en".into(),
+            dir_path: "/tmp/x".into(),
+        };
+        assert_eq!(d.id, "m1");
+    }
+
+    #[test]
+    fn storage_error_display_includes_kind() {
+        let e = StorageError::NotFound {
+            id: "abc".into(),
+            kind: "meeting",
+        };
+        let s = format!("{e}");
+        assert!(s.contains("meeting"), "got: {s}");
+        assert!(s.contains("abc"), "got: {s}");
+    }
+
+    #[test]
+    fn storage_error_io_via_from() {
+        let io: std::io::Error = std::io::Error::other("disk full");
+        let e: StorageError = io.into();
+        assert!(matches!(e, StorageError::Io { .. }));
+    }
+
+    #[test]
+    fn storage_error_sql_helper_does_not_require_rusqlite() {
+        let e = StorageError::sql("any displayable");
+        assert!(matches!(e, StorageError::Sql { .. }));
+    }
+}

--- a/crates/panops-core/src/storage.rs
+++ b/crates/panops-core/src/storage.rs
@@ -22,6 +22,21 @@ pub trait Storage: Send + Sync {
     fn delete_meeting(&self, id: &str) -> Result<(), StorageError>;
     fn create_note(&self, draft: NoteDraft) -> Result<Note, StorageError>;
     fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError>;
+
+    /// Atomic combined insert: meeting + note + (optional) ended_at
+    /// in a single transaction. Used by the CLI's `notes` flow so a
+    /// note insert failure rolls back the meeting row instead of
+    /// leaving a meeting-without-note in the registry. Real adapters
+    /// should use `BEGIN`/`COMMIT`; the in-memory fake fakes atomicity
+    /// by constructing both records up front and inserting only after
+    /// both validate.
+    fn create_meeting_with_note(
+        &self,
+        meeting: MeetingDraft,
+        note: NoteDraft,
+        ended_at: Option<&str>,
+        duration_ms: Option<u64>,
+    ) -> Result<(Meeting, Note), StorageError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,8 +93,21 @@ pub struct Note {
 pub enum StorageError {
     #[error("{kind} not found: {id}")]
     NotFound { id: String, kind: &'static str },
+    /// Primary-key collision: a row with this `id` already exists.
     #[error("{kind} already exists: {id}")]
     AlreadyExists { id: String, kind: &'static str },
+    /// Non-PK UNIQUE constraint collision. `field` names the column
+    /// (e.g., "dir_path") and `value` is the colliding value the
+    /// caller tried to write. Lets the wire layer surface a precise
+    /// error like "meeting.dir_path already in use" instead of
+    /// misattributing the conflict to the meeting's id (which is
+    /// what a blanket `AlreadyExists` mapping would do).
+    #[error("{kind}.{field} already in use: {value}")]
+    UniqueConflict {
+        kind: &'static str,
+        field: &'static str,
+        value: String,
+    },
     #[error("storage schema mismatch: actual {actual}, expected {expected}")]
     SchemaMismatch { actual: u32, expected: u32 },
     #[error("io: {source}")]

--- a/crates/panops-engine/Cargo.toml
+++ b/crates/panops-engine/Cargo.toml
@@ -21,6 +21,7 @@ panops-portable = { path = "../panops-portable" }
 panops-protocol = { path = "../panops-protocol", features = ["domain-conversions"] }
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -15,6 +15,7 @@ use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::ir::Screenshot;
 use panops_core::notes::pipeline::NotesGenerator;
+use panops_core::storage::{MeetingDraft, NoteDraft, Storage};
 use panops_portable::SherpaDiarizer;
 use panops_portable::WhisperRsAsr;
 use panops_portable::genai_llm::GenaiLlm;
@@ -22,6 +23,7 @@ use panops_portable::markdown_exporter::MarkdownExporter;
 use panops_portable::model::{
     DEFAULT_MODEL_NAME, default_model_path, ensure_diar_models, ensure_model,
 };
+use panops_portable::rusqlite_storage::RusqliteStorage;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -40,6 +42,13 @@ struct Cli {
 
     #[arg(long)]
     no_diarize: bool,
+
+    /// Override the data directory. Defaults to
+    /// `~/Library/Application Support/panops/`. The `panops.db`
+    /// registry and `meetings/<uuid>/` subdirs live here. No env
+    /// var equivalent — per AGENTS.md "no env vars for user config".
+    #[arg(long, global = true, value_name = "DIR")]
+    data_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -95,6 +104,7 @@ fn main() -> ExitCode {
         "panops-engine starting"
     );
     let cli = Cli::parse();
+    let data_dir = default_or_resolved_data_dir(&cli.data_dir);
     let res = match cli.cmd {
         None => run_default(cli.audio, cli.model, cli.language, cli.no_diarize),
         Some(Cmd::Notes {
@@ -117,8 +127,9 @@ fn main() -> ExitCode {
             llm_model,
             model,
             language,
+            data_dir.clone(),
         ),
-        Some(Cmd::Serve { socket }) => panops_engine::server::run_serve(socket),
+        Some(Cmd::Serve { socket }) => panops_engine::server::run_serve(socket, data_dir),
     };
     match res {
         Ok(()) => ExitCode::SUCCESS,
@@ -127,6 +138,24 @@ fn main() -> ExitCode {
             ExitCode::from(code)
         }
     }
+}
+
+/// Default data directory for the CLI. Mirrors `server::socket::default_socket_path`'s
+/// HOME handling: requires an absolute, non-empty HOME; falls back to
+/// `/tmp/panops` only if HOME is missing or relative (CI / unusual envs).
+/// Tests pass `--data-dir` explicitly so this fallback is for shell use.
+fn default_data_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute() && !p.as_os_str().is_empty())
+        .map_or_else(
+            || PathBuf::from("/tmp/panops"),
+            |home| home.join("Library/Application Support/panops"),
+        )
+}
+
+fn default_or_resolved_data_dir(opt: &Option<PathBuf>) -> PathBuf {
+    opt.clone().unwrap_or_else(default_data_dir)
 }
 
 fn init_tracing() {
@@ -184,6 +213,7 @@ fn run_notes(
     llm_model: Option<String>,
     model: Option<PathBuf>,
     language: Option<String>,
+    data_dir: PathBuf,
 ) -> Result<(), (u8, String)> {
     let mut transcript = transcribe(&audio, model, language.as_deref())?;
     if !no_diarize {
@@ -220,12 +250,14 @@ fn run_notes(
         .unwrap_or_default();
 
     let started_at = chrono::Local::now().fixed_offset();
+    let language_for_meeting = language.clone();
+    let audio_duration_ms = transcript.audio_duration_ms;
     let input = NotesInput {
         transcript: transcript.segments,
         screenshots,
         meeting_metadata: MeetingMetadata {
             started_at,
-            duration_ms: transcript.audio_duration_ms,
+            duration_ms: audio_duration_ms,
             source_path: Some(audio.clone()),
             language_hint: language,
         },
@@ -248,6 +280,94 @@ fn run_notes(
         .export(&notes, &out_dir)
         .map_err(|e| (2, e.to_string()))?;
     tracing::info!(file = ?art.primary_file, assets = art.assets.len(), "wrote notes");
+
+    // Slice 06: register the meeting + note in the registry. The CLI
+    // preserves its existing on-disk layout (notes alongside audio,
+    // not under `<data_dir>/meetings/<uuid>/`) — only the registry
+    // entry is new. Failure is non-fatal: the notes file is already
+    // on disk; we surface the storage error as a warning + non-zero
+    // exit so CI catches it but the user still has the artifact.
+    let dir_path = out_dir
+        .canonicalize()
+        .unwrap_or(out_dir.clone())
+        .to_string_lossy()
+        .into_owned();
+    let title = audio
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("untitled")
+        .to_string();
+    let dialect_str = match dialect {
+        MarkdownDialect::Basic => "basic",
+        MarkdownDialect::NotionEnhanced => "notion-enhanced",
+    };
+    // Open `panops.db` once for this CLI invocation. The handle is
+    // dropped at the end of `run_notes`. SQLite serialises concurrent
+    // writers file-wide, so a long-running `panops-engine serve`
+    // holding its own handle won't conflict — our brief insert just
+    // queues. If usage ever grows beyond single-user, the handle is
+    // a `&dyn Storage` arg to `register_meeting_in_registry` so a
+    // future shared-handle pattern is a one-line caller change.
+    std::fs::create_dir_all(&data_dir).map_err(|e| (3, format!("create data dir: {e}")))?;
+    let storage = RusqliteStorage::new(&data_dir.join("panops.db"))
+        .map_err(|e| (3, format!("open registry: {e}")))?;
+    register_meeting_in_registry(
+        &storage,
+        title,
+        started_at.to_rfc3339(),
+        audio_duration_ms,
+        language_for_meeting.unwrap_or_else(|| "auto".into()),
+        dir_path,
+        dialect_str.to_string(),
+        art.primary_file.display().to_string(),
+    )?;
+
+    Ok(())
+}
+
+/// Insert a fresh meeting + its initial note row into `storage`. Pure
+/// trait calls — no FS or DB-open — so callers may pass any `Storage`
+/// impl (real `RusqliteStorage` from CLI, in-memory fake from tests,
+/// or a future shared handle from a daemon-only-writes design).
+#[allow(clippy::too_many_arguments)]
+fn register_meeting_in_registry(
+    storage: &dyn Storage,
+    title: String,
+    started_at: String,
+    duration_ms: u64,
+    language: String,
+    dir_path: String,
+    dialect: String,
+    primary_path: String,
+) -> Result<(), (u8, String)> {
+    let meeting_id = uuid::Uuid::new_v4().simple().to_string();
+    let meeting = storage
+        .create_meeting(MeetingDraft {
+            id: meeting_id.clone(),
+            title,
+            started_at: started_at.clone(),
+            language,
+            dir_path,
+        })
+        .map_err(|e| (3, format!("register meeting: {e}")))?;
+    // Mark ended_at = started_at + duration so the registry row is
+    // immediately "complete" (CLI flow has no live capture).
+    let ended_at = chrono::DateTime::parse_from_rfc3339(&started_at)
+        .map(|dt| (dt + chrono::Duration::milliseconds(duration_ms as i64)).to_rfc3339())
+        .unwrap_or(started_at);
+    let _ = storage
+        .update_meeting_ended(&meeting.id, &ended_at, duration_ms)
+        .map_err(|e| (3, format!("update meeting ended: {e}")))?;
+    let _ = storage
+        .create_note(NoteDraft {
+            id: uuid::Uuid::new_v4().simple().to_string(),
+            meeting_id,
+            dialect,
+            content_md: std::fs::read_to_string(&primary_path).unwrap_or_default(),
+            primary_path,
+        })
+        .map_err(|e| (3, format!("register note: {e}")))?;
+    tracing::info!(meeting = %meeting.id, "registered meeting in registry");
     Ok(())
 }
 
@@ -310,4 +430,61 @@ fn diarize(audio: &std::path::Path) -> Result<Vec<panops_core::diar::SpeakerTurn
     let (seg, emb) = ensure_diar_models().map_err(|e| (3, e.to_string()))?;
     let diar = SherpaDiarizer::new(seg, emb).map_err(|e| (3, e.to_string()))?;
     diar.diarize(audio).map_err(|e| (2, e.to_string()))
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+    use panops_core::conformance::fakes::InMemoryStorage;
+
+    /// Trait-level test: `register_meeting_in_registry` is now a pure
+    /// `&dyn Storage` consumer, so we exercise it against the
+    /// in-memory fake (no DB open, no FS write for the storage path).
+    /// Verifies that the function inserts a meeting + an attached note
+    /// + the meeting is "complete" (ended_at + duration_ms set).
+    ///
+    /// `RusqliteStorage` independently passes the same conformance
+    /// suite (`crates/panops-portable/tests/conformance_rusqlite_storage.rs`),
+    /// so this fake-backed test doubles as evidence that the real
+    /// adapter behaves identically when the CLI calls it.
+    #[test]
+    fn register_meeting_inserts_meeting_and_note_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Only the `primary_path` needs to exist on disk — we read its
+        // contents into the `note.content_md` field. Everything else
+        // is pure storage trait calls.
+        let notes_dir = tmp.path().join("audio-notes");
+        std::fs::create_dir_all(&notes_dir).unwrap();
+        let notes_md = notes_dir.join("notes.md");
+        std::fs::write(&notes_md, "# Test notes\n").unwrap();
+
+        let storage = InMemoryStorage::new();
+        register_meeting_in_registry(
+            &storage,
+            "Test Meeting".to_string(),
+            "2026-05-05T10:00:00+00:00".to_string(),
+            60_000,
+            "en".to_string(),
+            notes_dir.to_string_lossy().into_owned(),
+            "basic".to_string(),
+            notes_md.to_string_lossy().into_owned(),
+        )
+        .expect("registration should succeed");
+
+        let rows = storage.list_meetings().unwrap();
+        assert_eq!(rows.len(), 1, "expected one registered meeting");
+        assert_eq!(rows[0].title, "Test Meeting");
+        assert_eq!(rows[0].duration_ms, 60_000);
+
+        let m = storage.get_meeting(&rows[0].id).unwrap();
+        assert_eq!(m.language, "en");
+        assert!(m.ended_at.is_some(), "ended_at should be set");
+        assert_eq!(m.duration_ms, Some(60_000));
+
+        let notes = storage.list_notes_for_meeting(&m.id).unwrap();
+        assert_eq!(notes.len(), 1, "expected one note row");
+        assert_eq!(notes[0].dialect, "basic");
+        assert_eq!(notes[0].primary_path, notes_md.to_string_lossy());
+        assert_eq!(notes[0].content_md, "# Test notes\n");
+    }
 }

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -297,10 +297,7 @@ fn run_notes(
         .and_then(|s| s.to_str())
         .unwrap_or("untitled")
         .to_string();
-    let dialect_str = match dialect {
-        MarkdownDialect::Basic => "basic",
-        MarkdownDialect::NotionEnhanced => "notion-enhanced",
-    };
+    let dialect_str = dialect.as_str();
     // Open `panops.db` once for this CLI invocation. The handle is
     // dropped at the end of `run_notes`. SQLite serialises concurrent
     // writers file-wide, so a long-running `panops-engine serve`
@@ -313,16 +310,33 @@ fn run_notes(
         .map_err(|e| (3, format!("open registry: {e}")))?;
     register_meeting_in_registry(
         &storage,
-        title,
-        started_at.to_rfc3339(),
-        audio_duration_ms,
-        language_for_meeting.unwrap_or_else(|| "auto".into()),
-        dir_path,
-        dialect_str.to_string(),
-        art.primary_file.display().to_string(),
+        RegisterInput {
+            title,
+            started_at: started_at.to_rfc3339(),
+            duration_ms: audio_duration_ms,
+            language: language_for_meeting.unwrap_or_else(|| "auto".into()),
+            dir_path,
+            dialect: dialect_str.to_string(),
+            primary_path: art.primary_file.display().to_string(),
+        },
     )?;
 
     Ok(())
+}
+
+/// Bundled input for [`register_meeting_in_registry`]. Avoids an
+/// 8-positional-arg signature (which is easy to misorder at call
+/// sites and forces `#[allow(clippy::too_many_arguments)]`). Fields
+/// map 1:1 to the underlying `MeetingDraft` + `NoteDraft` + the
+/// `ended_at` / `duration_ms` overrides.
+struct RegisterInput {
+    title: String,
+    started_at: String,
+    duration_ms: u64,
+    language: String,
+    dir_path: String,
+    dialect: String,
+    primary_path: String,
 }
 
 /// Insert a fresh meeting + its initial note row into `storage`
@@ -336,16 +350,9 @@ fn run_notes(
 /// any `Storage` impl (real `RusqliteStorage` from CLI, in-memory
 /// fake from tests, or a future shared handle from a daemon-only-
 /// writes design).
-#[allow(clippy::too_many_arguments)]
 fn register_meeting_in_registry(
     storage: &dyn Storage,
-    title: String,
-    started_at: String,
-    duration_ms: u64,
-    language: String,
-    dir_path: String,
-    dialect: String,
-    primary_path: String,
+    input: RegisterInput,
 ) -> Result<(), (u8, String)> {
     let meeting_id = uuid::Uuid::new_v4().simple().to_string();
     // Mark ended_at = started_at + duration so the registry row is
@@ -353,34 +360,34 @@ fn register_meeting_in_registry(
     // parse failure (shouldn't happen — `started_at` came from
     // chrono's own `to_rfc3339`), fall back to leaving ended_at
     // unset so the row is still queryable.
-    let ended_at = chrono::DateTime::parse_from_rfc3339(&started_at)
-        .map(|dt| (dt + chrono::Duration::milliseconds(duration_ms as i64)).to_rfc3339())
+    let ended_at = chrono::DateTime::parse_from_rfc3339(&input.started_at)
+        .map(|dt| (dt + chrono::Duration::milliseconds(input.duration_ms as i64)).to_rfc3339())
         .ok();
     // Surface read failures explicitly. If the freshly-written
     // markdown can't be read back, the operator should know
     // (permissions, antivirus quarantine, disk flap) — silently
     // storing empty content makes debugging meeting search later
     // much harder.
-    let content_md = std::fs::read_to_string(&primary_path)
-        .map_err(|e| (3, format!("read notes file {primary_path}: {e}")))?;
+    let content_md = std::fs::read_to_string(&input.primary_path)
+        .map_err(|e| (3, format!("read notes file {}: {}", input.primary_path, e)))?;
     let (meeting, _note) = storage
         .create_meeting_with_note(
             MeetingDraft {
                 id: meeting_id.clone(),
-                title,
-                started_at,
-                language,
-                dir_path,
+                title: input.title,
+                started_at: input.started_at,
+                language: input.language,
+                dir_path: input.dir_path,
             },
             NoteDraft {
                 id: uuid::Uuid::new_v4().simple().to_string(),
                 meeting_id,
-                dialect,
+                dialect: input.dialect,
                 content_md,
-                primary_path,
+                primary_path: input.primary_path,
             },
             ended_at.as_deref(),
-            Some(duration_ms),
+            Some(input.duration_ms),
         )
         .map_err(|e| (3, format!("register meeting+note: {e}")))?;
     tracing::info!(meeting = %meeting.id, "registered meeting in registry");
@@ -477,13 +484,15 @@ mod registry_tests {
         let storage = InMemoryStorage::new();
         register_meeting_in_registry(
             &storage,
-            "Test Meeting".to_string(),
-            "2026-05-05T10:00:00+00:00".to_string(),
-            60_000,
-            "en".to_string(),
-            notes_dir.to_string_lossy().into_owned(),
-            "basic".to_string(),
-            notes_md.to_string_lossy().into_owned(),
+            RegisterInput {
+                title: "Test Meeting".to_string(),
+                started_at: "2026-05-05T10:00:00+00:00".to_string(),
+                duration_ms: 60_000,
+                language: "en".to_string(),
+                dir_path: notes_dir.to_string_lossy().into_owned(),
+                dialect: "basic".to_string(),
+                primary_path: notes_md.to_string_lossy().into_owned(),
+            },
         )
         .expect("registration should succeed");
 

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -325,10 +325,17 @@ fn run_notes(
     Ok(())
 }
 
-/// Insert a fresh meeting + its initial note row into `storage`. Pure
-/// trait calls — no FS or DB-open — so callers may pass any `Storage`
-/// impl (real `RusqliteStorage` from CLI, in-memory fake from tests,
-/// or a future shared handle from a daemon-only-writes design).
+/// Insert a fresh meeting + its initial note row into `storage`
+/// **atomically**. Uses `Storage::create_meeting_with_note` which
+/// wraps both inserts in a single transaction (real adapter) or
+/// validates-all-then-commits (in-memory fake), so a note insert
+/// failure rolls back the meeting and never leaves the registry in
+/// a meeting-without-note state.
+///
+/// Pure trait calls — no FS-side DB open here — so callers may pass
+/// any `Storage` impl (real `RusqliteStorage` from CLI, in-memory
+/// fake from tests, or a future shared handle from a daemon-only-
+/// writes design).
 #[allow(clippy::too_many_arguments)]
 fn register_meeting_in_registry(
     storage: &dyn Storage,
@@ -341,32 +348,41 @@ fn register_meeting_in_registry(
     primary_path: String,
 ) -> Result<(), (u8, String)> {
     let meeting_id = uuid::Uuid::new_v4().simple().to_string();
-    let meeting = storage
-        .create_meeting(MeetingDraft {
-            id: meeting_id.clone(),
-            title,
-            started_at: started_at.clone(),
-            language,
-            dir_path,
-        })
-        .map_err(|e| (3, format!("register meeting: {e}")))?;
     // Mark ended_at = started_at + duration so the registry row is
-    // immediately "complete" (CLI flow has no live capture).
+    // immediately "complete" (CLI flow has no live capture). On
+    // parse failure (shouldn't happen — `started_at` came from
+    // chrono's own `to_rfc3339`), fall back to leaving ended_at
+    // unset so the row is still queryable.
     let ended_at = chrono::DateTime::parse_from_rfc3339(&started_at)
         .map(|dt| (dt + chrono::Duration::milliseconds(duration_ms as i64)).to_rfc3339())
-        .unwrap_or(started_at);
-    let _ = storage
-        .update_meeting_ended(&meeting.id, &ended_at, duration_ms)
-        .map_err(|e| (3, format!("update meeting ended: {e}")))?;
-    let _ = storage
-        .create_note(NoteDraft {
-            id: uuid::Uuid::new_v4().simple().to_string(),
-            meeting_id,
-            dialect,
-            content_md: std::fs::read_to_string(&primary_path).unwrap_or_default(),
-            primary_path,
-        })
-        .map_err(|e| (3, format!("register note: {e}")))?;
+        .ok();
+    // Surface read failures explicitly. If the freshly-written
+    // markdown can't be read back, the operator should know
+    // (permissions, antivirus quarantine, disk flap) — silently
+    // storing empty content makes debugging meeting search later
+    // much harder.
+    let content_md = std::fs::read_to_string(&primary_path)
+        .map_err(|e| (3, format!("read notes file {primary_path}: {e}")))?;
+    let (meeting, _note) = storage
+        .create_meeting_with_note(
+            MeetingDraft {
+                id: meeting_id.clone(),
+                title,
+                started_at,
+                language,
+                dir_path,
+            },
+            NoteDraft {
+                id: uuid::Uuid::new_v4().simple().to_string(),
+                meeting_id,
+                dialect,
+                content_md,
+                primary_path,
+            },
+            ended_at.as_deref(),
+            Some(duration_ms),
+        )
+        .map_err(|e| (3, format!("register meeting+note: {e}")))?;
     tracing::info!(meeting = %meeting.id, "registered meeting in registry");
     Ok(())
 }

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -176,39 +176,12 @@ impl IpcServer for IpcImpl {
         let storage = self.services.storage.clone();
         let data_dir = self.services.data_dir.clone();
         spawn_blocking_into_ipc("meeting.start", move || {
-            let id = uuid::Uuid::new_v4().simple().to_string();
-            let dir = data_dir.join("meetings").join(&id);
-            // The dir + screenshots subdir let the Mac shell drop
-            // assets immediately. `create_dir_all` is idempotent if
-            // the dir already exists (it can't, since `id` is fresh).
-            std::fs::create_dir_all(dir.join("screenshots")).map_err(|e| {
-                tracing::error!(error = %e, "meeting.start create_dir_all");
-                IpcError::Internal {
-                    message: "create meeting dir failed".into(),
-                }
-            })?;
-            let started_at = chrono::Local::now().fixed_offset().to_rfc3339();
-            // If the row insert fails, remove the dir we just created
-            // so we don't leave an orphan that no registry row points
-            // at. (Row-then-fs ordering is for delete; for create the
-            // safe path is fs-then-row + remove-fs-on-row-failure.)
-            let create_result = storage.create_meeting(panops_core::storage::MeetingDraft {
-                id: id.clone(),
-                title: params.title.unwrap_or_default(),
-                started_at,
-                language: params.language.unwrap_or_else(|| "auto".into()),
-                dir_path: dir.to_string_lossy().into_owned(),
-            });
-            if let Err(e) = create_result {
-                if let Err(rm_err) = std::fs::remove_dir_all(&dir) {
-                    tracing::warn!(
-                        error = %rm_err,
-                        dir = ?dir,
-                        "meeting.start: failed to clean up meeting dir after row insert error"
-                    );
-                }
-                return Err(IpcError::from(e));
-            }
+            let (id, _dir) = create_meeting_dir_and_row(
+                storage.as_ref(),
+                &data_dir,
+                params.title.unwrap_or_default(),
+                params.language.unwrap_or_else(|| "auto".into()),
+            )?;
             Ok(id)
         })
         .await
@@ -276,6 +249,7 @@ impl IpcServer for IpcImpl {
 
     async fn meeting_delete(&self, params: MeetingIdParam) -> Result<(), ErrorObjectOwned> {
         let storage = self.services.storage.clone();
+        let data_dir = self.services.data_dir.clone();
         let id = params.id;
         spawn_blocking_into_ipc("meeting.delete", move || {
             // Read first to capture dir_path. Deleting the row before
@@ -283,11 +257,18 @@ impl IpcServer for IpcImpl {
             // (orphan dir on fs failure is recoverable; orphan rows
             // are surprises waiting to bite later).
             let m = storage.get_meeting(&id).map_err(IpcError::from)?;
+            // Defense against a tampered `panops.db` whose `dir_path`
+            // points outside `<data_dir>/meetings/`. Without this,
+            // `remove_dir_all(/Users/fran/Code)` would be one row edit
+            // away. We refuse to delete the row at all if the path
+            // doesn't validate — better an orphan row than catastrophic
+            // recursive delete.
+            let safe_dir = validate_meeting_dir(&data_dir, &m.dir_path)?;
             storage.delete_meeting(&id).map_err(IpcError::from)?;
-            if let Err(e) = std::fs::remove_dir_all(&m.dir_path) {
+            if let Err(e) = std::fs::remove_dir_all(&safe_dir) {
                 tracing::warn!(
                     error = %e,
-                    dir = %m.dir_path,
+                    dir = ?safe_dir,
                     "meeting.delete: row gone but fs cleanup failed (orphan dir)"
                 );
             }
@@ -419,47 +400,23 @@ pub(super) fn run_notes_pipeline(
     let (resolved_meeting_id, canonical_out_dir) = match &params.meeting_id {
         Some(id) => {
             let m = services.storage.get_meeting(id).map_err(IpcError::from)?;
-            (id.clone(), PathBuf::from(m.dir_path))
+            // Same defense as `meeting.delete`: a tampered registry
+            // could route note output to an arbitrary location.
+            let safe_dir = validate_meeting_dir(&services.data_dir, &m.dir_path)?;
+            (id.clone(), safe_dir)
         }
         None => {
-            let id = uuid::Uuid::new_v4().simple().to_string();
-            let dir = services.data_dir.join("meetings").join(&id);
-            std::fs::create_dir_all(dir.join("screenshots")).map_err(|e| {
-                tracing::error!(error = %e, "notes.generate auto-create meetings dir");
-                IpcError::Internal {
-                    message: "failed to prepare meeting directory".into(),
-                }
-            })?;
             let title = audio_path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("untitled")
                 .to_string();
-            let started_at_str = chrono::Local::now().fixed_offset().to_rfc3339();
-            // If the row insert fails, remove the dir we just created
-            // so we don't orphan a `meetings/<uuid>/` directory under
-            // the data dir. Same rationale as `meeting.start`.
-            let create_result =
-                services
-                    .storage
-                    .create_meeting(panops_core::storage::MeetingDraft {
-                        id: id.clone(),
-                        title,
-                        started_at: started_at_str,
-                        language: params.language.clone().unwrap_or_else(|| "auto".into()),
-                        dir_path: dir.to_string_lossy().into_owned(),
-                    });
-            if let Err(e) = create_result {
-                if let Err(rm_err) = std::fs::remove_dir_all(&dir) {
-                    tracing::warn!(
-                        error = %rm_err,
-                        dir = ?dir,
-                        "notes.generate auto-create: failed to clean up dir after row insert error"
-                    );
-                }
-                return Err(IpcError::from(e));
-            }
-            (id, dir)
+            create_meeting_dir_and_row(
+                services.storage.as_ref(),
+                &services.data_dir,
+                title,
+                params.language.clone().unwrap_or_else(|| "auto".into()),
+            )?
         }
     };
 
@@ -534,10 +491,7 @@ pub(super) fn run_notes_pipeline(
     // still get JobDone with the path to the file we just wrote —
     // hiding the artifact would be worse UX than an unregistered
     // note. The storage error goes to `tracing::error!`.
-    let dialect_str = match dialect {
-        MarkdownDialect::Basic => "basic",
-        MarkdownDialect::NotionEnhanced => "notion-enhanced",
-    };
+    let dialect_str = dialect.as_str();
     let content_md = match std::fs::read_to_string(&artifact.primary_file) {
         Ok(s) => s,
         Err(e) => {
@@ -595,6 +549,108 @@ pub(super) fn run_notes_pipeline(
 pub(super) fn ipc_error_to_obj(e: IpcError) -> ErrorObjectOwned {
     let data = serde_json::to_value(&e).expect("IpcError serialise");
     ErrorObjectOwned::owned(-32000, e.to_string(), Some(data))
+}
+
+/// Allocate a fresh meeting id, create its `meetings/<id>/screenshots/`
+/// directory, and insert the corresponding registry row. On row
+/// insert failure, removes the freshly-created directory so we don't
+/// leave an orphan that no row points at. Used by both `meeting.start`
+/// and the `notes.generate` auto-create branch — extracted to keep
+/// the cleanup-on-failure pattern in one place.
+fn create_meeting_dir_and_row(
+    storage: &dyn panops_core::storage::Storage,
+    data_dir: &std::path::Path,
+    title: String,
+    language: String,
+) -> Result<(String, PathBuf), IpcError> {
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let dir = data_dir.join("meetings").join(&id);
+    std::fs::create_dir_all(dir.join("screenshots")).map_err(|e| {
+        tracing::error!(error = %e, "create meetings dir");
+        IpcError::Internal {
+            message: "create meeting dir failed".into(),
+        }
+    })?;
+    let started_at = chrono::Local::now().fixed_offset().to_rfc3339();
+    let create_result = storage.create_meeting(panops_core::storage::MeetingDraft {
+        id: id.clone(),
+        title,
+        started_at,
+        language,
+        dir_path: dir.to_string_lossy().into_owned(),
+    });
+    if let Err(e) = create_result {
+        // Row didn't commit — fs-then-row + cleanup-on-row-error
+        // ordering means we have to remove the dir we just created.
+        // Cleanup failure is logged but does NOT mask the original
+        // storage error (registry stays the source of truth).
+        if let Err(rm_err) = std::fs::remove_dir_all(&dir) {
+            tracing::warn!(
+                error = %rm_err,
+                dir = ?dir,
+                "failed to clean up meeting dir after row insert error"
+            );
+        }
+        return Err(IpcError::from(e));
+    }
+    Ok((id, dir))
+}
+
+/// Validate that a `dir_path` read from the registry actually lives
+/// under `<data_dir>/meetings/` before we delete it or write notes
+/// into it. Defends against a tampered `panops.db` whose `dir_path`
+/// column has been edited to point at e.g. `/Users/fran/Code` —
+/// `remove_dir_all` on that would be catastrophic. Two checks:
+///
+/// 1. **Lexical** prefix match (no FS access). Catches obviously-bad
+///    paths like `/etc` or `../etc/passwd` without requiring the file
+///    to exist (so `meeting.delete` of a row whose dir was rm'd out
+///    of band still works).
+/// 2. **Canonical** prefix match if the file exists. Resolves any
+///    symlinks. Catches the case where `dir_path` IS under
+///    `meetings/` but is a symlink to somewhere outside.
+///
+/// Returns the original `PathBuf` (for use as the destination) on
+/// success. The wire-side error is opaque (`Internal`); the operator
+/// gets the full path detail via `tracing::error!`.
+fn validate_meeting_dir(data_dir: &std::path::Path, dir_path: &str) -> Result<PathBuf, IpcError> {
+    let dir = PathBuf::from(dir_path);
+    let allowed_root = data_dir.join("meetings");
+
+    if !dir.starts_with(&allowed_root) {
+        tracing::error!(
+            dir = %dir_path,
+            allowed = ?allowed_root,
+            "registry dir_path escapes data_dir/meetings (lexical check failed)"
+        );
+        return Err(IpcError::Internal {
+            message: "registry path invalid".into(),
+        });
+    }
+
+    if dir.exists() {
+        let canonical_dir = std::fs::canonicalize(&dir).map_err(|e| {
+            tracing::error!(error = %e, path = %dir_path, "canonicalize dir_path failed");
+            IpcError::Internal {
+                message: "registry path invalid".into(),
+            }
+        })?;
+        // `meetings/` may not exist yet; fall back to the lexical root
+        // for the canonical comparison if so.
+        let canonical_root = std::fs::canonicalize(&allowed_root).unwrap_or(allowed_root);
+        if !canonical_dir.starts_with(&canonical_root) {
+            tracing::error!(
+                canonical_dir = ?canonical_dir,
+                canonical_root = ?canonical_root,
+                "registry dir_path escapes data_dir/meetings (symlink escape)"
+            );
+            return Err(IpcError::Internal {
+                message: "registry path invalid".into(),
+            });
+        }
+    }
+
+    Ok(dir)
 }
 
 /// Convert a `panops_core::storage::Meeting` (domain) to a

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -188,15 +188,27 @@ impl IpcServer for IpcImpl {
                 }
             })?;
             let started_at = chrono::Local::now().fixed_offset().to_rfc3339();
-            storage
-                .create_meeting(panops_core::storage::MeetingDraft {
-                    id: id.clone(),
-                    title: params.title.unwrap_or_default(),
-                    started_at,
-                    language: params.language.unwrap_or_else(|| "auto".into()),
-                    dir_path: dir.to_string_lossy().into_owned(),
-                })
-                .map_err(IpcError::from)?;
+            // If the row insert fails, remove the dir we just created
+            // so we don't leave an orphan that no registry row points
+            // at. (Row-then-fs ordering is for delete; for create the
+            // safe path is fs-then-row + remove-fs-on-row-failure.)
+            let create_result = storage.create_meeting(panops_core::storage::MeetingDraft {
+                id: id.clone(),
+                title: params.title.unwrap_or_default(),
+                started_at,
+                language: params.language.unwrap_or_else(|| "auto".into()),
+                dir_path: dir.to_string_lossy().into_owned(),
+            });
+            if let Err(e) = create_result {
+                if let Err(rm_err) = std::fs::remove_dir_all(&dir) {
+                    tracing::warn!(
+                        error = %rm_err,
+                        dir = ?dir,
+                        "meeting.start: failed to clean up meeting dir after row insert error"
+                    );
+                }
+                return Err(IpcError::from(e));
+            }
             Ok(id)
         })
         .await
@@ -217,7 +229,16 @@ impl IpcServer for IpcImpl {
                     message: "internal time-parse error".into(),
                 }
             })?;
-            let ended = chrono::DateTime::parse_from_rfc3339(&ended_at).expect("just-formatted");
+            let ended = chrono::DateTime::parse_from_rfc3339(&ended_at).map_err(|e| {
+                // Should be unreachable — we just formatted ended_at
+                // ourselves with chrono. If chrono ever changes its
+                // round-trip contract, this surfaces as Internal
+                // instead of panicking + poisoning shared state.
+                tracing::error!(error = %e, "meeting.stop parse self-formatted ended_at");
+                IpcError::Internal {
+                    message: "internal time-format error".into(),
+                }
+            })?;
             let dur = (ended - started).num_milliseconds().max(0) as u64;
             let updated = storage
                 .update_meeting_ended(&id, &ended_at, dur)
@@ -415,16 +436,29 @@ pub(super) fn run_notes_pipeline(
                 .unwrap_or("untitled")
                 .to_string();
             let started_at_str = chrono::Local::now().fixed_offset().to_rfc3339();
-            services
-                .storage
-                .create_meeting(panops_core::storage::MeetingDraft {
-                    id: id.clone(),
-                    title,
-                    started_at: started_at_str,
-                    language: params.language.clone().unwrap_or_else(|| "auto".into()),
-                    dir_path: dir.to_string_lossy().into_owned(),
-                })
-                .map_err(IpcError::from)?;
+            // If the row insert fails, remove the dir we just created
+            // so we don't orphan a `meetings/<uuid>/` directory under
+            // the data dir. Same rationale as `meeting.start`.
+            let create_result =
+                services
+                    .storage
+                    .create_meeting(panops_core::storage::MeetingDraft {
+                        id: id.clone(),
+                        title,
+                        started_at: started_at_str,
+                        language: params.language.clone().unwrap_or_else(|| "auto".into()),
+                        dir_path: dir.to_string_lossy().into_owned(),
+                    });
+            if let Err(e) = create_result {
+                if let Err(rm_err) = std::fs::remove_dir_all(&dir) {
+                    tracing::warn!(
+                        error = %rm_err,
+                        dir = ?dir,
+                        "notes.generate auto-create: failed to clean up dir after row insert error"
+                    );
+                }
+                return Err(IpcError::from(e));
+            }
             (id, dir)
         }
     };
@@ -493,24 +527,50 @@ pub(super) fn run_notes_pipeline(
         IpcError::from(e)
     })?;
 
-    // Persist the note row. Best-effort: even if storage rejects (e.g.,
-    // FK violation because the meeting was deleted mid-flight), we
-    // still surface the file we wrote to disk via the result so the
-    // caller has the artifact. Surface the storage error to the wire.
+    // Persist the note row. Genuinely best-effort: the markdown file
+    // is already on disk at `artifact.primary_file`. If the registry
+    // insert fails (e.g. FK violation because the meeting was
+    // deleted mid-flight, mutex poisoned, etc.), the client should
+    // still get JobDone with the path to the file we just wrote —
+    // hiding the artifact would be worse UX than an unregistered
+    // note. The storage error goes to `tracing::error!`.
     let dialect_str = match dialect {
         MarkdownDialect::Basic => "basic",
         MarkdownDialect::NotionEnhanced => "notion-enhanced",
     };
-    services
+    let content_md = match std::fs::read_to_string(&artifact.primary_file) {
+        Ok(s) => s,
+        Err(e) => {
+            // The file existed long enough for the exporter to write
+            // it; failing to read it back is unusual. Log the
+            // specific failure so the operator can investigate (FS
+            // permission flap, antivirus quarantine, disk error).
+            // Continue with empty `content_md` rather than blocking
+            // the client from learning about the artifact.
+            tracing::warn!(
+                error = %e,
+                path = ?artifact.primary_file,
+                "notes.generate could not read back artifact for registry; storing empty content"
+            );
+            String::new()
+        }
+    };
+    if let Err(e) = services
         .storage
         .create_note(panops_core::storage::NoteDraft {
             id: uuid::Uuid::new_v4().simple().to_string(),
             meeting_id: resolved_meeting_id.clone(),
             dialect: dialect_str.into(),
-            content_md: std::fs::read_to_string(&artifact.primary_file).unwrap_or_default(),
+            content_md,
             primary_path: artifact.primary_file.display().to_string(),
         })
-        .map_err(IpcError::from)?;
+    {
+        tracing::error!(
+            error = %e,
+            meeting_id = %resolved_meeting_id,
+            "notes.generate: registry insert failed; markdown file is on disk anyway"
+        );
+    }
 
     Ok(NotesGenerateResult {
         primary_file: artifact.primary_file.display().to_string(),

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -22,10 +22,25 @@ use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_protocol::{
-    Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, MeetingSummary, NotesDialect,
-    NotesGenerateParams, NotesGenerateResult,
+    Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig,
+    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
 };
 use tokio::sync::broadcast;
+
+/// Wrapper for `meeting.{stop,get,delete,set_language}` request params.
+/// jsonrpsee's `#[rpc]` macro accepts strongly-typed params via a single
+/// struct argument; we use distinct types per method so `serde_json` can
+/// validate the shape and so the API surface is self-documenting.
+#[derive(Debug, ::serde::Deserialize)]
+pub struct MeetingIdParam {
+    pub id: String,
+}
+
+#[derive(Debug, ::serde::Deserialize)]
+pub struct MeetingSetLanguageParams {
+    pub id: String,
+    pub language: String,
+}
 
 #[rpc(server, namespace = "ipc", namespace_separator = ".")]
 pub(super) trait Ipc {
@@ -37,6 +52,24 @@ pub(super) trait Ipc {
 
     #[method(name = "meeting.list")]
     async fn meeting_list(&self) -> Result<Vec<MeetingSummary>, ErrorObjectOwned>;
+
+    #[method(name = "meeting.start")]
+    async fn meeting_start(&self, params: MeetingConfig) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "meeting.stop")]
+    async fn meeting_stop(&self, params: MeetingIdParam) -> Result<Meeting, ErrorObjectOwned>;
+
+    #[method(name = "meeting.get")]
+    async fn meeting_get(&self, params: MeetingIdParam) -> Result<Meeting, ErrorObjectOwned>;
+
+    #[method(name = "meeting.set_language")]
+    async fn meeting_set_language(
+        &self,
+        params: MeetingSetLanguageParams,
+    ) -> Result<Meeting, ErrorObjectOwned>;
+
+    #[method(name = "meeting.delete")]
+    async fn meeting_delete(&self, params: MeetingIdParam) -> Result<(), ErrorObjectOwned>;
 
     #[subscription(
         name = "events.subscribe" => "events",
@@ -114,9 +147,132 @@ impl IpcServer for IpcImpl {
     }
 
     async fn meeting_list(&self) -> Result<Vec<MeetingSummary>, ErrorObjectOwned> {
-        // Slice 05 stub. Backed by SQLite once #17 lands; ships now to
-        // lock the response shape (see spec §D9).
-        Ok(Vec::new())
+        let storage = self.services.storage.clone();
+        let rows = tokio::task::spawn_blocking(move || storage.list_meetings())
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "meeting.list spawn_blocking join");
+                ipc_error_to_obj(IpcError::Internal {
+                    message: "meeting.list internal error".into(),
+                })
+            })?
+            .map_err(|e| ipc_error_to_obj(e.into()))?;
+
+        // Convert from `panops_core::storage::MeetingSummary` to the
+        // wire-shape `panops_protocol::MeetingSummary`. Same field set
+        // today; the explicit map keeps us free to diverge later.
+        Ok(rows
+            .into_iter()
+            .map(|s| MeetingSummary {
+                id: s.id,
+                title: s.title,
+                started_at: s.started_at,
+                duration_ms: s.duration_ms,
+            })
+            .collect())
+    }
+
+    async fn meeting_start(&self, params: MeetingConfig) -> Result<String, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        let data_dir = self.services.data_dir.clone();
+        spawn_blocking_into_ipc("meeting.start", move || {
+            let id = uuid::Uuid::new_v4().simple().to_string();
+            let dir = data_dir.join("meetings").join(&id);
+            // The dir + screenshots subdir let the Mac shell drop
+            // assets immediately. `create_dir_all` is idempotent if
+            // the dir already exists (it can't, since `id` is fresh).
+            std::fs::create_dir_all(dir.join("screenshots")).map_err(|e| {
+                tracing::error!(error = %e, "meeting.start create_dir_all");
+                IpcError::Internal {
+                    message: "create meeting dir failed".into(),
+                }
+            })?;
+            let started_at = chrono::Local::now().fixed_offset().to_rfc3339();
+            storage
+                .create_meeting(panops_core::storage::MeetingDraft {
+                    id: id.clone(),
+                    title: params.title.unwrap_or_default(),
+                    started_at,
+                    language: params.language.unwrap_or_else(|| "auto".into()),
+                    dir_path: dir.to_string_lossy().into_owned(),
+                })
+                .map_err(IpcError::from)?;
+            Ok(id)
+        })
+        .await
+    }
+
+    async fn meeting_stop(&self, params: MeetingIdParam) -> Result<Meeting, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        let id = params.id;
+        spawn_blocking_into_ipc("meeting.stop", move || {
+            // Read the existing row to compute duration_ms from
+            // started_at -> now. NotFound surfaces immediately as
+            // InputNotFound (no need to attempt the update).
+            let m = storage.get_meeting(&id).map_err(IpcError::from)?;
+            let ended_at = chrono::Local::now().fixed_offset().to_rfc3339();
+            let started = chrono::DateTime::parse_from_rfc3339(&m.started_at).map_err(|e| {
+                tracing::error!(error = %e, "meeting.stop parse started_at");
+                IpcError::Internal {
+                    message: "internal time-parse error".into(),
+                }
+            })?;
+            let ended = chrono::DateTime::parse_from_rfc3339(&ended_at).expect("just-formatted");
+            let dur = (ended - started).num_milliseconds().max(0) as u64;
+            let updated = storage
+                .update_meeting_ended(&id, &ended_at, dur)
+                .map_err(IpcError::from)?;
+            Ok(to_protocol_meeting(updated))
+        })
+        .await
+    }
+
+    async fn meeting_get(&self, params: MeetingIdParam) -> Result<Meeting, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        let id = params.id;
+        spawn_blocking_into_ipc("meeting.get", move || {
+            storage
+                .get_meeting(&id)
+                .map(to_protocol_meeting)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn meeting_set_language(
+        &self,
+        params: MeetingSetLanguageParams,
+    ) -> Result<Meeting, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("meeting.set_language", move || {
+            storage
+                .update_meeting_language(&params.id, &params.language)
+                .map(to_protocol_meeting)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn meeting_delete(&self, params: MeetingIdParam) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        let id = params.id;
+        spawn_blocking_into_ipc("meeting.delete", move || {
+            // Read first to capture dir_path. Deleting the row before
+            // the fs cleanup keeps the registry the source of truth
+            // (orphan dir on fs failure is recoverable; orphan rows
+            // are surprises waiting to bite later).
+            let m = storage.get_meeting(&id).map_err(IpcError::from)?;
+            storage.delete_meeting(&id).map_err(IpcError::from)?;
+            if let Err(e) = std::fs::remove_dir_all(&m.dir_path) {
+                tracing::warn!(
+                    error = %e,
+                    dir = %m.dir_path,
+                    "meeting.delete: row gone but fs cleanup failed (orphan dir)"
+                );
+            }
+            Ok(())
+        })
+        .await
     }
 
     async fn subscribe_events(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
@@ -233,6 +389,46 @@ pub(super) fn run_notes_pipeline(
         }
     })?;
 
+    // Slice 06: resolve `meeting_id`. If the caller passed one, verify
+    // it exists (NotFound -> InputNotFound surfaces synchronously).
+    // Otherwise, auto-create the meeting now so the exporter writes
+    // into the canonical `meetings/<uuid>/` layout. The created
+    // meeting's `started_at` is server-set; `title` defaults to the
+    // audio file stem.
+    let (resolved_meeting_id, canonical_out_dir) = match &params.meeting_id {
+        Some(id) => {
+            let m = services.storage.get_meeting(id).map_err(IpcError::from)?;
+            (id.clone(), PathBuf::from(m.dir_path))
+        }
+        None => {
+            let id = uuid::Uuid::new_v4().simple().to_string();
+            let dir = services.data_dir.join("meetings").join(&id);
+            std::fs::create_dir_all(dir.join("screenshots")).map_err(|e| {
+                tracing::error!(error = %e, "notes.generate auto-create meetings dir");
+                IpcError::Internal {
+                    message: "failed to prepare meeting directory".into(),
+                }
+            })?;
+            let title = audio_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("untitled")
+                .to_string();
+            let started_at_str = chrono::Local::now().fixed_offset().to_rfc3339();
+            services
+                .storage
+                .create_meeting(panops_core::storage::MeetingDraft {
+                    id: id.clone(),
+                    title,
+                    started_at: started_at_str,
+                    language: params.language.clone().unwrap_or_else(|| "auto".into()),
+                    dir_path: dir.to_string_lossy().into_owned(),
+                })
+                .map_err(IpcError::from)?;
+            (id, dir)
+        }
+    };
+
     let mut transcript = heavy
         .asr
         .transcribe_full(&audio_path, params.language.as_deref())
@@ -269,23 +465,14 @@ pub(super) fn run_notes_pipeline(
     let notes = generator.generate(input).map_err(IpcError::from)?;
     let exporter = heavy.exporter.clone();
 
-    // Output dir convention matches CLI `run_notes`: `<audio_stem>-notes`
-    // alongside the audio file. Falls back to `./notes` if the parent
-    // can't be resolved (shouldn't happen for valid inputs but keeps
-    // unwrap-free).
-    let stem = audio_path
-        .file_stem()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "notes".to_string());
-    let out_dir = audio_path
-        .parent()
-        .map(|p| p.join(format!("{stem}-notes")))
-        .unwrap_or_else(|| PathBuf::from("./notes"));
+    // Slice 06: write into the canonical `meetings/<uuid>/` layout
+    // (resolved above). The on-disk `screenshots/` subdir was already
+    // created during meeting.start (or during auto-create above) so
+    // we only need to make sure the dir itself exists for the
+    // existing-meeting path.
+    let out_dir = canonical_out_dir;
     if !out_dir.exists() {
         std::fs::create_dir_all(&out_dir).map_err(|e| {
-            // Wire-side message stays opaque: the full path + os error
-            // would let a probing client map the local FS layout. The
-            // operator gets the detail via tracing.
             tracing::error!(
                 error = %e,
                 path = ?out_dir,
@@ -306,6 +493,25 @@ pub(super) fn run_notes_pipeline(
         IpcError::from(e)
     })?;
 
+    // Persist the note row. Best-effort: even if storage rejects (e.g.,
+    // FK violation because the meeting was deleted mid-flight), we
+    // still surface the file we wrote to disk via the result so the
+    // caller has the artifact. Surface the storage error to the wire.
+    let dialect_str = match dialect {
+        MarkdownDialect::Basic => "basic",
+        MarkdownDialect::NotionEnhanced => "notion-enhanced",
+    };
+    services
+        .storage
+        .create_note(panops_core::storage::NoteDraft {
+            id: uuid::Uuid::new_v4().simple().to_string(),
+            meeting_id: resolved_meeting_id.clone(),
+            dialect: dialect_str.into(),
+            content_md: std::fs::read_to_string(&artifact.primary_file).unwrap_or_default(),
+            primary_path: artifact.primary_file.display().to_string(),
+        })
+        .map_err(IpcError::from)?;
+
     Ok(NotesGenerateResult {
         primary_file: artifact.primary_file.display().to_string(),
         assets: artifact
@@ -313,6 +519,7 @@ pub(super) fn run_notes_pipeline(
             .iter()
             .map(|p| p.display().to_string())
             .collect(),
+        meeting_id: resolved_meeting_id,
     })
 }
 
@@ -325,10 +532,44 @@ pub(super) fn run_notes_pipeline(
 /// `Ok(vec![])`. Kept because synchronous methods added in slice 06+
 /// (e.g. `meeting.get`) will need it. Removing now means re-deriving
 /// the (-32000, kind, data) shape later from the spec.
-#[allow(dead_code)]
 pub(super) fn ipc_error_to_obj(e: IpcError) -> ErrorObjectOwned {
     let data = serde_json::to_value(&e).expect("IpcError serialise");
     ErrorObjectOwned::owned(-32000, e.to_string(), Some(data))
+}
+
+/// Convert a `panops_core::storage::Meeting` (domain) to a
+/// `panops_protocol::Meeting` (wire). Same field set today; the
+/// explicit map keeps domain free to evolve without breaking wire.
+fn to_protocol_meeting(m: panops_core::storage::Meeting) -> Meeting {
+    Meeting {
+        id: m.id,
+        title: m.title,
+        started_at: m.started_at,
+        ended_at: m.ended_at,
+        duration_ms: m.duration_ms,
+        language: m.language,
+        dir_path: m.dir_path,
+    }
+}
+
+/// Run a synchronous closure on the blocking pool and convert the
+/// result into a JSON-RPC `ErrorObjectOwned`. Centralizes the
+/// `JoinError -> Internal` mapping so each handler stays focused on
+/// its own logic. `op` is the method name for tracing context.
+async fn spawn_blocking_into_ipc<T, F>(op: &'static str, f: F) -> Result<T, ErrorObjectOwned>
+where
+    F: FnOnce() -> Result<T, IpcError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| {
+            tracing::error!(method = op, error = %e, "spawn_blocking join error");
+            ipc_error_to_obj(IpcError::Internal {
+                message: format!("{op} internal error"),
+            })
+        })?
+        .map_err(ipc_error_to_obj)
 }
 
 #[cfg(test)]
@@ -352,13 +593,17 @@ mod readiness_tests {
             llm_model: None,
             no_diarize: None,
             language: None,
+            meeting_id: None,
         }
     }
 
     #[test]
     fn pending_services_yield_provider_unavailable_during_warmup() {
         let llm: Arc<dyn LlmProvider + Send + Sync> = Arc::new(MockLlm::default());
-        let (services, _heavy_lock) = crate::server::EngineServices::pending(llm);
+        let storage: Arc<dyn panops_core::storage::Storage> =
+            Arc::new(panops_core::conformance::fakes::InMemoryStorage::new());
+        let (services, _heavy_lock) =
+            crate::server::EngineServices::pending(llm, storage, std::path::PathBuf::from("/tmp"));
         let err = run_notes_pipeline(&services, &dummy_params()).expect_err("warmup must error");
         match err {
             IpcError::ProviderUnavailable { message } => {
@@ -374,7 +619,10 @@ mod readiness_tests {
     #[test]
     fn pending_services_yield_internal_when_init_failed() {
         let llm: Arc<dyn LlmProvider + Send + Sync> = Arc::new(MockLlm::default());
-        let (services, heavy_lock) = crate::server::EngineServices::pending(llm);
+        let storage: Arc<dyn panops_core::storage::Storage> =
+            Arc::new(panops_core::conformance::fakes::InMemoryStorage::new());
+        let (services, heavy_lock) =
+            crate::server::EngineServices::pending(llm, storage, std::path::PathBuf::from("/tmp"));
         // Simulate init failure (e.g., model download blew up).
         heavy_lock
             .set(Err("simulated whisper init failure".to_string()))

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -37,6 +37,7 @@ use panops_core::asr::AsrProvider;
 use panops_core::diar::Diarizer;
 use panops_core::exporter::NotesExporter;
 use panops_core::llm::LlmProvider;
+use panops_core::storage::Storage;
 use tokio::sync::watch;
 
 use crate::server::handlers::{IpcImpl, IpcServer};
@@ -70,6 +71,14 @@ pub(super) struct HeavyAdapters {
 /// in `run_notes_pipeline`.
 pub struct EngineServices {
     pub llm: Arc<dyn LlmProvider + Send + Sync>,
+    /// Storage port (slice 06). Cheap to open (SQLite file open is
+    /// microseconds), so it lives in the **direct** lane next to
+    /// `llm`, NOT in the `heavy` `OnceLock`.
+    pub storage: Arc<dyn Storage>,
+    /// Root for `panops.db` and `meetings/<uuid>/` subdirs.
+    /// Defaults to `~/Library/Application Support/panops/` in the
+    /// CLI; tests inject a `tempfile::TempDir.path()`.
+    pub data_dir: PathBuf,
     pub(super) heavy: Arc<OnceLock<Result<HeavyAdapters, String>>>,
 }
 
@@ -79,6 +88,8 @@ impl EngineServices {
     /// shape every integration test uses.
     pub fn ready(
         llm: Arc<dyn LlmProvider + Send + Sync>,
+        storage: Arc<dyn Storage>,
+        data_dir: PathBuf,
         asr: Arc<dyn AsrProvider + Send + Sync>,
         diar: Arc<dyn Diarizer + Send + Sync>,
         exporter: Arc<dyn NotesExporter + Send + Sync>,
@@ -89,13 +100,18 @@ impl EngineServices {
             diar,
             exporter,
         }));
-        Self { llm, heavy }
+        Self {
+            llm,
+            storage,
+            data_dir,
+            heavy,
+        }
     }
 
-    /// Construct with only the (cheap) LLM adapter. Returns the
-    /// `OnceLock` handle so the caller can spawn a background init
-    /// task that resolves the heavy trio and fills the lock. Until
-    /// the lock is set, `notes.generate` returns
+    /// Construct with only the (cheap) LLM + storage adapters.
+    /// Returns the `OnceLock` handle so the caller can spawn a
+    /// background init task that resolves the heavy trio and fills
+    /// the lock. Until the lock is set, `notes.generate` returns
     /// `IpcError::ProviderUnavailable`.
     ///
     /// `pub(crate)` — only `run_serve` (same crate) needs to construct
@@ -104,10 +120,14 @@ impl EngineServices {
     /// `server::*`.
     pub(crate) fn pending(
         llm: Arc<dyn LlmProvider + Send + Sync>,
+        storage: Arc<dyn Storage>,
+        data_dir: PathBuf,
     ) -> (Self, Arc<OnceLock<Result<HeavyAdapters, String>>>) {
         let heavy = Arc::new(OnceLock::new());
         let services = Self {
             llm,
+            storage,
+            data_dir,
             heavy: heavy.clone(),
         };
         (services, heavy)
@@ -115,11 +135,22 @@ impl EngineServices {
 }
 
 /// CLI entry point — owns both tokio runtimes and the signal handler.
-pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
+pub fn run_serve(socket: Option<PathBuf>, data_dir: PathBuf) -> Result<(), (u8, String)> {
     let path = match socket {
         Some(p) => p,
         None => socket::default_socket_path().map_err(|e| (3, e))?,
     };
+
+    // Ensure the data directory exists; benign if it already does.
+    // Open the registry DB before starting any runtime so a corrupt or
+    // wrong-version DB fails fast with a clean exit code.
+    std::fs::create_dir_all(&data_dir)
+        .map_err(|e| (3, format!("create data dir {data_dir:?}: {e}")))?;
+    let storage_path = data_dir.join("panops.db");
+    let storage: Arc<dyn Storage> = Arc::new(
+        panops_portable::RusqliteStorage::new(&storage_path)
+            .map_err(|e| (3, format!("open storage at {storage_path:?}: {e}")))?,
+    );
 
     // Runtime B: outbound LLM HTTP. Built first so its handle can be
     // cloned into the LLM adapter before Runtime A starts polling RPC.
@@ -138,14 +169,14 @@ pub fn run_serve(socket: Option<PathBuf>) -> Result<(), (u8, String)> {
         .map_err(|e| (3, format!("build rpc runtime: {e}")))?;
 
     let result = rpc_rt.block_on(async move {
-        // Build the LIGHT services first — just the LLM adapter (cheap,
-        // instant). The heavy trio (Whisper / Sherpa / MarkdownExporter)
-        // is filled by a `spawn_blocking` task that runs concurrent
+        // Build the LIGHT services first — LLM + storage (both cheap).
+        // The heavy trio (Whisper / Sherpa / MarkdownExporter) is
+        // filled by a `spawn_blocking` task that runs concurrent
         // with the accept loop, so the socket binds within the 5s
         // budget and `notes.generate` is gated with
         // `ProviderUnavailable` until the trio is ready.
         let llm = build_llm(llm_handle);
-        let (services, heavy_lock) = EngineServices::pending(llm);
+        let (services, heavy_lock) = EngineServices::pending(llm, storage, data_dir);
         spawn_heavy_init(heavy_lock);
         run_serve_in_process(&path, services, None).await
     });

--- a/crates/panops-engine/tests/common/mod.rs
+++ b/crates/panops-engine/tests/common/mod.rs
@@ -13,11 +13,28 @@
 
 #![allow(dead_code)]
 
-use std::path::Path;
+pub mod notes_pipeline;
+
+use std::path::{Path, PathBuf};
 use std::process::{Child, ExitStatus};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use panops_core::conformance::fakes::InMemoryStorage;
+use panops_core::storage::Storage;
+use tempfile::TempDir;
 use tokio::net::UnixStream;
+
+/// Returns a `(TempDir, Arc<dyn Storage>, PathBuf)` triple for tests.
+/// The caller MUST hold the `TempDir` until after the test ends so the
+/// dir isn't reaped while the engine still expects it. The `PathBuf`
+/// is the same `tmp.path()`, copied to free the borrow.
+pub fn tempdir_storage() -> (TempDir, Arc<dyn Storage>, PathBuf) {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let path = tmp.path().to_owned();
+    let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::new());
+    (tmp, storage, path)
+}
 
 /// Poll `child.try_wait()` until it exits or `dur` elapses, then SIGKILL
 /// and reap. Used by tests that send SIGTERM to the engine and need a

--- a/crates/panops-engine/tests/common/notes_pipeline.rs
+++ b/crates/panops-engine/tests/common/notes_pipeline.rs
@@ -1,24 +1,15 @@
-//! Slice 05 — `notes.generate` round-trips through UDS+WS, completes
-//! the pipeline on the blocking pool, and surfaces `Event::JobDone`
-//! on `events.subscribe`.
+//! Deterministic ASR/diar/LLM/exporter wiring shared by every test
+//! that exercises `notes.generate` end-to-end.
 //!
-//! ASR/diar are deterministic inline fakes (not the sidecar-file fakes
-//! in `panops-core::conformance::fakes`) because the slice-04 golden
-//! prompt fingerprints depend on the EXACT 3-segment shape used in
-//! `regenerate_multi_speaker_60s_goldens`. `TranscriptFileFake` would
-//! return one segment covering the whole audio, which mismatches the
-//! `MockLlm` fingerprint and panics. The inline fakes echo the same
-//! segments / turns the regen test uses, so the section + frontmatter
-//! prompts hash identically.
+//! The fakes here are tightly coupled: the segments returned by
+//! `DeterministicAsr` MUST match the prompt fingerprints registered
+//! on `build_mock_llm`'s output. If you change one, change both.
 
-mod common;
+#![allow(dead_code)]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
-use std::time::Duration;
 
-use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
-use jsonrpsee::rpc_params;
 use panops_core::asr::{AsrError, AsrProvider};
 use panops_core::conformance::fakes::MockLlm;
 use panops_core::diar::{DiarError, Diarizer, SpeakerTurn};
@@ -27,18 +18,15 @@ use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::prompts::{
     SectionSummary, build_frontmatter_prompt, build_section_narrative_prompt,
 };
+use panops_core::storage::Storage;
 use panops_core::{Segment, Transcript};
-use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_engine::server::EngineServices;
 use panops_portable::markdown_exporter::MarkdownExporter;
-use panops_protocol::{Event, JobAccepted};
-use tempfile::tempdir;
-use tokio::sync::watch;
 
-use common::{tempdir_storage, uds_ws_client, wait_for_socket};
-
-/// Returns the same 3 segments the slice-04 golden regen uses, so the
-/// `MockLlm` prompt fingerprint matches verbatim.
-fn golden_segments() -> Vec<Segment> {
+/// Three-segment golden transcript used by the slice-04 regen test.
+/// Reproduced verbatim here so the `MockLlm` prompt fingerprints
+/// match the canned responses.
+pub fn golden_segments() -> Vec<Segment> {
     vec![
         Segment {
             start_ms: 0,
@@ -76,10 +64,7 @@ fn golden_segments() -> Vec<Segment> {
     ]
 }
 
-/// Inline ASR fake that returns the golden segments verbatim. Speaker
-/// IDs are already set, so the diar merge below is effectively a no-op
-/// (turns map 1:1 to speakers already in the segments).
-struct DeterministicAsr;
+pub struct DeterministicAsr;
 
 impl AsrProvider for DeterministicAsr {
     fn transcribe_full(
@@ -102,10 +87,7 @@ impl AsrProvider for DeterministicAsr {
     }
 }
 
-/// Inline diar fake matching `multi_speaker_60s.turns.json`. Returns
-/// turns aligned exactly with the segment boundaries above so
-/// `merge_speaker_turns` doesn't reshape segments.
-struct DeterministicDiar;
+pub struct DeterministicDiar;
 
 impl Diarizer for DeterministicDiar {
     fn diarize(&self, _audio_path: &Path) -> Result<Vec<SpeakerTurn>, DiarError> {
@@ -133,9 +115,8 @@ impl Diarizer for DeterministicDiar {
     }
 }
 
-fn build_mock_llm(dialect: MarkdownDialect) -> MockLlm {
+pub fn build_mock_llm(dialect: MarkdownDialect) -> MockLlm {
     let segments = golden_segments();
-    // Match the regen test's canned section / frontmatter responses.
     let canned_section = serde_json::json!({
         "title": "Meeting kickoff and quarterly budget review",
         "narrative_md": "The session opened with a welcome and a brief handoff \
@@ -176,79 +157,19 @@ fn build_mock_llm(dialect: MarkdownDialect) -> MockLlm {
         )
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn notes_generate_round_trip_emits_job_done() {
-    let dir = tempdir().unwrap();
-    let socket = dir.path().join("engine.sock");
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
-    // Stage the audio path inside a tempdir so the pipeline's output
-    // directory (alongside the audio) doesn't pollute repo fixtures.
-    // The wav doesn't need real bytes — `DeterministicAsr` ignores
-    // file contents.
-    let audio_dir = tempdir().unwrap();
-    let audio_path = audio_dir.path().join("multi_speaker_60s.wav");
-    std::fs::write(&audio_path, b"placeholder").unwrap();
-
-    let (_storage_tmp, storage, data_dir) = tempdir_storage();
-    let services = EngineServices::ready(
+/// Build an `EngineServices` with a deterministic ASR + diar + LLM
+/// pipeline and a real `MarkdownExporter`. Uses dialect = `Basic` so
+/// the prompts are simpler and the goldens are short.
+pub fn build_deterministic_notes_services(
+    storage: Arc<dyn Storage>,
+    data_dir: std::path::PathBuf,
+) -> EngineServices {
+    EngineServices::ready(
         Arc::new(build_mock_llm(MarkdownDialect::Basic)),
         storage,
         data_dir,
         Arc::new(DeterministicAsr),
         Arc::new(DeterministicDiar),
         Arc::new(MarkdownExporter),
-    );
-
-    let server_socket = socket.clone();
-    let server_shutdown = shutdown_rx.clone();
-    let server = tokio::spawn(async move {
-        run_serve_in_process(&server_socket, services, Some(server_shutdown))
-            .await
-            .unwrap();
-    });
-
-    wait_for_socket(&socket).await;
-
-    let client = uds_ws_client(&socket).await;
-
-    // Subscribe FIRST so we don't race the job-completion broadcast.
-    let mut subscription: Subscription<Event> = SubscriptionClientT::subscribe(
-        &client,
-        "ipc.events.subscribe",
-        rpc_params![],
-        "ipc.events.unsubscribe",
     )
-    .await
-    .expect("subscribe to events");
-
-    let _accepted: JobAccepted = ClientT::request(
-        &client,
-        "ipc.notes.generate",
-        rpc_params![serde_json::json!({
-            "audio": audio_path.to_string_lossy(),
-            "dialect": "basic",
-        })],
-    )
-    .await
-    .expect("call notes.generate");
-
-    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
-        .await
-        .expect("event arrived within 60s")
-        .expect("subscription not closed")
-        .expect("event payload deserialised");
-
-    let primary_file = match event {
-        Event::JobDone(d) => PathBuf::from(d.result.primary_file),
-        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
-        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
-    };
-    assert!(
-        primary_file.exists(),
-        "primary_file does not exist: {primary_file:?}"
-    );
-
-    let _ = shutdown_tx.send(true);
-    let _ = server.await;
 }

--- a/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
+++ b/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
@@ -22,7 +22,7 @@ use panops_protocol::{Event, IpcError, JobAccepted};
 use tempfile::tempdir;
 use tokio::sync::watch;
 
-use common::{uds_ws_client, wait_for_socket};
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn notes_generate_emits_job_error_with_input_not_found_kind() {
@@ -30,8 +30,11 @@ async fn notes_generate_emits_job_error_with_input_not_found_kind() {
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
     let services = EngineServices::ready(
         Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
         Arc::new(TranscriptFileFake),
         Arc::new(KnownTurnsFake),
         Arc::new(FakeNotesExporter),

--- a/crates/panops-engine/tests/ipc_meeting_delete_removes_row_and_dir.rs
+++ b/crates/panops-engine/tests/ipc_meeting_delete_removes_row_and_dir.rs
@@ -1,0 +1,131 @@
+//! Slice 06 — `ipc.meeting.delete` removes the registry row, cascades
+//! the `note` rows via FK, and removes the on-disk meeting directory.
+//! Unknown id surfaces as `InputNotFound`.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::{ClientT, Error as ClientError};
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_core::storage::NoteDraft;
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_removes_row_dir_and_cascades_notes() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir.clone(),
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let id: String = ClientT::request(&client, "ipc.meeting.start", rpc_params![json!({})])
+        .await
+        .expect("start");
+
+    // Insert a note via storage directly so we can verify cascade.
+    storage
+        .create_note(NoteDraft {
+            id: "n1".into(),
+            meeting_id: id.clone(),
+            dialect: "basic".into(),
+            content_md: "# x".into(),
+            primary_path: "/tmp/x".into(),
+        })
+        .unwrap();
+
+    let meeting_dir = data_dir.join("meetings").join(&id);
+    assert!(meeting_dir.exists());
+
+    let _: () = ClientT::request(
+        &client,
+        "ipc.meeting.delete",
+        rpc_params![json!({"id":id.clone()})],
+    )
+    .await
+    .expect("delete");
+
+    // Row gone.
+    assert!(storage.get_meeting(&id).is_err());
+    // Notes gone (FK cascade in real impl; manual filter in fake).
+    assert!(storage.list_notes_for_meeting(&id).unwrap().is_empty());
+    // Directory gone.
+    assert!(
+        !meeting_dir.exists(),
+        "dir should be gone, found: {meeting_dir:?}"
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_unknown_id_is_input_not_found() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let err = ClientT::request::<(), _>(
+        &client,
+        "ipc.meeting.delete",
+        rpc_params![json!({"id":"nope"})],
+    )
+    .await
+    .expect_err("unknown id must error");
+
+    let ClientError::Call(call_err) = err else {
+        panic!("expected Call error, got {err:?}");
+    };
+    let data: serde_json::Value =
+        serde_json::from_str(call_err.data().unwrap().get()).expect("data is JSON");
+    assert_eq!(data["kind"], "input_not_found");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_meeting_get_returns_full.rs
+++ b/crates/panops-engine/tests/ipc_meeting_get_returns_full.rs
@@ -1,0 +1,118 @@
+//! Slice 06 — `ipc.meeting.get` returns the full `Meeting` shape
+//! (including `dir_path` and `language`). Unknown id surfaces as
+//! `InputNotFound` over the wire.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::{ClientT, Error as ClientError};
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::Meeting;
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_get_returns_all_fields() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"X","language":"es"})],
+    )
+    .await
+    .expect("start");
+
+    let m: Meeting = ClientT::request(
+        &client,
+        "ipc.meeting.get",
+        rpc_params![json!({"id":id.clone()})],
+    )
+    .await
+    .expect("get");
+
+    assert_eq!(m.id, id);
+    assert_eq!(m.title, "X");
+    assert_eq!(m.language, "es");
+    assert!(m.ended_at.is_none());
+    assert!(m.duration_ms.is_none());
+    assert!(m.dir_path.contains("/meetings/"));
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_get_unknown_id_is_input_not_found() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let err = ClientT::request::<Meeting, _>(
+        &client,
+        "ipc.meeting.get",
+        rpc_params![json!({"id":"nope"})],
+    )
+    .await
+    .expect_err("unknown id must error");
+
+    let ClientError::Call(call_err) = err else {
+        panic!("expected Call error, got {err:?}");
+    };
+    let data: serde_json::Value =
+        serde_json::from_str(call_err.data().unwrap().get()).expect("data is JSON");
+    assert_eq!(data["kind"], "input_not_found");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_meeting_list_returns_empty.rs
+++ b/crates/panops-engine/tests/ipc_meeting_list_returns_empty.rs
@@ -14,7 +14,7 @@ use panops_protocol::MeetingSummary;
 use tempfile::tempdir;
 use tokio::sync::watch;
 
-use common::{uds_ws_client, wait_for_socket};
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn meeting_list_returns_empty_array() {
@@ -22,8 +22,11 @@ async fn meeting_list_returns_empty_array() {
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
     let services = EngineServices::ready(
         Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
         Arc::new(TranscriptFileFake),
         Arc::new(KnownTurnsFake),
         Arc::new(FakeNotesExporter),

--- a/crates/panops-engine/tests/ipc_meeting_list_returns_inserted_rows.rs
+++ b/crates/panops-engine/tests/ipc_meeting_list_returns_inserted_rows.rs
@@ -1,0 +1,88 @@
+//! Slice 06 — `ipc.meeting.list` returns the rows in storage.
+//! The slice-05 `ipc_meeting_list_returns_empty` still covers the
+//! empty case (storage starts empty in that test); this one inserts
+//! via the `Storage` port directly (since `meeting.start` is a later
+//! task) and asserts the row surfaces over IPC.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_core::storage::MeetingDraft;
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::MeetingSummary;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_list_returns_rows_inserted_via_storage() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+
+    // Insert two meetings BEFORE starting the server. Order matters:
+    // started_at DESC, so "B" (later) should come first.
+    storage
+        .create_meeting(MeetingDraft {
+            id: "a".into(),
+            title: "A".into(),
+            started_at: "2026-05-01T10:00:00+00:00".into(),
+            language: "en".into(),
+            dir_path: data_dir.join("meetings/a").to_string_lossy().into_owned(),
+        })
+        .unwrap();
+    storage
+        .create_meeting(MeetingDraft {
+            id: "b".into(),
+            title: "B".into(),
+            started_at: "2026-05-03T10:00:00+00:00".into(),
+            language: "en".into(),
+            dir_path: data_dir.join("meetings/b").to_string_lossy().into_owned(),
+        })
+        .unwrap();
+
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let result: Vec<MeetingSummary> = ClientT::request(&client, "ipc.meeting.list", rpc_params![])
+        .await
+        .expect("call meeting.list");
+
+    assert_eq!(result.len(), 2, "expected two rows, got {result:?}");
+    // Order is started_at DESC: B (2026-05-03) before A (2026-05-01).
+    assert_eq!(result[0].id, "b");
+    assert_eq!(result[0].title, "B");
+    assert_eq!(result[1].id, "a");
+    assert_eq!(result[1].title, "A");
+    // In-progress meetings render duration_ms as 0 (not Option<u64>).
+    assert_eq!(result[0].duration_ms, 0);
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_meeting_set_language_persists.rs
+++ b/crates/panops-engine/tests/ipc_meeting_set_language_persists.rs
@@ -1,4 +1,5 @@
-//! Slice 05 — calling an unknown method returns JSON-RPC error code -32601.
+//! Slice 06 — `ipc.meeting.set_language` updates the row and the
+//! change survives a re-fetch.
 
 mod common;
 
@@ -10,13 +11,15 @@ use panops_core::conformance::fakes::{
     FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
 };
 use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::Meeting;
+use serde_json::json;
 use tempfile::tempdir;
 use tokio::sync::watch;
 
 use common::{tempdir_storage, uds_ws_client, wait_for_socket};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn unknown_method_returns_method_not_found() {
+async fn set_language_updates_row() {
     let dir = tempdir().unwrap();
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -24,7 +27,7 @@ async fn unknown_method_returns_method_not_found() {
     let (_storage_tmp, storage, data_dir) = tempdir_storage();
     let services = EngineServices::ready(
         Arc::new(MockLlm::default()),
-        storage,
+        storage.clone(),
         data_dir,
         Arc::new(TranscriptFileFake),
         Arc::new(KnownTurnsFake),
@@ -38,21 +41,30 @@ async fn unknown_method_returns_method_not_found() {
             .await
             .unwrap();
     });
-
     wait_for_socket(&socket).await;
 
     let client = uds_ws_client(&socket).await;
-    let err = ClientT::request::<serde_json::Value, _>(&client, "ipc.foo.bar", rpc_params![])
-        .await
-        .expect_err("foo.bar must error");
+    let id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"language":"en"})],
+    )
+    .await
+    .expect("start");
 
-    let msg = format!("{err:?}");
-    assert!(
-        msg.contains("Method not found")
-            || msg.contains("-32601")
-            || msg.contains("MethodNotFound"),
-        "expected method-not-found error, got: {msg}"
-    );
+    let updated: Meeting = ClientT::request(
+        &client,
+        "ipc.meeting.set_language",
+        rpc_params![json!({"id":id.clone(),"language":"es"})],
+    )
+    .await
+    .expect("set_language");
+
+    assert_eq!(updated.language, "es");
+
+    // Round-trip via storage too.
+    let row = storage.get_meeting(&id).unwrap();
+    assert_eq!(row.language, "es");
 
     let _ = shutdown_tx.send(true);
     let _ = server.await;

--- a/crates/panops-engine/tests/ipc_meeting_start_creates_row_and_dir.rs
+++ b/crates/panops-engine/tests/ipc_meeting_start_creates_row_and_dir.rs
@@ -1,0 +1,115 @@
+//! Slice 06 — `ipc.meeting.start` creates a meeting row, an on-disk
+//! directory, and a `screenshots/` subdir. Returns the new id as a
+//! plain string. Data-plane only (no capture coupling); Anchor B
+//! layers ScreenCaptureKit on top.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_start_creates_row_directory_and_screenshots_subdir() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir.clone(),
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Daily","language":"en"})],
+    )
+    .await
+    .expect("call meeting.start");
+
+    assert!(!id.is_empty(), "id should be non-empty");
+
+    // Row exists with the right title + language; started_at server-set.
+    let m = storage.get_meeting(&id).expect("row should exist");
+    assert_eq!(m.title, "Daily");
+    assert_eq!(m.language, "en");
+    assert!(m.ended_at.is_none());
+    assert!(!m.started_at.is_empty(), "started_at server-set");
+
+    // Filesystem layout.
+    let meeting_dir = data_dir.join("meetings").join(&id);
+    assert!(
+        meeting_dir.exists(),
+        "meeting dir should exist: {meeting_dir:?}"
+    );
+    assert!(
+        meeting_dir.join("screenshots").exists(),
+        "screenshots subdir should exist"
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_start_with_empty_config_uses_defaults() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let id: String = ClientT::request(&client, "ipc.meeting.start", rpc_params![json!({})])
+        .await
+        .expect("call meeting.start with empty config");
+    let m = storage.get_meeting(&id).unwrap();
+    assert_eq!(m.title, "", "default title is empty string");
+    assert_eq!(m.language, "auto", "default language is 'auto'");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_meeting_stop_writes_ended_at.rs
+++ b/crates/panops-engine/tests/ipc_meeting_stop_writes_ended_at.rs
@@ -1,0 +1,125 @@
+//! Slice 06 — `ipc.meeting.stop` sets `ended_at` and computes
+//! `duration_ms = ended_at - started_at`. Returns the updated row.
+//! Unknown id surfaces as `InputNotFound` over the wire.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::core::client::Error as ClientError;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::Meeting;
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_stop_sets_ended_at_and_duration() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"X"})],
+    )
+    .await
+    .expect("start");
+
+    // Brief sleep so duration_ms is observably > 0.
+    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+
+    let stopped: Meeting =
+        ClientT::request(&client, "ipc.meeting.stop", rpc_params![json!({"id":id})])
+            .await
+            .expect("stop");
+
+    assert_eq!(stopped.id, id);
+    assert!(stopped.ended_at.is_some(), "ended_at should be set");
+    let dur = stopped.duration_ms.expect("duration_ms set");
+    assert!(dur >= 50, "expected >=50ms, got {dur}");
+
+    // Round-trip via storage.
+    let row = storage.get_meeting(&id).unwrap();
+    assert!(row.ended_at.is_some());
+    assert!(row.duration_ms.unwrap() >= 50);
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_stop_unknown_id_is_input_not_found() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let err = ClientT::request::<Meeting, _>(
+        &client,
+        "ipc.meeting.stop",
+        rpc_params![json!({"id":"nope"})],
+    )
+    .await
+    .expect_err("unknown id must error");
+
+    let ClientError::Call(call_err) = err else {
+        panic!("expected Call error, got {err:?}");
+    };
+    let data: serde_json::Value =
+        serde_json::from_str(call_err.data().unwrap().get()).expect("error data is JSON");
+    assert_eq!(
+        data["kind"], "input_not_found",
+        "expected InputNotFound kind, got {data}"
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
@@ -1,0 +1,108 @@
+//! Slice 06 — `notes.generate` with no `meeting_id` auto-creates a
+//! meeting in the registry and writes notes into the canonical
+//! `<data_dir>/meetings/<id>/` layout.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::rpc_params;
+use panops_engine::server::run_serve_in_process;
+use panops_protocol::{Event, JobAccepted};
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::notes_pipeline::build_deterministic_notes_services;
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn notes_generate_without_meeting_id_auto_creates_one() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let audio_dir = tempdir().unwrap();
+    let audio_path = audio_dir.path().join("multi_speaker_60s.wav");
+    std::fs::write(&audio_path, b"placeholder").unwrap();
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = build_deterministic_notes_services(Arc::clone(&storage), data_dir.clone());
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    // Subscribe FIRST so we don't race the broadcast.
+    let mut subscription: Subscription<Event> = SubscriptionClientT::subscribe(
+        &client,
+        "ipc.events.subscribe",
+        rpc_params![],
+        "ipc.events.unsubscribe",
+    )
+    .await
+    .expect("subscribe to events");
+
+    let _accepted: JobAccepted = ClientT::request(
+        &client,
+        "ipc.notes.generate",
+        rpc_params![serde_json::json!({
+            "audio": audio_path.to_string_lossy(),
+            "dialect": "basic",
+        })],
+    )
+    .await
+    .expect("call notes.generate");
+
+    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
+        .await
+        .expect("event arrived within 60s")
+        .expect("subscription not closed")
+        .expect("event payload deserialised");
+
+    let (primary_file, meeting_id) = match event {
+        Event::JobDone(d) => (PathBuf::from(d.result.primary_file), d.result.meeting_id),
+        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
+        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+    };
+
+    assert!(
+        primary_file.exists(),
+        "primary_file does not exist: {primary_file:?}"
+    );
+    assert!(!meeting_id.is_empty(), "meeting_id should be set");
+
+    // Verify meeting actually exists in storage and the registry has
+    // exactly one row (the auto-created one).
+    let m = storage.get_meeting(&meeting_id).expect("row exists");
+    assert!(
+        m.dir_path.contains("/meetings/"),
+        "dir_path should be canonical: {}",
+        m.dir_path
+    );
+    let list = storage.list_meetings().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].id, meeting_id);
+
+    // Note row attached.
+    let notes = storage.list_notes_for_meeting(&meeting_id).unwrap();
+    assert_eq!(notes.len(), 1);
+
+    // Output went into the canonical meeting dir.
+    assert!(
+        primary_file.starts_with(data_dir.join("meetings").join(&meeting_id)),
+        "primary_file {primary_file:?} should live under canonical meeting dir"
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
@@ -2,179 +2,25 @@
 //! the pipeline on the blocking pool, and surfaces `Event::JobDone`
 //! on `events.subscribe`.
 //!
-//! ASR/diar are deterministic inline fakes (not the sidecar-file fakes
-//! in `panops-core::conformance::fakes`) because the slice-04 golden
-//! prompt fingerprints depend on the EXACT 3-segment shape used in
-//! `regenerate_multi_speaker_60s_goldens`. `TranscriptFileFake` would
-//! return one segment covering the whole audio, which mismatches the
-//! `MockLlm` fingerprint and panics. The inline fakes echo the same
-//! segments / turns the regen test uses, so the section + frontmatter
-//! prompts hash identically.
+//! Deterministic ASR / diar / MockLlm wiring lives in
+//! `tests/common/notes_pipeline.rs` (shared with the slice-06
+//! `ipc_notes_generate_*` tests so we don't carry parallel copies of
+//! the golden segments + prompt fingerprints).
 
 mod common;
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
 use jsonrpsee::rpc_params;
-use panops_core::asr::{AsrError, AsrProvider};
-use panops_core::conformance::fakes::MockLlm;
-use panops_core::diar::{DiarError, Diarizer, SpeakerTurn};
-use panops_core::llm::LlmResponse;
-use panops_core::notes::dialect::MarkdownDialect;
-use panops_core::notes::prompts::{
-    SectionSummary, build_frontmatter_prompt, build_section_narrative_prompt,
-};
-use panops_core::{Segment, Transcript};
-use panops_engine::server::{EngineServices, run_serve_in_process};
-use panops_portable::markdown_exporter::MarkdownExporter;
+use panops_engine::server::run_serve_in_process;
 use panops_protocol::{Event, JobAccepted};
 use tempfile::tempdir;
 use tokio::sync::watch;
 
+use common::notes_pipeline::build_deterministic_notes_services;
 use common::{tempdir_storage, uds_ws_client, wait_for_socket};
-
-/// Returns the same 3 segments the slice-04 golden regen uses, so the
-/// `MockLlm` prompt fingerprint matches verbatim.
-fn golden_segments() -> Vec<Segment> {
-    vec![
-        Segment {
-            start_ms: 0,
-            end_ms: 20_000,
-            text: "Welcome to this meeting. Let's go over the agenda for today. \
-                   We have several important items to discuss in the next sixty minutes together."
-                .into(),
-            language_detected: Some("en".into()),
-            confidence: 1.0,
-            is_partial: false,
-            speaker_id: Some(0),
-        },
-        Segment {
-            start_ms: 20_000,
-            end_ms: 40_000,
-            text: "Thanks for the introduction. The first item is the budget review for next quarter. \
-                   We need to approve the spending plan before the end of this week."
-                .into(),
-            language_detected: Some("en".into()),
-            confidence: 1.0,
-            is_partial: false,
-            speaker_id: Some(1),
-        },
-        Segment {
-            start_ms: 40_000,
-            end_ms: 60_000,
-            text: "Right. I'll start with the marketing line items, then move to engineering, \
-                   and finally we will cover any remaining operations expenses for the team."
-                .into(),
-            language_detected: Some("en".into()),
-            confidence: 1.0,
-            is_partial: false,
-            speaker_id: Some(0),
-        },
-    ]
-}
-
-/// Inline ASR fake that returns the golden segments verbatim. Speaker
-/// IDs are already set, so the diar merge below is effectively a no-op
-/// (turns map 1:1 to speakers already in the segments).
-struct DeterministicAsr;
-
-impl AsrProvider for DeterministicAsr {
-    fn transcribe_full(
-        &self,
-        audio_path: &Path,
-        _language_hint: Option<&str>,
-    ) -> Result<Transcript, AsrError> {
-        Ok(Transcript {
-            schema_version: Transcript::SCHEMA_VERSION,
-            model: "deterministic-asr".into(),
-            audio_path: audio_path.to_path_buf(),
-            audio_duration_ms: 60_000,
-            diarized: false,
-            segments: golden_segments(),
-        })
-    }
-
-    fn is_fake(&self) -> bool {
-        true
-    }
-}
-
-/// Inline diar fake matching `multi_speaker_60s.turns.json`. Returns
-/// turns aligned exactly with the segment boundaries above so
-/// `merge_speaker_turns` doesn't reshape segments.
-struct DeterministicDiar;
-
-impl Diarizer for DeterministicDiar {
-    fn diarize(&self, _audio_path: &Path) -> Result<Vec<SpeakerTurn>, DiarError> {
-        Ok(vec![
-            SpeakerTurn {
-                start_ms: 0,
-                end_ms: 20_000,
-                speaker_id: 0,
-            },
-            SpeakerTurn {
-                start_ms: 20_000,
-                end_ms: 40_000,
-                speaker_id: 1,
-            },
-            SpeakerTurn {
-                start_ms: 40_000,
-                end_ms: 60_000,
-                speaker_id: 0,
-            },
-        ])
-    }
-
-    fn is_fake(&self) -> bool {
-        true
-    }
-}
-
-fn build_mock_llm(dialect: MarkdownDialect) -> MockLlm {
-    let segments = golden_segments();
-    // Match the regen test's canned section / frontmatter responses.
-    let canned_section = serde_json::json!({
-        "title": "Meeting kickoff and quarterly budget review",
-        "narrative_md": "The session opened with a welcome and a brief handoff \
-            into the agenda. The first agenda item framed the rest of the \
-            meeting, with the discussion organising the review into a clear \
-            sequence so each functional area would get its own slot.",
-        "key_points": [
-            "Budget review scoped to next quarter only",
-            "Review sequence: marketing, engineering, operations"
-        ],
-        "action_items": [
-            {"description": "Approve quarterly spending plan before end of week", "owner": null}
-        ]
-    });
-    let canned_fm = serde_json::json!({
-        "title": "Quarterly budget review kickoff",
-        "tags": ["budget-review", "quarterly", "kickoff"]
-    });
-    let summaries = vec![SectionSummary {
-        title: "Meeting kickoff and quarterly budget review".into(),
-        key_points: vec![
-            "Budget review scoped to next quarter only".into(),
-            "Review sequence: marketing, engineering, operations".into(),
-        ],
-    }];
-    let section_prompt = build_section_narrative_prompt(&segments, dialect, "en");
-    let frontmatter_prompt = build_frontmatter_prompt(&summaries, "en", 60_000);
-    MockLlm::default()
-        .with_response_for(
-            section_prompt.system.as_deref(),
-            &section_prompt.user,
-            LlmResponse::Json(canned_section),
-        )
-        .with_response_for(
-            frontmatter_prompt.system.as_deref(),
-            &frontmatter_prompt.user,
-            LlmResponse::Json(canned_fm),
-        )
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn notes_generate_round_trip_emits_job_done() {
@@ -191,14 +37,7 @@ async fn notes_generate_round_trip_emits_job_done() {
     std::fs::write(&audio_path, b"placeholder").unwrap();
 
     let (_storage_tmp, storage, data_dir) = tempdir_storage();
-    let services = EngineServices::ready(
-        Arc::new(build_mock_llm(MarkdownDialect::Basic)),
-        storage,
-        data_dir,
-        Arc::new(DeterministicAsr),
-        Arc::new(DeterministicDiar),
-        Arc::new(MarkdownExporter),
-    );
+    let services = build_deterministic_notes_services(storage, data_dir);
 
     let server_socket = socket.clone();
     let server_shutdown = shutdown_rx.clone();

--- a/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
@@ -1,0 +1,102 @@
+//! Slice 06 — `notes.generate` with an existing `meeting_id` attaches
+//! the generated note to that meeting and writes into its `dir_path`.
+//! No new meeting is auto-created.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::rpc_params;
+use panops_engine::server::run_serve_in_process;
+use panops_protocol::{Event, JobAccepted};
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::notes_pipeline::build_deterministic_notes_services;
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn notes_generate_with_existing_meeting_id_attaches_note() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let audio_dir = tempdir().unwrap();
+    let audio_path = audio_dir.path().join("multi_speaker_60s.wav");
+    std::fs::write(&audio_path, b"placeholder").unwrap();
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = build_deterministic_notes_services(Arc::clone(&storage), data_dir);
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    // Create meeting up front via meeting.start.
+    let meeting_id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![serde_json::json!({"title":"My Meeting"})],
+    )
+    .await
+    .expect("meeting.start");
+
+    let mut subscription: Subscription<Event> = SubscriptionClientT::subscribe(
+        &client,
+        "ipc.events.subscribe",
+        rpc_params![],
+        "ipc.events.unsubscribe",
+    )
+    .await
+    .expect("subscribe");
+
+    let _accepted: JobAccepted = ClientT::request(
+        &client,
+        "ipc.notes.generate",
+        rpc_params![serde_json::json!({
+            "audio": audio_path.to_string_lossy(),
+            "dialect": "basic",
+            "meeting_id": meeting_id.clone(),
+        })],
+    )
+    .await
+    .expect("notes.generate");
+
+    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
+        .await
+        .expect("event within 60s")
+        .expect("subscription open")
+        .expect("payload deserialises");
+
+    let result_meeting_id = match event {
+        Event::JobDone(d) => d.result.meeting_id,
+        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
+        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+    };
+
+    assert_eq!(
+        result_meeting_id, meeting_id,
+        "result.meeting_id should equal the supplied meeting_id"
+    );
+
+    // Note row attached to the supplied meeting.
+    let notes = storage.list_notes_for_meeting(&meeting_id).unwrap();
+    assert_eq!(notes.len(), 1, "exactly one note attached");
+    assert_eq!(notes[0].meeting_id, meeting_id);
+
+    // No second meeting was auto-created.
+    let list = storage.list_meetings().unwrap();
+    assert_eq!(list.len(), 1, "expected exactly one meeting");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
@@ -1,0 +1,92 @@
+//! Slice 06 — `notes.generate` with a `meeting_id` that doesn't exist
+//! surfaces an `InputNotFound` (the meeting lookup is the first thing
+//! the pipeline does after canonicalize, so the error arrives via
+//! `job.error` over the events subscription).
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::rpc_params;
+use panops_engine::server::run_serve_in_process;
+use panops_protocol::{Event, IpcError, JobAccepted};
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::notes_pipeline::build_deterministic_notes_services;
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn notes_generate_with_unknown_meeting_id_returns_input_not_found() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let audio_dir = tempdir().unwrap();
+    let audio_path = audio_dir.path().join("multi_speaker_60s.wav");
+    std::fs::write(&audio_path, b"placeholder").unwrap();
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = build_deterministic_notes_services(Arc::clone(&storage), data_dir);
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    let mut subscription: Subscription<Event> = SubscriptionClientT::subscribe(
+        &client,
+        "ipc.events.subscribe",
+        rpc_params![],
+        "ipc.events.unsubscribe",
+    )
+    .await
+    .expect("subscribe");
+
+    let _accepted: JobAccepted = ClientT::request(
+        &client,
+        "ipc.notes.generate",
+        rpc_params![serde_json::json!({
+            "audio": audio_path.to_string_lossy(),
+            "dialect": "basic",
+            "meeting_id": "unknown-meeting-id",
+        })],
+    )
+    .await
+    .expect("notes.generate accepts the request even for unknown id");
+
+    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
+        .await
+        .expect("event within 60s")
+        .expect("subscription open")
+        .expect("payload deserialises");
+
+    match event {
+        Event::JobError(e) => match e.error {
+            IpcError::InputNotFound { path } => {
+                assert!(
+                    path.contains("meeting"),
+                    "expected meeting in path, got: {path}"
+                );
+            }
+            other => panic!("expected InputNotFound, got {other:?}"),
+        },
+        Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d.result),
+        Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
+    }
+
+    // No meeting was created (the lookup failed before any side effects).
+    let list = storage.list_meetings().unwrap();
+    assert!(list.is_empty(), "no meetings should exist, got {list:?}");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_persistence_survives_restart.rs
+++ b/crates/panops-engine/tests/ipc_persistence_survives_restart.rs
@@ -1,0 +1,113 @@
+//! Slice 06 — meetings created in one server lifecycle are visible
+//! in the next. Uses `RusqliteStorage` (not the in-memory fake) so
+//! the on-disk DB actually has to persist.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_core::storage::Storage;
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_portable::rusqlite_storage::RusqliteStorage;
+use panops_protocol::MeetingSummary;
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meetings_created_in_one_session_visible_in_next() {
+    let data_tmp = tempdir().unwrap();
+    let data_dir = data_tmp.path().to_owned();
+    let socket_tmp = tempdir().unwrap();
+    let socket = socket_tmp.path().join("engine.sock");
+
+    // === Session A ===
+    {
+        let storage: Arc<dyn Storage> =
+            Arc::new(RusqliteStorage::new(&data_dir.join("panops.db")).unwrap());
+        let services = EngineServices::ready(
+            Arc::new(MockLlm::default()),
+            storage,
+            data_dir.clone(),
+            Arc::new(TranscriptFileFake),
+            Arc::new(KnownTurnsFake),
+            Arc::new(FakeNotesExporter),
+        );
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let server_socket = socket.clone();
+        let server = tokio::spawn(async move {
+            run_serve_in_process(&server_socket, services, Some(shutdown_rx))
+                .await
+                .unwrap();
+        });
+        wait_for_socket(&socket).await;
+
+        let client = uds_ws_client(&socket).await;
+        let _id: String = ClientT::request(
+            &client,
+            "ipc.meeting.start",
+            rpc_params![json!({"title":"Session A"})],
+        )
+        .await
+        .expect("session A start");
+
+        // Drop the client BEFORE shutdown so the WS task can finish
+        // cleanly; otherwise the server may wait on the still-open
+        // connection beyond shutdown.
+        drop(client);
+
+        let _ = shutdown_tx.send(true);
+        let _ = server.await;
+    }
+    // RusqliteStorage Arc dropped here; on-disk DB closed.
+
+    // === Session B ===
+    {
+        let storage: Arc<dyn Storage> = Arc::new(
+            RusqliteStorage::new(&data_dir.join("panops.db"))
+                .expect("re-open should succeed against existing DB at version 1"),
+        );
+        let services = EngineServices::ready(
+            Arc::new(MockLlm::default()),
+            storage,
+            data_dir.clone(),
+            Arc::new(TranscriptFileFake),
+            Arc::new(KnownTurnsFake),
+            Arc::new(FakeNotesExporter),
+        );
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let server_socket = socket.clone();
+        let server = tokio::spawn(async move {
+            run_serve_in_process(&server_socket, services, Some(shutdown_rx))
+                .await
+                .unwrap();
+        });
+        wait_for_socket(&socket).await;
+
+        let client = uds_ws_client(&socket).await;
+        let rows: Vec<MeetingSummary> =
+            ClientT::request(&client, "ipc.meeting.list", rpc_params![])
+                .await
+                .expect("session B list");
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "expected the meeting from session A to persist; got {rows:?}"
+        );
+        assert_eq!(rows[0].title, "Session A");
+
+        drop(client);
+        let _ = shutdown_tx.send(true);
+        let _ = server.await;
+    }
+}

--- a/crates/panops-portable/Cargo.toml
+++ b/crates/panops-portable/Cargo.toml
@@ -14,9 +14,11 @@ sherpa-rs = "0.6"
 hound = "3.5"
 directories = "6"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
 sha2 = "0.10"
 tar = "0.4"
 bzip2 = "0.6"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 genai = "=0.5.3"
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/panops-portable/src/lib.rs
+++ b/crates/panops-portable/src/lib.rs
@@ -4,11 +4,13 @@
 pub mod genai_llm;
 pub mod markdown_exporter;
 pub mod model;
+pub mod rusqlite_storage;
 
 mod sherpa_diarizer;
 mod whisper_adapter;
 
 pub use genai_llm::GenaiLlm;
 pub use markdown_exporter::MarkdownExporter;
+pub use rusqlite_storage::RusqliteStorage;
 pub use sherpa_diarizer::SherpaDiarizer;
 pub use whisper_adapter::WhisperRsAsr;

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -74,13 +74,7 @@ fn render_frontmatter(notes: &StructuredNotes) -> String {
         }
     }
     s.push_str(&format!("template: {}\n", yaml_scalar(&fm.template)));
-    s.push_str(&format!(
-        "dialect: {}\n",
-        match fm.dialect {
-            MarkdownDialect::NotionEnhanced => "notion-enhanced",
-            MarkdownDialect::Basic => "basic",
-        }
-    ));
+    s.push_str(&format!("dialect: {}\n", fm.dialect.as_str()));
     s.push_str(&format!(
         "panops_version: {}\n",
         yaml_scalar(&fm.panops_version)

--- a/crates/panops-portable/src/rusqlite_storage.rs
+++ b/crates/panops-portable/src/rusqlite_storage.rs
@@ -1,0 +1,337 @@
+//! `Storage` real adapter backed by `rusqlite` against a single
+//! SQLite file. Single-user local-first; one
+//! `Arc<Mutex<Connection>>` serializes all access. Per-meeting DB at
+//! `meetings/<uuid>/meeting.db` is deferred to Anchor B (live
+//! capture); for now everything lives in one registry DB.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use rusqlite::{Connection, OptionalExtension, params};
+
+use panops_core::storage::{
+    Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError,
+};
+
+const EXPECTED_SCHEMA_VERSION: u32 = 1;
+
+// `PRAGMA foreign_keys = ON` is set per-connection in `new()`, not in DDL —
+// the DDL `PRAGMA` would be redundant on a fresh DB and a no-op on re-open
+// (PRAGMAs aren't persisted in SQLite; they're connection-scoped).
+const DDL: &str = r"
+CREATE TABLE IF NOT EXISTS meeting (
+    id TEXT PRIMARY KEY NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    duration_ms INTEGER,
+    language TEXT NOT NULL DEFAULT 'auto',
+    dir_path TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_meeting_started_at ON meeting(started_at DESC);
+
+CREATE TABLE IF NOT EXISTS note (
+    id TEXT PRIMARY KEY NOT NULL,
+    meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE,
+    dialect TEXT NOT NULL,
+    content_md TEXT NOT NULL,
+    primary_path TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_meeting_id ON note(meeting_id);
+";
+
+pub struct RusqliteStorage {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl RusqliteStorage {
+    /// Open or create the DB at `path`. Runs DDL if the file is fresh
+    /// (`user_version = 0`) or already at the expected version.
+    /// Errors with `SchemaMismatch` if `user_version` is set but
+    /// doesn't match `EXPECTED_SCHEMA_VERSION`.
+    pub fn new(path: &Path) -> Result<Self, StorageError> {
+        let conn = Connection::open(path).map_err(StorageError::sql)?;
+        // Always enable FKs per-connection (rusqlite default is OFF).
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .map_err(StorageError::sql)?;
+
+        let actual: u32 = conn
+            .query_row("PRAGMA user_version;", [], |r| r.get::<_, u32>(0))
+            .map_err(StorageError::sql)?;
+
+        if actual == 0 {
+            conn.execute_batch(DDL).map_err(StorageError::sql)?;
+            conn.execute_batch(&format!("PRAGMA user_version = {EXPECTED_SCHEMA_VERSION};"))
+                .map_err(StorageError::sql)?;
+        } else if actual != EXPECTED_SCHEMA_VERSION {
+            return Err(StorageError::SchemaMismatch {
+                actual,
+                expected: EXPECTED_SCHEMA_VERSION,
+            });
+        }
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+}
+
+fn map_meeting_row(r: &rusqlite::Row) -> rusqlite::Result<Meeting> {
+    Ok(Meeting {
+        id: r.get(0)?,
+        title: r.get(1)?,
+        started_at: r.get(2)?,
+        ended_at: r.get(3)?,
+        duration_ms: r.get::<_, Option<i64>>(4)?.map(|v| v as u64),
+        language: r.get(5)?,
+        dir_path: r.get(6)?,
+    })
+}
+
+impl Storage for RusqliteStorage {
+    fn create_meeting(&self, d: MeetingDraft) -> Result<Meeting, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let result = conn.execute(
+            "INSERT INTO meeting (id, title, started_at, language, dir_path)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![d.id, d.title, d.started_at, d.language, d.dir_path],
+        );
+        match result {
+            Ok(_) => Ok(Meeting {
+                id: d.id,
+                title: d.title,
+                started_at: d.started_at,
+                ended_at: None,
+                duration_ms: None,
+                language: d.language,
+                dir_path: d.dir_path,
+            }),
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Err(StorageError::AlreadyExists {
+                    id: d.id,
+                    kind: "meeting",
+                })
+            }
+            Err(e) => Err(StorageError::sql(e)),
+        }
+    }
+
+    fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, title, started_at, ended_at, duration_ms, language, dir_path
+             FROM meeting WHERE id = ?1",
+            params![id],
+            map_meeting_row,
+        )
+        .optional()
+        .map_err(StorageError::sql)?
+        .ok_or_else(|| StorageError::NotFound {
+            id: id.into(),
+            kind: "meeting",
+        })
+    }
+
+    fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, title, started_at, COALESCE(duration_ms, 0)
+                 FROM meeting ORDER BY started_at DESC",
+            )
+            .map_err(StorageError::sql)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(MeetingSummary {
+                    id: r.get(0)?,
+                    title: r.get(1)?,
+                    started_at: r.get(2)?,
+                    duration_ms: r.get::<_, i64>(3)? as u64,
+                })
+            })
+            .map_err(StorageError::sql)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(StorageError::sql)?);
+        }
+        Ok(out)
+    }
+
+    fn update_meeting_ended(
+        &self,
+        id: &str,
+        ended_at: &str,
+        duration_ms: u64,
+    ) -> Result<Meeting, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute(
+                "UPDATE meeting SET ended_at = ?2, duration_ms = ?3 WHERE id = ?1",
+                params![id, ended_at, duration_ms as i64],
+            )
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            });
+        }
+        drop(conn);
+        self.get_meeting(id)
+    }
+
+    fn update_meeting_language(&self, id: &str, language: &str) -> Result<Meeting, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute(
+                "UPDATE meeting SET language = ?2 WHERE id = ?1",
+                params![id, language],
+            )
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            });
+        }
+        drop(conn);
+        self.get_meeting(id)
+    }
+
+    fn delete_meeting(&self, id: &str) -> Result<(), StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute("DELETE FROM meeting WHERE id = ?1", params![id])
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "meeting",
+            });
+        }
+        Ok(())
+    }
+
+    fn create_note(&self, d: NoteDraft) -> Result<Note, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        // FK guard: surface a friendly NotFound instead of a raw FK error.
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM meeting WHERE id = ?1",
+                params![d.meeting_id],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(StorageError::sql)?
+            .unwrap_or(false);
+        if !exists {
+            return Err(StorageError::NotFound {
+                id: d.meeting_id,
+                kind: "meeting",
+            });
+        }
+
+        let created_at = Utc::now().to_rfc3339();
+        let result = conn.execute(
+            "INSERT INTO note (id, meeting_id, dialect, content_md, primary_path, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                d.id,
+                d.meeting_id,
+                d.dialect,
+                d.content_md,
+                d.primary_path,
+                created_at
+            ],
+        );
+        match result {
+            Ok(_) => Ok(Note {
+                id: d.id,
+                meeting_id: d.meeting_id,
+                dialect: d.dialect,
+                content_md: d.content_md,
+                primary_path: d.primary_path,
+                created_at,
+            }),
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Err(StorageError::AlreadyExists {
+                    id: d.id,
+                    kind: "note",
+                })
+            }
+            Err(e) => Err(StorageError::sql(e)),
+        }
+    }
+
+    fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, meeting_id, dialect, content_md, primary_path, created_at
+                 FROM note WHERE meeting_id = ?1 ORDER BY created_at ASC",
+            )
+            .map_err(StorageError::sql)?;
+        let rows = stmt
+            .query_map(params![meeting_id], |r| {
+                Ok(Note {
+                    id: r.get(0)?,
+                    meeting_id: r.get(1)?,
+                    dialect: r.get(2)?,
+                    content_md: r.get(3)?,
+                    primary_path: r.get(4)?,
+                    created_at: r.get(5)?,
+                })
+            })
+            .map_err(StorageError::sql)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(StorageError::sql)?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_db_initialises_schema_and_sets_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("panops.db");
+        let _ = RusqliteStorage::new(&db).expect("open fresh");
+        let conn = Connection::open(&db).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version;", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, EXPECTED_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn second_open_does_not_re_run_ddl() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("panops.db");
+        let _ = RusqliteStorage::new(&db).unwrap();
+        // Insert a row, then re-open and confirm it survived.
+        {
+            let conn = Connection::open(&db).unwrap();
+            conn.execute(
+                "INSERT INTO meeting (id, title, started_at, dir_path)
+                 VALUES ('a', 'A', '2026-05-05T10:00:00+00:00', '/tmp/a')",
+                [],
+            )
+            .unwrap();
+        }
+        let storage = RusqliteStorage::new(&db).unwrap();
+        let m = storage.get_meeting("a").unwrap();
+        assert_eq!(m.id, "a");
+    }
+}

--- a/crates/panops-portable/src/rusqlite_storage.rs
+++ b/crates/panops-portable/src/rusqlite_storage.rs
@@ -305,7 +305,9 @@ impl Storage for RusqliteStorage {
                     id: r.get(0)?,
                     title: r.get(1)?,
                     started_at: r.get(2)?,
-                    duration_ms: r.get::<_, i64>(3)? as u64,
+                    // Clamp negative durations to 0 (same defense as
+                    // `map_meeting_row` — the DB file is not trusted).
+                    duration_ms: r.get::<_, i64>(3)?.max(0) as u64,
                 })
             })
             .map_err(StorageError::sql)?;

--- a/crates/panops-portable/src/rusqlite_storage.rs
+++ b/crates/panops-portable/src/rusqlite_storage.rs
@@ -5,7 +5,7 @@
 //! capture); for now everything lives in one registry DB.
 
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use chrono::Utc;
 use rusqlite::{Connection, OptionalExtension, params};
@@ -13,6 +13,50 @@ use rusqlite::{Connection, OptionalExtension, params};
 use panops_core::storage::{
     Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError,
 };
+
+/// Lock the connection mutex, mapping a poisoned mutex to a
+/// `StorageError::Sql` instead of panicking. A poisoned mutex
+/// indicates a panic happened in another storage call (rare, since
+/// our calls are short rusqlite operations) — surfacing it as a
+/// recoverable storage error is friendlier to long-running callers
+/// than tearing down the whole server with another panic.
+fn lock<'a>(m: &'a Mutex<Connection>) -> Result<MutexGuard<'a, Connection>, StorageError> {
+    m.lock().map_err(|e| StorageError::Sql {
+        message: format!("storage mutex poisoned: {e}"),
+    })
+}
+
+/// Inspect a rusqlite SqliteFailure on `meeting` insert and choose
+/// the right `StorageError` variant. PK collision (`meeting.id`) maps
+/// to `AlreadyExists`; the secondary `dir_path` UNIQUE collision maps
+/// to `UniqueConflict { field: "dir_path", value }` so callers don't
+/// receive a misleading id-already-exists error when the actual
+/// conflict was on a different column.
+fn map_meeting_constraint_violation(
+    err: rusqlite::Error,
+    draft_id: &str,
+    draft_dir_path: &str,
+) -> StorageError {
+    if let rusqlite::Error::SqliteFailure(_, Some(ref msg)) = err {
+        // libsqlite encodes the constraint name in the message:
+        //   "UNIQUE constraint failed: meeting.id"
+        //   "UNIQUE constraint failed: meeting.dir_path"
+        if msg.contains("meeting.dir_path") {
+            return StorageError::UniqueConflict {
+                kind: "meeting",
+                field: "dir_path",
+                value: draft_dir_path.to_string(),
+            };
+        }
+        if msg.contains("meeting.id") {
+            return StorageError::AlreadyExists {
+                id: draft_id.to_string(),
+                kind: "meeting",
+            };
+        }
+    }
+    StorageError::sql(err)
+}
 
 const EXPECTED_SCHEMA_VERSION: u32 = 1;
 
@@ -86,7 +130,16 @@ fn map_meeting_row(r: &rusqlite::Row) -> rusqlite::Result<Meeting> {
         title: r.get(1)?,
         started_at: r.get(2)?,
         ended_at: r.get(3)?,
-        duration_ms: r.get::<_, Option<i64>>(4)?.map(|v| v as u64),
+        // Clamp negative durations to 0. SQLite stores `INTEGER` as
+        // signed i64; a negative value (corruption, manual edit) cast
+        // straight to u64 would wrap to ~9 quintillion ms and
+        // surface as a nonsensical wire value. Clamping is the
+        // conservative read-side defense; insert-side validation
+        // would also reject negatives before storage but read-side
+        // doesn't trust the database file.
+        duration_ms: r
+            .get::<_, Option<i64>>(4)?
+            .map(|v| if v < 0 { 0 } else { v as u64 }),
         language: r.get(5)?,
         dir_path: r.get(6)?,
     })
@@ -94,7 +147,7 @@ fn map_meeting_row(r: &rusqlite::Row) -> rusqlite::Result<Meeting> {
 
 impl Storage for RusqliteStorage {
     fn create_meeting(&self, d: MeetingDraft) -> Result<Meeting, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let result = conn.execute(
             "INSERT INTO meeting (id, title, started_at, language, dir_path)
              VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -110,20 +163,120 @@ impl Storage for RusqliteStorage {
                 language: d.language,
                 dir_path: d.dir_path,
             }),
-            Err(rusqlite::Error::SqliteFailure(e, _))
+            Err(rusqlite::Error::SqliteFailure(e, ref msg))
                 if e.code == rusqlite::ErrorCode::ConstraintViolation =>
             {
-                Err(StorageError::AlreadyExists {
-                    id: d.id,
-                    kind: "meeting",
-                })
+                Err(map_meeting_constraint_violation(
+                    rusqlite::Error::SqliteFailure(e, msg.clone()),
+                    &d.id,
+                    &d.dir_path,
+                ))
             }
             Err(e) => Err(StorageError::sql(e)),
         }
     }
 
+    fn create_meeting_with_note(
+        &self,
+        meeting: MeetingDraft,
+        note: NoteDraft,
+        ended_at: Option<&str>,
+        duration_ms: Option<u64>,
+    ) -> Result<(Meeting, Note), StorageError> {
+        if note.meeting_id != meeting.id {
+            return Err(StorageError::Sql {
+                message: "create_meeting_with_note: note.meeting_id must match meeting.id".into(),
+            });
+        }
+        let mut conn = lock(&self.conn)?;
+        let tx = conn.transaction().map_err(StorageError::sql)?;
+
+        // Meeting insert (with optional ended_at + duration_ms in one shot).
+        let dur_i64 = duration_ms.map(|v| v as i64);
+        let result = tx.execute(
+            "INSERT INTO meeting
+                (id, title, started_at, ended_at, duration_ms, language, dir_path)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                meeting.id,
+                meeting.title,
+                meeting.started_at,
+                ended_at,
+                dur_i64,
+                meeting.language,
+                meeting.dir_path
+            ],
+        );
+        if let Err(e) = result {
+            return Err(match e {
+                rusqlite::Error::SqliteFailure(c, ref m)
+                    if c.code == rusqlite::ErrorCode::ConstraintViolation =>
+                {
+                    map_meeting_constraint_violation(
+                        rusqlite::Error::SqliteFailure(c, m.clone()),
+                        &meeting.id,
+                        &meeting.dir_path,
+                    )
+                }
+                other => StorageError::sql(other),
+            });
+        }
+
+        // Note insert. FK on `meeting_id` references the row we just
+        // inserted in this transaction; it'll resolve before COMMIT.
+        let created_at = Utc::now().to_rfc3339();
+        let note_result = tx.execute(
+            "INSERT INTO note (id, meeting_id, dialect, content_md, primary_path, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                note.id,
+                note.meeting_id,
+                note.dialect,
+                note.content_md,
+                note.primary_path,
+                created_at
+            ],
+        );
+        if let Err(e) = note_result {
+            // Transaction will roll back on drop (we don't COMMIT).
+            return Err(match e {
+                rusqlite::Error::SqliteFailure(c, _)
+                    if c.code == rusqlite::ErrorCode::ConstraintViolation =>
+                {
+                    StorageError::AlreadyExists {
+                        id: note.id,
+                        kind: "note",
+                    }
+                }
+                other => StorageError::sql(other),
+            });
+        }
+
+        tx.commit().map_err(StorageError::sql)?;
+
+        Ok((
+            Meeting {
+                id: meeting.id,
+                title: meeting.title,
+                started_at: meeting.started_at,
+                ended_at: ended_at.map(str::to_owned),
+                duration_ms,
+                language: meeting.language,
+                dir_path: meeting.dir_path,
+            },
+            Note {
+                id: note.id,
+                meeting_id: note.meeting_id,
+                dialect: note.dialect,
+                content_md: note.content_md,
+                primary_path: note.primary_path,
+                created_at,
+            },
+        ))
+    }
+
     fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         conn.query_row(
             "SELECT id, title, started_at, ended_at, duration_ms, language, dir_path
              FROM meeting WHERE id = ?1",
@@ -139,7 +292,7 @@ impl Storage for RusqliteStorage {
     }
 
     fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let mut stmt = conn
             .prepare(
                 "SELECT id, title, started_at, COALESCE(duration_ms, 0)
@@ -169,7 +322,7 @@ impl Storage for RusqliteStorage {
         ended_at: &str,
         duration_ms: u64,
     ) -> Result<Meeting, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let n = conn
             .execute(
                 "UPDATE meeting SET ended_at = ?2, duration_ms = ?3 WHERE id = ?1",
@@ -187,7 +340,7 @@ impl Storage for RusqliteStorage {
     }
 
     fn update_meeting_language(&self, id: &str, language: &str) -> Result<Meeting, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let n = conn
             .execute(
                 "UPDATE meeting SET language = ?2 WHERE id = ?1",
@@ -205,7 +358,7 @@ impl Storage for RusqliteStorage {
     }
 
     fn delete_meeting(&self, id: &str) -> Result<(), StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let n = conn
             .execute("DELETE FROM meeting WHERE id = ?1", params![id])
             .map_err(StorageError::sql)?;
@@ -219,7 +372,7 @@ impl Storage for RusqliteStorage {
     }
 
     fn create_note(&self, d: NoteDraft) -> Result<Note, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         // FK guard: surface a friendly NotFound instead of a raw FK error.
         let exists: bool = conn
             .query_row(
@@ -272,7 +425,7 @@ impl Storage for RusqliteStorage {
     }
 
     fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = lock(&self.conn)?;
         let mut stmt = conn
             .prepare(
                 "SELECT id, meeting_id, dialect, content_md, primary_path, created_at

--- a/crates/panops-portable/tests/conformance_rusqlite_storage.rs
+++ b/crates/panops-portable/tests/conformance_rusqlite_storage.rs
@@ -1,0 +1,30 @@
+//! `RusqliteStorage` must pass the same `Storage` conformance suite
+//! the fake passes.
+
+use panops_core::conformance::storage::run_suite;
+use panops_portable::rusqlite_storage::RusqliteStorage;
+
+#[test]
+fn rusqlite_storage_passes_conformance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("panops.db");
+    let storage = RusqliteStorage::new(&db).expect("open fresh DB");
+    run_suite(&storage);
+}
+
+#[test]
+fn rusqlite_storage_rejects_unknown_schema_version() {
+    use rusqlite::Connection;
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("panops.db");
+    {
+        let conn = Connection::open(&db).unwrap();
+        // Pretend a future version wrote this DB.
+        conn.execute_batch("PRAGMA user_version = 999;").unwrap();
+    }
+    let result = RusqliteStorage::new(&db);
+    match result {
+        Ok(_) => panic!("future version should be rejected"),
+        Err(e) => assert!(format!("{e}").contains("schema mismatch"), "got: {e}"),
+    }
+}

--- a/crates/panops-protocol/src/error.rs
+++ b/crates/panops-protocol/src/error.rs
@@ -103,6 +103,7 @@ mod from_domain {
     use panops_core::exporter::ExportError;
     use panops_core::llm::LlmError;
     use panops_core::notes::error::NotesError;
+    use panops_core::storage::StorageError;
 
     impl From<AsrError> for IpcError {
         fn from(e: AsrError) -> Self {
@@ -186,6 +187,37 @@ mod from_domain {
                 // emitted via `tracing::error!` at the call site.
                 ExportError::Io(_) | ExportError::Render(_) => IpcError::Internal {
                     message: "export failed".into(),
+                },
+            }
+        }
+    }
+
+    impl From<StorageError> for IpcError {
+        fn from(e: StorageError) -> Self {
+            match e {
+                // `path` carries `<kind>/<id>` so clients can tell which
+                // entity was missing. `kind` is a `&'static` from a
+                // closed set ("meeting" | "note"); the id was the input
+                // they just passed, so this is not a new info leak.
+                StorageError::NotFound { id, kind } => IpcError::InputNotFound {
+                    path: format!("{kind}/{id}"),
+                },
+                StorageError::AlreadyExists { kind, .. } => IpcError::InvalidInput {
+                    message: format!("{kind} already exists"),
+                },
+                // Internal-state conditions: the wire stays opaque so
+                // version numbers / SQL fragments / FS paths never reach
+                // the client. Full detail is logged at the call site
+                // (handlers.rs) where `tracing` is available — this
+                // crate is `tracing`-free to keep transport types thin.
+                StorageError::SchemaMismatch { .. } => IpcError::Internal {
+                    message: "storage schema mismatch".into(),
+                },
+                StorageError::Io { .. } => IpcError::Internal {
+                    message: "storage io error".into(),
+                },
+                StorageError::Sql { .. } => IpcError::Internal {
+                    message: "storage error".into(),
                 },
             }
         }
@@ -344,5 +376,76 @@ mod from_domain_tests {
         } else {
             panic!("expected InvalidInput");
         }
+    }
+
+    use panops_core::storage::StorageError;
+
+    #[test]
+    fn storage_not_found_maps_to_input_not_found_with_kind_and_id() {
+        let e: IpcError = StorageError::NotFound {
+            id: "abc".into(),
+            kind: "meeting",
+        }
+        .into();
+        let IpcError::InputNotFound { path } = e else {
+            panic!("expected InputNotFound");
+        };
+        assert!(path.contains("meeting"), "got: {path}");
+        assert!(path.contains("abc"), "got: {path}");
+    }
+
+    #[test]
+    fn storage_already_exists_maps_to_invalid_input_without_id_leak() {
+        let e: IpcError = StorageError::AlreadyExists {
+            id: "secret-id-do-not-leak".into(),
+            kind: "note",
+        }
+        .into();
+        let IpcError::InvalidInput { message } = e else {
+            panic!("expected InvalidInput");
+        };
+        assert!(message.contains("note"), "got: {message}");
+        assert!(
+            !message.contains("secret-id-do-not-leak"),
+            "id leaked: {message}"
+        );
+    }
+
+    #[test]
+    fn storage_schema_mismatch_maps_to_internal_without_version_leak() {
+        let e: IpcError = StorageError::SchemaMismatch {
+            actual: 2,
+            expected: 1,
+        }
+        .into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        // No version-number leak in wire message.
+        assert_eq!(message, "storage schema mismatch");
+    }
+
+    #[test]
+    fn storage_io_maps_to_internal_without_path_leak() {
+        let io = std::io::Error::other("/some/secret/path failed");
+        let e: IpcError = StorageError::Io { source: io }.into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "storage io error");
+        assert!(!message.contains("/some/secret/path"));
+    }
+
+    #[test]
+    fn storage_sql_maps_to_internal_without_query_leak() {
+        let e: IpcError = StorageError::Sql {
+            message: "near 'SELECT': syntax error".into(),
+        }
+        .into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "storage error");
+        assert!(!message.contains("SELECT"));
     }
 }

--- a/crates/panops-protocol/src/error.rs
+++ b/crates/panops-protocol/src/error.rs
@@ -205,6 +205,9 @@ mod from_domain {
                 StorageError::AlreadyExists { kind, .. } => IpcError::InvalidInput {
                     message: format!("{kind} already exists"),
                 },
+                StorageError::UniqueConflict { kind, field, .. } => IpcError::InvalidInput {
+                    message: format!("{kind}.{field} already in use"),
+                },
                 // Internal-state conditions: the wire stays opaque so
                 // version numbers / SQL fragments / FS paths never reach
                 // the client. Full detail is logged at the call site
@@ -392,6 +395,23 @@ mod from_domain_tests {
         };
         assert!(path.contains("meeting"), "got: {path}");
         assert!(path.contains("abc"), "got: {path}");
+    }
+
+    #[test]
+    fn storage_unique_conflict_maps_to_invalid_input_without_value_leak() {
+        let e: IpcError = StorageError::UniqueConflict {
+            kind: "meeting",
+            field: "dir_path",
+            value: "/Users/fran/Library/Application Support/panops/meetings/abc".into(),
+        }
+        .into();
+        let IpcError::InvalidInput { message } = e else {
+            panic!("expected InvalidInput");
+        };
+        assert!(message.contains("meeting"), "got: {message}");
+        assert!(message.contains("dir_path"), "got: {message}");
+        // The path itself must not leak — only kind+field on the wire.
+        assert!(!message.contains("/Users/fran"), "value leaked: {message}");
     }
 
     #[test]

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -14,6 +14,6 @@ pub mod methods;
 
 pub use error::IpcError;
 pub use methods::{
-    Event, JobAccepted, JobDoneEvent, JobErrorEvent, MeetingSummary, NotesDialect,
-    NotesGenerateParams, NotesGenerateResult,
+    Event, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig, MeetingSummary,
+    NotesDialect, NotesGenerateParams, NotesGenerateResult,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -85,6 +85,11 @@ pub struct NotesGenerateParams {
     pub no_diarize: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// When `Some`, attach the generated note to the existing meeting.
+    /// When `None`, the handler auto-creates a meeting, returns its
+    /// id, and writes notes into `<data_dir>/meetings/<id>/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meeting_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -98,6 +103,9 @@ pub enum NotesDialect {
 pub struct NotesGenerateResult {
     pub primary_file: String,
     pub assets: Vec<String>,
+    /// The meeting this note belongs to. Always set after slice 06
+    /// (auto-created when `NotesGenerateParams.meeting_id` was `None`).
+    pub meeting_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -109,6 +117,34 @@ pub struct MeetingSummary {
     /// a Rust-specific time crate to consume it.
     pub started_at: String,
     pub duration_ms: u64,
+}
+
+/// Full meeting record returned by `meeting.get` / `meeting.start` /
+/// `meeting.stop`. New in slice 06; `MeetingSummary` (lighter shape
+/// for `meeting.list`) remains unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Meeting {
+    pub id: String,
+    pub title: String,
+    /// RFC3339. See `MeetingSummary` doc on string-vs-DateTime choice.
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub duration_ms: Option<u64>,
+    /// BCP-47 language hint, or "auto".
+    pub language: String,
+    /// Absolute path to the meeting directory (where notes / future
+    /// audio + screenshots live).
+    pub dir_path: String,
+}
+
+/// Input shape for `meeting.start`. Both fields optional; server
+/// applies defaults (title="", language="auto").
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MeetingConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
 }
 
 #[cfg(test)]
@@ -124,6 +160,7 @@ mod tests {
             llm_model: None,
             no_diarize: None,
             language: None,
+            meeting_id: None,
         };
         let json = serde_json::to_string(&p).unwrap();
         // Optional fields with skip_serializing_if must be absent.
@@ -141,10 +178,85 @@ mod tests {
             llm_model: Some("gemma3:4b".into()),
             no_diarize: Some(true),
             language: Some("en".into()),
+            meeting_id: Some("m1".into()),
         };
         let back: NotesGenerateParams =
             serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
         assert_eq!(back, p);
+    }
+
+    #[test]
+    fn meeting_round_trips_with_all_fields() {
+        let m = Meeting {
+            id: "m1".into(),
+            title: "Test".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            ended_at: Some("2026-05-05T11:00:00+00:00".into()),
+            duration_ms: Some(3_600_000),
+            language: "en".into(),
+            dir_path: "/tmp/m1".into(),
+        };
+        let back: Meeting = serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn meeting_in_progress_serialises_with_nulls() {
+        let m = Meeting {
+            id: "m1".into(),
+            title: "Test".into(),
+            started_at: "2026-05-05T10:00:00+00:00".into(),
+            ended_at: None,
+            duration_ms: None,
+            language: "auto".into(),
+            dir_path: "/tmp/m1".into(),
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        assert!(s.contains("\"ended_at\":null"), "got: {s}");
+        assert!(s.contains("\"duration_ms\":null"), "got: {s}");
+    }
+
+    #[test]
+    fn meeting_config_round_trips_with_optionals_omitted() {
+        let cfg = MeetingConfig {
+            title: None,
+            language: None,
+        };
+        let s = serde_json::to_string(&cfg).unwrap();
+        let back: MeetingConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn meeting_config_accepts_empty_object() {
+        let back: MeetingConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(back.title, None);
+        assert_eq!(back.language, None);
+    }
+
+    #[test]
+    fn notes_generate_params_accepts_meeting_id() {
+        let json = r#"{"audio":"/x.wav","meeting_id":"abc"}"#;
+        let p: NotesGenerateParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.meeting_id.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn notes_generate_params_accepts_no_meeting_id() {
+        let json = r#"{"audio":"/x.wav"}"#;
+        let p: NotesGenerateParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.meeting_id, None);
+    }
+
+    #[test]
+    fn notes_generate_result_emits_meeting_id() {
+        let r = NotesGenerateResult {
+            primary_file: "/x/notes.md".into(),
+            assets: vec!["/x/screenshots/1.jpg".into()],
+            meeting_id: "abc".into(),
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"meeting_id\":\"abc\""), "got: {s}");
     }
 
     #[test]
@@ -166,6 +278,7 @@ mod tests {
             result: NotesGenerateResult {
                 primary_file: "/tmp/notes.md".into(),
                 assets: vec!["/tmp/screenshots/a.jpg".into()],
+                meeting_id: "m1".into(),
             },
         });
         let json = serde_json::to_string(&e).unwrap();

--- a/docs/proto/ipc.md
+++ b/docs/proto/ipc.md
@@ -1,4 +1,4 @@
-# panops IPC protocol — slice 05
+# panops IPC protocol — slices 05 + 06
 
 ## Transport
 
@@ -11,19 +11,65 @@
 
 | Method | Params | Result | Notes |
 |---|---|---|---|
-| `ipc.notes.generate` | `{ audio, dialect?, llm_provider?, llm_model?, no_diarize?, language? }` | `{ job_id }` | Async. Listen on `ipc.events.subscribe` for `job.done` / `job.error`. |
-| `ipc.meeting.list` | `()` | `[]` (until #17) | Returns array of `MeetingSummary`. |
+| `ipc.notes.generate` | `{ audio, dialect?, llm_provider?, llm_model?, no_diarize?, language?, meeting_id? }` | `{ job_id }` | Async. Listen on `ipc.events.subscribe` for `job.done` / `job.error`. |
+| `ipc.meeting.list` | `()` | `[MeetingSummary]` | Returns rows from the registry, ordered `started_at DESC`. |
+| `ipc.meeting.start` | `MeetingConfig` | `meeting_id` (string) | Slice 06. Data-plane scaffolding (no live capture). Creates row + `meetings/<uuid>/screenshots/`. |
+| `ipc.meeting.stop` | `{ id }` | `Meeting` | Sets `ended_at = now()` and computes `duration_ms`. |
+| `ipc.meeting.get` | `{ id }` | `Meeting` | Full row including `dir_path`, `language`, `ended_at`. |
+| `ipc.meeting.set_language` | `{ id, language }` | `Meeting` | Updates BCP-47 language hint. |
+| `ipc.meeting.delete` | `{ id }` | `()` | Removes registry row (FK-cascades notes), then `rm -rf meetings/<id>/`. Orphan dir on FS-error is logged, not an error. |
 
 The `ipc.` namespace + `.` separator are wired via jsonrpsee `#[rpc(server, namespace = "ipc", namespace_separator = ".")]`.
 
-`NotesGenerateParams` fields (all but `audio` are optional):
+### `NotesGenerateParams`
 
-- `audio` — absolute or working-dir-relative path to the audio file.
-- `dialect` — `"notion-enhanced"` (default) or `"basic"`.
-- `llm_provider` — provider name string (e.g. `"ollama"`). Slice-04 wiring picks the default if absent.
-- `llm_model` — provider-specific model id (e.g. `"gemma3:4b"`).
-- `no_diarize` — skip the diarization merge step.
-- `language` — BCP-47 language hint passed to ASR.
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `audio` | string | required | Absolute or working-dir-relative path to the audio file. Canonicalized server-side. |
+| `dialect` | `"notion-enhanced"` \| `"basic"` | `"notion-enhanced"` | Output markdown dialect. |
+| `llm_provider` | string | absent | E.g. `"ollama"`. Slice-04 wiring picks the default if absent. |
+| `llm_model` | string | provider default | E.g. `"gemma3:4b"`. |
+| `no_diarize` | bool | `false` | Skip the diarization merge step. |
+| `language` | string | absent | BCP-47 language hint passed to ASR + LLM. |
+| `meeting_id` | string | absent | **Slice 06.** When `Some`, attach the generated note to the existing meeting (its `dir_path` becomes the output dir). When `None`, the engine auto-creates a meeting under `<data_dir>/meetings/<uuid>/` and returns the new id in `result.meeting_id`. |
+
+### `NotesGenerateResult` (delivered via `job.done` event)
+
+| Field | Type | Notes |
+|---|---|---|
+| `primary_file` | string | Absolute path to the rendered `notes.md`. |
+| `assets` | `[string]` | Additional written assets (screenshots, etc.). |
+| `meeting_id` | string | **Slice 06.** Always set; either the value passed in `params.meeting_id` or the id of the auto-created meeting. |
+
+### `Meeting` and `MeetingSummary`
+
+```json
+// MeetingSummary (slice 05; shape unchanged)
+{ "id": "...", "title": "...", "started_at": "RFC3339", "duration_ms": 0 }
+
+// Meeting (slice 06; new)
+{
+  "id": "...",
+  "title": "...",
+  "started_at": "RFC3339",
+  "ended_at": null | "RFC3339",
+  "duration_ms": null | u64,
+  "language": "en" | "es" | "auto" | ...,
+  "dir_path": "/Users/.../meetings/<uuid>"
+}
+```
+
+In-progress meetings render `ended_at: null` and `duration_ms: null` on `Meeting`; `MeetingSummary.duration_ms` defaults to `0` to keep the slice-05 wire shape stable.
+
+### `MeetingConfig` (input to `meeting.start`)
+
+```json
+{ "title": "Daily standup",  // optional, defaults to ""
+  "language": "en"            // optional, defaults to "auto"
+}
+```
+
+Both fields are optional; an empty `{}` is accepted and applies defaults.
 
 Param structs intentionally do NOT use `#[serde(deny_unknown_fields)]` — same forward-compat philosophy as `IpcError::Unknown`. New optional fields are non-breaking.
 
@@ -38,7 +84,7 @@ The subscription is server-push backed by a `tokio::sync::broadcast` channel. A 
 ## Event types
 
 ```json
-{ "type": "job.done",  "job_id": "...", "result": { "primary_file": "...", "assets": [...] } }
+{ "type": "job.done",  "job_id": "...", "result": { "primary_file": "...", "assets": [...], "meeting_id": "..." } }
 { "type": "job.error", "job_id": "...", "error": { "kind": "input_not_found" | "invalid_input" | "provider_unavailable" | "internal" | "cancelled", "message": "..." } }
 ```
 
@@ -50,7 +96,7 @@ The `Event` enum is internally tagged on `type`. Future event kinds (`asr.partia
 
 | `kind` | Meaning | Payload |
 |---|---|---|
-| `input_not_found` | A path the engine was told to read does not exist. | `path` |
+| `input_not_found` | A path or id the engine was told to read does not exist. Slice 06 also uses this for unknown `meeting_id`s, with `path: "<kind>/<id>"` (e.g. `"meeting/abc"`). | `path` |
 | `invalid_input` | A request param failed validation. | `message` |
 | `provider_unavailable` | An external LLM/STT provider was unreachable or returned empty. | `message` |
 | `internal` | Engine-side bug or unrecognised failure. | `message` |
@@ -61,25 +107,76 @@ Adding new variants is non-breaking for existing clients (they deserialise as `u
 
 At the JSON-RPC boundary, errors flowing back as `ErrorObjectOwned` use code `-32000` with `IpcError` shape preserved in the `data` field; `notes.generate` reports per-job failures via `job.error` events on the subscription instead.
 
-## What's NOT shipped in slice 05
+## Storage (slice 06)
 
-- Control methods: `meeting.start` / `meeting.stop` / `meeting.get` / `meeting.delete` / `meeting.set_language`, `asr.post_pass` / `asr.cancel`, `notes.export`, `llm.probe` / `llm.providers` / `llm.test`, `settings.get` / `settings.set`.
+- Single SQLite file at `<data_dir>/panops.db` with `meeting` + `note` tables. Default `<data_dir>` is `~/Library/Application Support/panops/`; override with `panops-engine --data-dir <path>`.
+- Per-meeting directory: `<data_dir>/meetings/<uuid>/notes.md` and `<data_dir>/meetings/<uuid>/screenshots/` (empty until live capture).
+- Schema version: `PRAGMA user_version = 1`. A future-versioned DB is rejected on engine start with a clean exit code; the `domain-conversions` mapping translates the underlying `StorageError::SchemaMismatch` to `IpcError::Internal { message: "storage schema mismatch" }` for any IPC consumer that hits it later.
+- Concurrency: single `Arc<Mutex<Connection>>`; all storage calls are wrapped in `tokio::task::spawn_blocking`. Single-user-fine for v0.1.
+
+### Known limitations
+
+- Per-meeting `meeting.db` (with `segment / speaker / screenshot / job` tables) is deferred to the live-capture slice.
+- WAL mode is off; concurrent readers serialise behind the single mutex.
+- Manually deleting `panops.db` orphans the per-meeting directories on disk. There is no orphan reaper; clean up by hand.
+- No schema migration framework yet — version bumps require a v0.2 plan.
+- `notes.generate` returning `meeting_id` is a wire **extension**, not a removal — clients that ignored the field continue to work.
+
+## What's NOT shipped (still deferred)
+
+- IPC: `asr.post_pass` / `asr.cancel`, `notes.export`, `llm.probe` / `llm.providers` / `llm.test`, `settings.get` / `settings.set`.
 - Live-capture events: `asr.partial`, `asr.final`, `screenshot`, `job.progress`.
 - Token auth, WS reconnection, event replay buffer.
 - `CancellationToken` plumbed through `LlmRequest` (the `spawn_blocking` task is uncancellable today).
+- Push events for storage mutations (`meeting.created`, `meeting.deleted`).
 
-Each deferred item has a tracking issue under `type:debt area:ipc` on the project board.
+Each deferred item has a tracking issue under `type:debt area:ipc` (or `area:storage`) on the project board.
 
 ## Manual smoke
 
 ```bash
 # Terminal 1
-panops-engine serve --socket /tmp/panops.sock
-
-# Terminal 2
-websocat unix-connect:/tmp/panops.sock
-> {"jsonrpc":"2.0","id":1,"method":"ipc.meeting.list","params":{}}
-< {"jsonrpc":"2.0","id":1,"result":[]}
+panops-engine serve --data-dir /tmp/panops-smoke --socket /tmp/panops.sock
 ```
 
-Until #74 is resolved, `serve` uses stub adapters — `notes.generate` will return errors via `job.error` instead of producing real notes. In-process integration tests under `crates/panops-engine/tests/` exercise the real path with injected adapters via `EngineServices`.
+The engine accepts JSON-RPC 2.0 over both raw HTTP and WebSocket on the
+same UDS. **Use HTTP (curl) for one-off requests; use WebSocket
+(websocat) when you need `events.subscribe` server-push.**
+
+**curl (HTTP, simplest):**
+
+```bash
+# Terminal 2
+curl -s --unix-socket /tmp/panops.sock \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"ipc.meeting.start","params":[{"title":"Test","language":"en"}]}' \
+  http://localhost/
+# < {"jsonrpc":"2.0","id":1,"result":"<uuid>"}
+
+curl -s --unix-socket /tmp/panops.sock \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"ipc.meeting.list","params":[]}' \
+  http://localhost/
+# < {"jsonrpc":"2.0","id":2,"result":[{"id":"<uuid>","title":"Test","started_at":"...","duration_ms":0}]}
+```
+
+**websocat (WebSocket, for events):**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"ipc.meeting.list","params":[]}' \
+  | websocat -n1 -t --ws-c-uri=ws://localhost/ - ws-c:unix:/tmp/panops.sock
+```
+
+The `- ws-c:unix:` proxy form is required by websocat 1.x (`-` is stdio
+as the "other" endpoint of the proxy; `ws-c:` wraps the UDS transport
+in a WS handshake).
+
+**Params shape:** all `#[rpc]` methods take their params as a single
+positional element in the JSON-RPC `params` array — `params: [<obj>]`,
+NOT `params: <obj>`. jsonrpsee's macro generates positional dispatch by
+default; named-object params would require an extra wrapper struct per
+method.
+
+Restart the engine pointing at the same `--data-dir`; `ipc.meeting.list` returns the same row (persistence verified).
+
+In-process integration tests under `crates/panops-engine/tests/` exercise the full IPC surface with injected fakes via `EngineServices::ready` — see `tests/common/mod.rs` and `tests/common/notes_pipeline.rs` for the helper layout.

--- a/docs/superpowers/specs/2026-05-05-slice-06-storage-brainstorm.md
+++ b/docs/superpowers/specs/2026-05-05-slice-06-storage-brainstorm.md
@@ -1,0 +1,91 @@
+# Slice 06 — SQLite storage + meeting lifecycle: brainstorm
+
+**Status:** brainstorm artifact. Source for the locked spec at `2026-05-05-slice-06-storage-design.md`. Captures the 2026-05-05 interactive brainstorm session that walked the maintainer through scope, scaffolding semantics, and DB layout. Decisions made here are reflected in the locked spec.
+
+## 0. Pickup state
+
+Slice 05 (IPC) shipped clean on May 2 (`d22c0ab`). The three intervening days were cleanup: #74 (real adapters in `serve`) closed via PR #93, Claude GitHub Actions added (PR #92), Copilot review instructions added (PR #94), AGENTS.md amended with OnceLock terminal-state + domain-error no-Serialize rules (PR #104), dependabot bumps merged. **No active slice plan exists; the project board has 33 Todo items at brainstorm time.**
+
+## 1. Trajectory choice — which slice next?
+
+Per the trajectory in `AGENTS.md` (with #74 done), four options were on the table:
+
+| Option | Argument | Argument against |
+|---|---|---|
+| **#17 SQLite persistence** | Smallest well-scoped slice; no new language surface; unblocks Anchor A AND v0.1 acceptance #4 | Doesn't visibly change product yet (no UI, no calibration win) |
+| **Real-meeting calibration** | Hits v0.1 acceptance #5 (the "would I actually use this" gate) | Requires real meeting recording; doesn't unblock Anchor A code-wise |
+| **Anchor A — Mac shell + ASR sidecar** | First time the product is usable in app form | Largest scope; lands Swift code against stub data plane and would need rework |
+| **Audit drift cleanup first** | Knocks out 5 unresolved drift items before any new code | Small, doesn't justify a slice; blocks v0.1 progress |
+
+**Maintainer chose**: #17 SQLite persistence (recommended).
+
+## 2. Scope size — thin / medium / fat
+
+Three thicknesses considered for #17:
+
+- **Thin (walking-skeleton)** — Storage port + registry adapter only. `meeting.list` returns rows from a registry that only `meeting.start/stop` would populate, but those don't exist yet, so the registry stays empty. `notes.generate` continues writing markdown next to input audio with no DB record. Pure plumbing slice; doesn't actually hit acceptance #4 yet.
+- **Medium (recommended at brainstorm time)** — Storage port + rusqlite registry + per-meeting DB for `note` only. Wire `notes.generate` to (a) write into canonical `meetings/<uuid>/`, (b) insert into registry, (c) return meeting id. `meeting.list` reads real rows.
+- **Fat (#17 + #75)** — Above plus the new `meeting.start / stop / get / delete / set_language` IPC methods (currently filed as #75). Two slice-worth of work bundled.
+
+**Maintainer chose**: Fat (#17 + #75). Reason: lifecycle methods are blocked on #17 and naturally land together; one slice ships a complete data plane the Mac shell can land against.
+
+## 3. `meeting.start` / `meeting.stop` semantics — what do they mean before live capture?
+
+Per design spec, `meeting.start(config)` opens the meeting dir + initializes `audio.m4a / video.mp4 / meeting.db / screenshots/`. Without ScreenCaptureKit (Anchor B), these methods don't have a "real" job to do. Three interpretations considered:
+
+- **Data-plane scaffolding (recommended)** — `start` creates the row + dir + `screenshots/`, sets `started_at`. No capture coupling. `stop` writes `ended_at` and `duration_ms`. Anchor A (Mac shell) calls them when the user clicks record/stop; Anchor B layers on actual capture.
+- **Defer entirely to Anchor B** — slice 06 ships only `meeting.list / get / delete / set_language`. Smaller scope; #75 stays partially open; Mac shell has incomplete lifecycle to call.
+- **Import-existing-audio semantics** — re-shape `meeting.start(audio: String, language: String) -> meeting_id`. CLI uses this. Diverges from spec's `MeetingConfig` shape — spec amendment required.
+
+**Maintainer chose**: Data-plane scaffolding. The locked spec captures this as decision D3.
+
+## 4. DB layout — per-spec split now or single-DB now?
+
+Design spec calls for two SQLite files: registry at `panops.db` (just `meeting_id → path` + global settings) and per-meeting at `meetings/<uuid>/meeting.db` (full `meeting + segment + speaker + screenshot + note + job`).
+
+Three layouts considered:
+
+| Layout | Pros | Cons |
+|---|---|---|
+| **Single-DB now (recommended)** | Simplest; `meeting.list` is one SELECT; no premature complexity for empty tables | Spec amendment; per-meeting DB lands when Anchor B needs it |
+| **Per-spec split now** | Stays faithful to locked design; `meeting.delete` is just `rm -rf` + delete row | Two adapters or one with two connections; `meeting.list` = N+1 opens for nothing; `segment/speaker/screenshot/job` tables empty until Anchor B |
+| **Hybrid (denormalised)** | Fast `meeting.list`; forward-compat with Anchor B | Two sources of truth for meeting metadata; write-time sync burden |
+
+**Maintainer chose**: Single-DB now, per-meeting split deferred to Anchor B. Recorded as **deliberate spec amendment**, not silent drift.
+
+## 5. Sub-decisions taken with assistant defaults (subject to maintainer veto via spec review)
+
+These weren't asked individually because they're either AGENTS.md-mandated or low-risk:
+
+- `Storage` trait is sync; async wrapping at handler via `spawn_blocking` — matches existing port pattern.
+- `RusqliteStorage` uses `Arc<Mutex<Connection>>` — single-user; pool unjustified.
+- `rusqlite` with `bundled` feature — predictable CI, no system-sqlite link pain.
+- PRAGMA `user_version` for schema versioning; mismatch = hard error — YAGNI for v0.1.
+- `--data-dir` CLI flag, no `PANOPS_DATA_DIR` env var — drift §1 + AGENTS.md.
+- UUIDv4 simple form for meeting/note ids — `uuid` already a workspace dep.
+- `meeting.delete` orders registry-row-then-fs; orphan dir = logged warning, not failure — registry is source of truth.
+- `notes.generate` non-breaking extension with optional `meeting_id` — keeps existing IPC clients working.
+- `Storage` port lives in `panops-core`; `RusqliteStorage` in `panops-portable`; `InMemoryStorage` fake in `panops-core::conformance::fakes` — matches existing port locations.
+- `EngineServices` gains `Arc<dyn Storage> + data_dir: PathBuf` in the **direct** lane (next to `llm`), not in the `heavy` `OnceLock` — SQLite open is microseconds, no model load.
+- New `Meeting` type uses `Option<u64> duration_ms` and `Option<String> ended_at`; existing `MeetingSummary` shape preserved.
+
+## 6. Open questions surfaced (NOT for this slice — surfaced for separate decision)
+
+1. **Drift §3 — `NotionEnhanced` as current default**. Slice 06 touches `note.dialect`. The May 2 alignment audit flagged that the genesis quote (`f0690f89:150`) framed Notion as "future phase" but code defaults to `NotionEnhanced`. Slice 06 preserves the default to avoid bundling unrelated change. **Maintainer decides separately.**
+2. **Schema migration framework for v0.2**.
+3. **Concurrency at scale** (`Arc<Mutex<Connection>>` is single-user-fine; revisit if real usage shows contention).
+4. **Title source for auto-created meetings** (today: audio file stem; Mac shell will let user enter one).
+5. **Cross-meeting search** — not in slice 06.
+
+## 7. What this artifact is NOT
+
+- Not the locked spec — that's `2026-05-05-slice-06-storage-design.md`.
+- Not the executable plan — that's `docs/superpowers/plans/06-storage.md` (written by `superpowers:writing-plans` post-spec-approval).
+- Not authoritative on architecture — the locked spec is. If they disagree, the spec wins.
+
+## 8. References
+
+- Plan file (in-flight brainstorm scratchpad, identical content): `~/.claude/plans/let-s-continue-with-the-steady-deer.md`
+- Locked design (storage section): `docs/superpowers/specs/2026-04-30-panops-design.md:222-252`
+- May 2 alignment audit: `docs/superpowers/reviews/2026-05-02-alignment-audit.md`
+- Tracking: #17 (SQLite persistence), #75 (meeting.* IPC methods)

--- a/docs/superpowers/specs/2026-05-05-slice-06-storage-design.md
+++ b/docs/superpowers/specs/2026-05-05-slice-06-storage-design.md
@@ -226,7 +226,9 @@ impl EngineServices {
 }
 ```
 
-`run_serve` constructs `RusqliteStorage::new(data_dir.join("panops.db"))?` eagerly **after** binding the socket but **before** registering handlers (matches the eager-after-bind pattern from #74 fix in `dbd80c8`). Failure during DB open returns the same error path as `--socket` failures. Each integration test that uses `run_serve_in_process` injects its own `Arc<InMemoryStorage>` + `tempfile::TempDir` for `data_dir`.
+`run_serve` constructs `RusqliteStorage::new(data_dir.join("panops.db"))?` **before** binding the socket. SQLite open is microseconds (no model load, no I/O budget concern), so the eager-after-bind pattern from #74 — which exists specifically to defer multi-second Whisper / Sherpa init past the 5s "socket appears" test budget — does NOT apply to storage. Opening before bind means a corrupt or wrong-schema-version DB fails with a clean exit code BEFORE we claim the socket, instead of leaving a dangling socket file behind a startup failure. (Spec amended 2026-05-09 from earlier "after bind" wording, ratified by maintainer; the code has always done this.)
+
+Each integration test that uses `run_serve_in_process` injects its own `Arc<InMemoryStorage>` + `tempfile::TempDir` for `data_dir`.
 
 ### IPC surface
 

--- a/docs/superpowers/specs/2026-05-05-slice-06-storage-design.md
+++ b/docs/superpowers/specs/2026-05-05-slice-06-storage-design.md
@@ -1,0 +1,473 @@
+# Slice 06 — SQLite storage + meeting lifecycle: design
+
+**Status:** locked. Amendments require a maintainer decision recorded inline with a date stamp.
+**Closes:** #17 (no SQLite persistence), #75 (IPC: implement `meeting.*` control methods).
+**Brainstorm:** `docs/superpowers/specs/2026-05-05-slice-06-storage-brainstorm.md` (2026-05-05).
+**Slice tracking issue:** TBD (open with `gh issue create --label type:feature --milestone slice-06-storage`).
+
+## Why this shape
+
+Four load-bearing decisions, each with an alternative considered and rejected:
+
+1. **Storage is one trait, one real impl, one fake.** Per AGENTS.md "MUST introduce one trait at a time". `Storage` lives in `panops-core`; `RusqliteStorage` lives in `panops-portable` (per the locked design doc: "SQLite is portable already"); `InMemoryStorage` fake lives in `panops-core::conformance`. A conformance harness exercises both. Rejected: pre-trait for hypothetical `PostgresStorage` / `IcloudStorage`.
+
+2. **Single registry DB now; per-meeting DB deferred to Anchor B.** One `~/Library/Application Support/panops/panops.db` with `meeting + note` tables. The locked design doc spec at `docs/superpowers/specs/2026-04-30-panops-design.md:222-252` calls for a per-meeting `meeting.db` containing `segment + speaker + screenshot + job + note + meeting`. Slice 06 has none of `segment / speaker / screenshot / job` data to put there yet — those tables would sit empty, and `meeting.list` would pay N+1 opens for nothing. The per-meeting DB lands when live capture (Anchor B) creates content for it. **This is a deliberate spec amendment**, not silent drift.
+
+3. **`meeting.start` / `meeting.stop` ship as data-plane scaffolding, not capture-coupled methods.** Without ScreenCaptureKit (Anchor B), `start` creates the row + meeting directory + `screenshots/` + sets `started_at`; `stop` writes `ended_at` and computes `duration_ms`. No capture wiring. Anchor A (Mac shell) calls them when the user clicks record/stop; Anchor B wires them to real capture. Rejected: defer `start/stop` entirely to Anchor B (would leave the lifecycle surface inconsistent across slice 06 and Anchor A).
+
+4. **`notes.generate` extends, doesn't break.** Adds optional `meeting_id: Option<String>` field to `NotesGenerateParams`. If absent, the handler auto-creates a meeting and writes into the canonical `meetings/<uuid>/` layout. If present, the handler attaches notes to the existing meeting. Existing IPC clients (the engine's own integration tests, future Mac shell early scaffolding) keep working without modification. Rejected: a separate `meeting.create_from_audio + notes.generate(meeting_id)` two-step (cleaner conceptually, but breaks the existing single-call CLI flow).
+
+## What the maintainer actually said
+
+Per the May 2 alignment audit's recommendation #2 ("add a 'what the user actually said' section to each slice spec"), here are the maintainer's verbatim decisions captured during the 2026-05-05 brainstorm. Anything in this spec that isn't in these quotes is an assistant default, marked "(assistant default)" inline.
+
+> **Question:** Which trajectory item should the next slice cover?
+> **Maintainer:** "#17 SQLite persistence (Recommended)"
+
+> **Question:** How fat should slice 06 be?
+> **Maintainer:** "Fat: full meeting lifecycle (#17 + #75)"
+
+> **Question:** What should `meeting.start` / `meeting.stop` mean in slice 06, before live capture exists?
+> **Maintainer:** "Data-plane scaffolding (Recommended)"
+
+> **Question:** Per-spec split now, or single-DB for slice 06 with split deferred to Anchor B?
+> **Maintainer:** "Single-DB now, split when needed (Recommended)" — selected with the preview showing the schema sketch in §Architecture below.
+
+Everything else (concurrency model, error taxonomy, schema versioning approach, CLI flag shape, table column choices, RusqliteStorage internal structure, default `Mutex<Connection>` over a connection pool) is an assistant default the maintainer accepted by approving this spec.
+
+## Scope (in this slice)
+
+- New port `Storage` in `panops-core::storage` with associated domain types (`Meeting`, `MeetingDraft`, `Note`, `NoteDraft`) and `StorageError`.
+- New conformance harness `panops-core::storage::conformance::storage_conformance(adapter)` that runs the same suite against any `Storage` impl (matching the existing `asr_conformance` / `notes_exporter_conformance` patterns).
+- New fake adapter `InMemoryStorage` in `panops-core::conformance::fakes` (matches the existing `MockLlm` / `FakeNotesExporter` pattern).
+- New `rusqlite` crate dep in `panops-portable` with `bundled` feature.
+- New real adapter `RusqliteStorage` in `panops-portable` over a single SQLite file at the data-dir root.
+- DB schema version 1 with two tables (`meeting`, `note`) — full DDL in §Architecture.
+- `EngineServices` gains `Arc<dyn Storage>` and `data_dir: PathBuf` fields (both direct, NOT in the `heavy` OnceLock — SQLite open is cheap); `serve` constructs eagerly at startup with `--data-dir` (defaults to canonical macOS path).
+- IPC methods (extend `crates/panops-protocol`). Method names below are the Rust trait names; the on-the-wire names carry the `ipc.` namespace prefix (e.g., `meeting.list` → wire method `ipc.meeting.list`) per the existing `#[rpc(server, namespace = "ipc", namespace_separator = ".")]` declaration on the `Ipc` trait at `crates/panops-engine/src/server/handlers.rs`.
+  - `meeting.list() -> Vec<MeetingSummary>` — replace stub at `crates/panops-engine/src/server/handlers.rs:116-120` with real impl.
+  - `meeting.start(MeetingConfig) -> meeting_id` — data-plane only.
+  - `meeting.stop(id) -> Meeting`.
+  - `meeting.get(id) -> Meeting`.
+  - `meeting.delete(id) -> ()` — registry row first, then `rm -rf meetings/<id>/`.
+  - `meeting.set_language(id, lang)`.
+  - `notes.generate` extended with optional `meeting_id` (auto-create on `None`).
+- New CLI flag `--data-dir <path>` on `panops-engine` (no env var; per drift §1).
+- Existing CLI `panops notes <wav>` continues writing notes next to audio AND newly registers the meeting in the registry. CLI default mode (`panops <wav>` → JSON to stdout) does NOT register — it produces no notes artifact, and a meeting-without-notes row is misleading state for the Mac shell and future UIs that list meetings expecting notes. **Amended 2026-05-05** from the original brainstorm which had both modes registering; ratified by maintainer post-implementation.
+- Protocol doc at `docs/proto/ipc.md` updated: new methods, new `meeting.*` shape, updated "What's NOT shipped" list.
+
+## Out of scope (defer; file as `type:debt` issues at slice end)
+
+- Per-meeting `meeting.db` (split deferred to Anchor B). Tables `segment`, `speaker`, `screenshot`, `job` remain unborn until that slice.
+- Schema migrations beyond version 1. PRAGMA `user_version` mismatch hard-errors with `StorageError::SchemaMismatch`. v0.2 will pick a migration framework.
+- Meeting-level full-text search across notes content.
+- WebSocket events for storage mutations (e.g., `meeting.created`, `meeting.deleted`). Slice 06 returns the new `Meeting` from the request handler; subscribers don't get push updates yet.
+- Cross-meeting transactions / atomic multi-meeting operations.
+- WAL mode + per-task connections (single `Arc<Mutex<Connection>>` is single-user-fine).
+- Cleanup of orphan `meetings/<uuid>/` directories whose registry rows were lost (e.g., manual `rm` of `panops.db`). Out-of-band recovery; document in protocol doc as a known limitation.
+- Token-based auth on IPC (filed as #83).
+- Filesystem encryption (relies on FileVault).
+- Cloud sync / multi-device (architectural future).
+
+## Architecture
+
+### Port — `panops-core::storage::Storage`
+
+```rust
+// crates/panops-core/src/storage/mod.rs
+
+pub trait Storage: Send + Sync {
+    fn create_meeting(&self, draft: MeetingDraft) -> Result<Meeting, StorageError>;
+    fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError>;
+    fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError>;
+    fn update_meeting_ended(&self, id: &str, ended_at: &str, duration_ms: u64) -> Result<Meeting, StorageError>;
+    fn update_meeting_language(&self, id: &str, language: &str) -> Result<Meeting, StorageError>;
+    fn delete_meeting(&self, id: &str) -> Result<(), StorageError>;
+    fn create_note(&self, draft: NoteDraft) -> Result<Note, StorageError>;
+    fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError>;
+}
+
+pub struct MeetingDraft {
+    pub id: String,            // caller-generated UUIDv4 hex
+    pub title: String,
+    pub started_at: String,    // RFC3339
+    pub language: String,      // BCP-47, e.g. "en", "es", "auto"
+    pub dir_path: String,      // absolute path to meetings/<uuid>/
+}
+
+pub struct Meeting {
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub language: String,
+    pub dir_path: String,
+}
+
+pub struct MeetingSummary {
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub duration_ms: u64,        // 0 if not yet stopped (for protocol non-Optional shape compat with slice 05)
+}
+
+pub struct NoteDraft {
+    pub id: String,             // UUIDv4
+    pub meeting_id: String,
+    pub dialect: String,        // "notion-enhanced" | "basic"
+    pub content_md: String,
+    pub primary_path: String,   // absolute path to notes.md on disk
+}
+
+pub struct Note {
+    pub id: String,
+    pub meeting_id: String,
+    pub dialect: String,
+    pub content_md: String,
+    pub primary_path: String,
+    pub created_at: String,
+}
+
+pub enum StorageError {
+    NotFound { id: String, kind: &'static str },     // kind = "meeting" | "note"
+    AlreadyExists { id: String, kind: &'static str },
+    SchemaMismatch { actual: u32, expected: u32 },
+    Io { source: std::io::Error },           // #[from]
+    Sql { message: String },                 // not rusqlite::Error — keeps panops-core rusqlite-free
+}
+// MUST NOT derive Serialize per AGENTS.md.
+// `Sql { message }` (not `Sql { source: rusqlite::Error }`) so `panops-core`
+// has no rusqlite dep. The adapter constructs via `StorageError::sql<E: Display>`
+// helper. Trade-off: callers can't downcast to the original rusqlite::Error type;
+// domain code never inspects, so acceptable.
+```
+
+The trait is sync (matches the existing `LlmProvider`, `AsrProvider`, `Diarizer`, `NotesExporter` ports). Async wrapping happens at the handler boundary via `tokio::task::spawn_blocking`.
+
+### DB schema (single file, version 1)
+
+DDL applied on first open by `RusqliteStorage::new(path)`:
+
+```sql
+PRAGMA user_version = 1;
+
+CREATE TABLE IF NOT EXISTS meeting (
+    id TEXT PRIMARY KEY NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    started_at TEXT NOT NULL,           -- RFC3339
+    ended_at TEXT,
+    duration_ms INTEGER,
+    language TEXT NOT NULL DEFAULT 'auto',
+    dir_path TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_meeting_started_at ON meeting(started_at DESC);
+
+CREATE TABLE IF NOT EXISTS note (
+    id TEXT PRIMARY KEY NOT NULL,
+    meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE,
+    dialect TEXT NOT NULL,
+    content_md TEXT NOT NULL,
+    primary_path TEXT NOT NULL,
+    created_at TEXT NOT NULL            -- RFC3339
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_meeting_id ON note(meeting_id);
+```
+
+`PRAGMA user_version` is checked on `RusqliteStorage::new`; if it's `0` we treat the DB as freshly-created and run the DDL above; if it's `>= 1 && != EXPECTED` we return `SchemaMismatch`. (assistant default)
+
+`PRAGMA foreign_keys = ON` set on every connection (rusqlite default is OFF). (assistant default)
+
+### Filesystem layout
+
+```
+~/Library/Application Support/panops/
+├── panops.db                            # registry (this slice's whole DB)
+├── engine.sock                          # existing UDS (slice 05)
+└── meetings/
+    └── <uuid>/                          # one dir per meeting
+        ├── notes.md                     # canonical note location for IPC-created meetings
+        └── screenshots/                 # empty until Anchor B
+```
+
+`meetings/<uuid>/meeting.db` lands in Anchor B, not this slice.
+
+### DI — `EngineServices` shape
+
+`EngineServices` lives at `crates/panops-engine/src/server/mod.rs:71`. Today it has two fields: `llm: Arc<dyn LlmProvider>` (direct because `GenaiLlm::with_handle` is instant) and `heavy: Arc<OnceLock<Result<HeavyAdapters, String>>>` (deferred, holds `asr/diar/exporter` whose models load 20s+).
+
+`Storage` is cheap to open (SQLite file open is microseconds, no model load). It joins the **direct** lane next to `llm`, NOT the OnceLock. `data_dir` is also direct.
+
+```rust
+pub struct EngineServices {
+    pub llm: Arc<dyn LlmProvider + Send + Sync>,
+    pub storage: Arc<dyn Storage>,                                          // NEW
+    pub data_dir: PathBuf,                                                  // NEW
+    pub(super) heavy: Arc<OnceLock<Result<HeavyAdapters, String>>>,
+}
+
+impl EngineServices {
+    pub fn ready(
+        llm: Arc<dyn LlmProvider + Send + Sync>,
+        storage: Arc<dyn Storage>,                                          // NEW
+        data_dir: PathBuf,                                                  // NEW
+        asr: Arc<dyn AsrProvider + Send + Sync>,
+        diar: Arc<dyn Diarizer + Send + Sync>,
+        exporter: Arc<dyn NotesExporter + Send + Sync>,
+    ) -> Self { /* ... */ }
+
+    pub fn pending(
+        llm: Arc<dyn LlmProvider + Send + Sync>,
+        storage: Arc<dyn Storage>,                                          // NEW
+        data_dir: PathBuf,                                                  // NEW
+    ) -> (Self, Arc<OnceLock<Result<HeavyAdapters, String>>>) { /* ... */ }
+}
+```
+
+`run_serve` constructs `RusqliteStorage::new(data_dir.join("panops.db"))?` eagerly **after** binding the socket but **before** registering handlers (matches the eager-after-bind pattern from #74 fix in `dbd80c8`). Failure during DB open returns the same error path as `--socket` failures. Each integration test that uses `run_serve_in_process` injects its own `Arc<InMemoryStorage>` + `tempfile::TempDir` for `data_dir`.
+
+### IPC surface
+
+Wire types added to `crates/panops-protocol/src/methods.rs`. Keep `chrono`-free (slice 05 invariant; `started_at` stays a `String`).
+
+```rust
+// extension
+
+pub struct MeetingConfig {
+    pub title: Option<String>,           // defaults to "" if None
+    pub language: Option<String>,        // defaults to "auto" if None
+}
+
+pub struct Meeting {                     // NEW in slice 06 (slice 05 only shipped MeetingSummary)
+    pub id: String,
+    pub title: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub language: String,
+    pub dir_path: String,
+}
+
+// MeetingSummary already exists at slice 05 (id, title, started_at, duration_ms: u64);
+// keep its shape unchanged. duration_ms stays u64, defaulting to 0 for in-progress meetings.
+
+#[derive(serde::Deserialize)]
+pub struct NotesGenerateParams {
+    pub audio: String,
+    pub language: Option<String>,        // already exists at slice 05 (post-Copilot fix wave)
+    pub dialect: Option<NotesDialect>,   // already exists at slice 05
+    pub llm_provider: Option<String>,    // already exists at slice 05
+    pub llm_model: Option<String>,       // already exists at slice 05
+    pub no_diarize: Option<bool>,        // already exists at slice 05
+    pub meeting_id: Option<String>,      // NEW — None = auto-create
+}
+
+pub struct NotesGenerateResult {
+    pub primary_file: String,            // already exists
+    pub assets: Vec<String>,             // already exists
+    pub meeting_id: String,              // NEW — always set after slice 06
+}
+```
+
+**No wire-breaking changes**, per the slice-05 forward-compat invariant ("new variants and new optional fields are non-breaking" — `docs/proto/ipc.md`). `Meeting` is newly introduced. `MeetingSummary` shape is unchanged. `NotesGenerateParams` adds optional `meeting_id`. `NotesGenerateResult` adds `meeting_id` (server emits; clients that ignore unknown fields keep working; the slice-05 design explicitly does NOT use `#[serde(deny_unknown_fields)]` on params or results).
+
+### Concurrency & error model
+
+`RusqliteStorage` holds `Arc<Mutex<rusqlite::Connection>>`. All trait methods take `&self` and are called from inside `tokio::task::spawn_blocking` at the handler layer. The mutex serializes writes; reads are not concurrent (single-user constraint, acceptable for v0.1).
+
+All `StorageError` variants convert to `IpcError` at the protocol boundary via `From<StorageError> for IpcError` (gated behind the `domain-conversions` feature flag, matching slice-05 `AsrError`/`LlmError`/etc.):
+
+| `StorageError` | `IpcError` | Wire message |
+|---|---|---|
+| `NotFound { id, kind }` | `InputNotFound` | `"<kind> not found"` (no id leak) |
+| `AlreadyExists { id, kind }` | `InvalidInput` | `"<kind> already exists"` |
+| `SchemaMismatch` | `Internal` | `"storage schema mismatch"` |
+| `Io` | `Internal` | `"storage io error"` |
+| `Sql` | `Internal` | `"storage error"` |
+
+Per the slice-05 hardening pattern: full path / SQL / error chain goes to `tracing::error!`; the wire message stays opaque.
+
+### `meeting.delete` ordering
+
+1. Read meeting from DB to capture `dir_path`.
+2. Delete meeting row (cascades to `note` rows via FK).
+3. `std::fs::remove_dir_all(dir_path)`. On error: `tracing::warn!` with the path; return Ok (registry is the source of truth; orphan dir reaper is out of scope).
+
+If step 2 fails: return error; nothing touched. If step 1 fails with `NotFound`: return `InputNotFound`.
+
+### `notes.generate` extension
+
+Pseudocode:
+
+```rust
+async fn notes_generate(svc: &EngineServices, params: NotesGenerateParams) -> Result<NotesGenerateResult, IpcError> {
+    let audio_path = canonicalize_under_allowlist(&params.audio)?;  // existing slice-05 hardening
+    let meeting_id = match params.meeting_id {
+        Some(id) => {
+            let _ = svc.storage.get_meeting(&id)?;                  // verify exists; enrich if needed
+            id
+        }
+        None => {
+            let id = Uuid::new_v4().simple().to_string();
+            let dir = svc.data_dir.join("meetings").join(&id);
+            std::fs::create_dir_all(dir.join("screenshots"))?;
+            svc.storage.create_meeting(MeetingDraft {
+                id: id.clone(),
+                title: audio_path.file_stem().unwrap_or_default().to_string_lossy().into_owned(),
+                started_at: now_rfc3339(),
+                language: params.language.clone().unwrap_or_else(|| "auto".into()),
+                dir_path: dir.to_string_lossy().into_owned(),
+            })?;
+            id
+        }
+    };
+    // existing pipeline (asr → diar → llm → exporter), but exporter writes to:
+    //   - meeting.dir_path  (when auto-created or existing meeting)
+    //   - audio_path.parent().join(<stem>-notes)  (CLI-only legacy path; see §CLI behavior)
+    // ... existing spawn_blocking + JobDone/JobError event flow ...
+    let note = svc.storage.create_note(NoteDraft { id: Uuid::new_v4()..., meeting_id: meeting_id.clone(), ... })?;
+    Ok(NotesGenerateResult { primary_file: ..., assets: ..., meeting_id })
+}
+```
+
+### CLI behavior
+
+| Surface | Before slice 06 | After slice 06 |
+|---|---|---|
+| `panops <wav>` (default mode) | Print JSON to stdout | **Unchanged.** No registry write. Default mode produces no notes artifact; a meeting-without-notes row would be misleading state. (Amended 2026-05-05 from the brainstorm; ratified by maintainer.) |
+| `panops notes <wav>` | Write notes to `<audio_dir>/<stem>-notes/` | Same, plus register meeting (and a `note` row pointing at `notes.md`) in the registry. `dir_path = <audio_dir>/<stem>-notes/` (the legacy on-disk location), NOT `meetings/<uuid>/`. The registry just records the location; the IPC `notes.generate` path uses the canonical `meetings/<uuid>/` layout. Two flows, one registry. |
+| `panops-engine serve` | Single mode | Add `--data-dir <path>` flag |
+
+`--data-dir` defaults to `~/Library/Application Support/panops/` on macOS. Tests pass an explicit `tempfile::TempDir` path.
+
+## Test surface
+
+PR-gating tests:
+
+**Conformance harness (panops-core)** — one suite, two adapters:
+1. `storage_conformance` — runs against `InMemoryStorage` AND `RusqliteStorage` via a `#[test]` per adapter; covers create/get/list/update/delete for both `meeting` and `note`, plus `NotFound`, `AlreadyExists`, `SchemaMismatch`, `IoError`, and FK-cascade-on-meeting-delete.
+
+**Integration (panops-engine/tests)** — one file per concern:
+2. `ipc_meeting_list_real_storage` — supersedes slice-05's `ipc_meeting_list_returns_empty`. Asserts empty when the storage is empty, then creates rows via `Storage` directly and asserts they appear.
+3. `ipc_meeting_start_creates_row_and_dir` — calls `ipc.meeting.start`, verifies row exists in DB, dir exists on disk with `screenshots/` subdir, `started_at` is server-set RFC3339.
+4. `ipc_meeting_stop_writes_ended_at` — start then stop, verify `ended_at` and `duration_ms` populated.
+5. `ipc_meeting_get_returns_full` — get the meeting created above.
+6. `ipc_meeting_delete_removes_row_and_dir` — start → delete; verify no row, no dir, FK-cascaded notes also gone.
+7. `ipc_meeting_set_language_persists` — set language, get back, verify.
+8. `ipc_notes_generate_auto_creates_meeting` — call `notes.generate` with no `meeting_id`; verify result includes a new `meeting_id` and `meeting.list` returns one row.
+9. `ipc_notes_generate_with_existing_meeting_id` — `meeting.start` then `notes.generate` with that id; verify the note row links to that meeting.
+10. `ipc_notes_generate_with_unknown_meeting_id` — pass a bogus id; verify `InputNotFound` over the wire.
+11. `ipc_persistence_survives_restart` — start meeting in process A (in-process via `run_serve_in_process` against a `tempfile::TempDir`), tear down, start a new in-process server pointing at the same dir, `meeting.list` returns the meeting from process A.
+
+Existing slice-05 integration tests (`ipc_server_starts_and_binds`, `ipc_socket_perms_are_0600`, `ipc_stale_socket_is_cleaned`, `ipc_refuses_to_steal_live_socket`, `ipc_method_not_found_carries_jsonrpc_error`, `ipc_notes_generate_round_trip`, `ipc_job_error_carries_kind`) MUST continue to pass.
+
+Total: 1 conformance suite (× 2 adapters) + 10 IPC integration tests + 7 retained slice-05 tests = **PR-gating count: 18 tests** (one of which has two adapter instances).
+
+## Implementation order (sketch)
+
+Canonical task list goes in the writing-plans output. This is illustrative.
+
+1. Add `Storage` port + types + `StorageError` to `panops-core`. No impl yet. Compile & clippy clean.
+2. Write `storage_conformance` harness. No adapter yet (compile only).
+3. Implement `InMemoryStorage` fake (HashMap-backed). Wire into conformance harness; `cargo test` passes.
+4. Add `rusqlite` dep + `RusqliteStorage::new` (open + DDL + version check). `storage_conformance` runs against it; `cargo test` passes.
+5. Add `Storage` and `data_dir` to `EngineServices`. Construct `RusqliteStorage` in `run_serve`. Existing slice-05 tests still pass (with `Arc::new(InMemoryStorage::new())` injected for in-process tests).
+6. Replace `meeting.list` stub with real impl. Update slice-05 test or add new one.
+7. Add `meeting.start` handler + integration test.
+8. Add `meeting.stop` handler + integration test.
+9. Add `meeting.get` + `meeting.set_language` handlers + tests.
+10. Add `meeting.delete` handler (with fs cleanup) + integration test.
+11. Extend `notes.generate` with `meeting_id` (auto-create + existing + unknown-id paths) + 3 integration tests.
+12. Add `--data-dir` CLI flag. Update CLI smoke tests.
+13. Wire CLI default and `notes` modes to register the meeting (post-pipeline). Update `tests/cli_smoke.rs` (or equivalent).
+14. Add `ipc_persistence_survives_restart` integration test.
+15. Update `docs/proto/ipc.md`.
+16. File deferred items as `type:debt` issues with `severity:` + `area:storage` (or `area:ipc`).
+
+## Three-tier boundaries
+
+Per AGENTS.md "every slice spec MUST define them".
+
+### ✅ Always do
+
+- Run `cargo fmt && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked` before claiming any task done.
+- Wrap every `RusqliteStorage` call site in `tokio::task::spawn_blocking` at the handler.
+- Use `tempfile::TempDir` for every test that touches disk.
+- Insert meeting + initial note rows in a single transaction when both happen in one handler call.
+- Sanitize wire-side error messages: opaque "<kind> error" externally, full detail to `tracing::error!`.
+- Commit per task in the slice plan (per L3 autonomy in AGENTS.md).
+- File a follow-up `type:debt` GitHub issue for any "deferred" / "out of scope" item discovered during implementation.
+- Run `storage_conformance` against both `InMemoryStorage` and `RusqliteStorage`.
+- Drive `OnceLock` / `OnceCell` slots to a terminal state on every path including panic (per AGENTS.md `OnceLock` rule).
+
+### ⚠️ Ask first
+
+- Renaming a public protocol type (`Meeting`, `MeetingConfig`, `MeetingSummary`, `NotesGenerateResult`, `MeetingDraft`, `NoteDraft`).
+- Adding `chrono` to `panops-protocol` (intentionally date-dep-free per `methods.rs:107` comment; `started_at` stays a `String` on the wire). `chrono` is already on `panops-core` / `panops-portable` / `panops-engine` — use it server-side for parsing/formatting RFC3339, just don't leak it into the protocol crate.
+- Introducing a new `panops-portable` crate dep beyond `rusqlite` itself (e.g., `r2d2-rusqlite` for a connection pool).
+- Choosing `rusqlite` features beyond `bundled` (e.g., `chrono`, `serde_json`, `blob`, `array`).
+- Bundling a non-#17 / non-#75 issue into the slice (drift §3 NotionEnhanced default, drift §1 env-var cleanup, etc.).
+- Changing the schema after the first commit lands (forces `user_version` bump + spec amendment + migration discussion).
+- Removing or repurposing the existing CLI `panops notes` flow.
+- Introducing WAL mode or per-task connections.
+- Changing the file layout (`meetings/<uuid>/...`) after the first integration test lands.
+
+### 🚫 Never do
+
+- Add an env var for data dir, db path, or any user-facing config (per drift §1, AGENTS.md, north-star).
+- Ship a public IPC method without an integration test.
+- Auto-merge a PR (slice-05 lesson).
+- Auto-file new architectural concerns as issues without surfacing to the maintainer first (slice-05 audit §5).
+- Pre-trait a `Storage` variant — one trait, one real impl, one fake, period.
+- Create the per-meeting `meeting.db` (defer to Anchor B).
+- Create `segment / speaker / screenshot / job` tables (defer to Anchor B).
+- Phone home or log to disk anything that contains user content beyond what's already persisted.
+- Derive `serde::Serialize` on `StorageError` or any other domain error (per AGENTS.md).
+- Open a PR autonomously. The maintainer opens PRs; commits within the slice plan don't need per-commit approval (L3) but PR open is L2.
+
+## Decisions (locked)
+
+- **D1**: Storage port = sync trait; async wrapping happens at handler via `spawn_blocking`. Reason: matches existing port shape (`AsrProvider`, `LlmProvider`, etc.) and keeps `panops-core` async-runtime-free.
+- **D2**: Single registry DB at `panops.db`; per-meeting DB deferred to Anchor B. Reason: no per-meeting data exists yet; the split would buy nothing now.
+- **D3**: `meeting.start` / `meeting.stop` ship as data-plane scaffolding. Reason: lets Mac shell (Anchor A) wire to them immediately; Anchor B layers on capture coupling.
+- **D4**: `notes.generate` extends with optional `meeting_id`; auto-create when `None`. Reason: non-breaking IPC extension.
+- **D5**: `RusqliteStorage` uses `Arc<Mutex<Connection>>`. Reason: single-user; pool overhead unjustified.
+- **D6**: `rusqlite` with `bundled` feature, no system sqlite. Reason: predictable CI, no dynamic-lib pain (slice-04 #34 lesson).
+- **D7**: `--data-dir` flag, no `PANOPS_DATA_DIR` env var. Reason: drift §1 + AGENTS.md.
+- **D8**: PRAGMA `user_version` for schema versioning; mismatch = hard error. Reason: YAGNI for v0.1; migration framework is a v0.2 decision.
+- **D9**: `meeting.delete` orders registry-then-fs; orphan dir is a logged warning, not a failure. Reason: registry is the source of truth.
+- **D10**: `NotionEnhanced` remains the default `note.dialect`. Reason: changing the default is orthogonal to slice 06's storage focus; bundling expands scope. **Surfaced as Open question 1 for separate decision.**
+- **D11**: New `Meeting` type uses `Option<u64>` for `duration_ms` and `Option<String>` for `ended_at`; existing `MeetingSummary` keeps `u64 duration_ms` unchanged (defaults to 0 for in-progress). Reason: in-progress meetings can't honestly report a duration; keeping `MeetingSummary` shape preserves slice-05 forward-compat.
+- **D12**: All `StorageError` variants map to `IpcError` via the existing `domain-conversions` feature-flag pattern. `NotFound` → `InputNotFound`; everything else internal. Reason: matches slice-05 transport boundary.
+
+## Open questions (out of slice 06; surface for separate decision)
+
+1. **Drift §3 — `NotionEnhanced` as current default**. The May 2 alignment audit flagged that the genesis quote (`f0690f89:150`) framed Notion as "future phase" but code defaults to `NotionEnhanced`. Slice 06 preserves the default to avoid bundling unrelated change. Recommendation: maintainer decides before or after slice 06 whether to flip; if flipped, re-emit slice-04 goldens. One-line code change.
+2. **Schema migration framework for v0.2**. PRAGMA `user_version` + hard-error works for v0.1. v0.2 needs `refinery` or `sqlx-migrate` or hand-rolled migrations. Decide when v0.2 begins.
+3. **Concurrency at scale**. `Arc<Mutex<Connection>>` is single-user-fine; if real usage shows contention, evaluate WAL mode + per-task connections. File as debt only if it surfaces.
+4. **Title source for auto-created meetings**. CLI uses audio file stem; Mac shell will let user enter one. The IPC `meeting.start(MeetingConfig)` accepts an optional title. Acceptable for v0.1; revisit with Mac shell UX.
+5. **Cross-meeting search**. Not in slice 06. File as debt when needed.
+
+## Done when
+
+- All 18 PR-gating tests pass (`storage_conformance` × 2 adapters + 10 new IPC integration tests + 7 retained slice-05 tests; counts in §Test surface).
+- `cargo fmt && cargo clippy --workspace --all-targets --locked -- -D warnings` is clean.
+- Manual smoke succeeds: start `panops-engine serve --data-dir /tmp/panops-smoke`, run `panops --data-dir /tmp/panops-smoke notes tests/fixtures/audio/multi_speaker_60s.wav`, send `{"jsonrpc":"2.0","id":1,"method":"ipc.meeting.list","params":{}}` over the UDS — expect one row. Kill engine, restart with same `--data-dir`, repeat — still one row. Send `ipc.meeting.delete` with that id; `ipc.meeting.list` returns `[]`; `meetings/<id>/` directory gone.
+- `docs/proto/ipc.md` updated.
+- Deferred items filed as `type:debt` issues with `severity:` + `area:` labels and added to the project board.
+- Slice-tracking issue closed; milestone `slice-06-storage` closed via `gh api -X PATCH`.
+- Plan file moved to `docs/superpowers/plans/done/06-storage.md`.
+- Slice-boundary alignment audit run after PR merge, written to `docs/superpowers/reviews/YYYY-MM-DD-slice-06-audit.md`.
+
+## References
+
+- Brainstorm: `docs/superpowers/specs/2026-05-05-slice-06-storage-brainstorm.md`
+- Locked design (storage section): `docs/superpowers/specs/2026-04-30-panops-design.md:222-252`
+- Slice 05 IPC spec (sibling, sets the protocol-crate pattern): `docs/superpowers/specs/2026-05-02-slice-05-ipc-design.md`
+- May 2 alignment audit (recommendations #1, #2, #3, #5): `docs/superpowers/reviews/2026-05-02-alignment-audit.md`
+- Tracking issues: #17 (https://github.com/vfmatzkin/panops/issues/17), #75 (https://github.com/vfmatzkin/panops/issues/75)
+- AGENTS.md: workflow contract, three-tier boundaries rule, `OnceLock` rule, no-Serialize-on-domain-errors rule, no-env-vars rule
+- North star: `docs/north-star.md` — v0.1 acceptance criterion #4 (notes persist across app restarts)
+- rusqlite docs: https://docs.rs/rusqlite/0.31/


### PR DESCRIPTION
## Summary

Closes **#17** (no SQLite persistence) and **#75** (IPC `meeting.*` control methods deferred from slice 05).

Lands the storage port + adapters and the full meeting lifecycle on the IPC surface, so the future Mac shell (Anchor A) has a populated registry to read from. Hits **v0.1 acceptance criterion #4** (notes persist across app restarts).

### What ships

- **New port** `Storage` in `panops-core` with one trait + one real (`RusqliteStorage` in `panops-portable`, `bundled` rusqlite) + one fake (`InMemoryStorage` in `panops-core::conformance::fakes`). Conformance harness exercises both.
- **Single registry DB** at `<data_dir>/panops.db`, schema `version 1`, two tables (`meeting`, `note`) with FK `ON DELETE CASCADE` + per-connection `PRAGMA foreign_keys = ON`. Per-meeting DB deferred to Anchor B (live capture).
- **IPC methods** (all under namespace `ipc.`): `meeting.list` (real, replaces slice-05 stub), `meeting.start`, `meeting.stop`, `meeting.get`, `meeting.set_language`, `meeting.delete` (registry-row-then-fs ordering, orphan dir = warn-only).
- **`notes.generate` extended** with optional `meeting_id`. `None` → auto-create meeting + write into `<data_dir>/meetings/<uuid>/`. `Some(id)` → attach note to existing meeting. Result always carries `meeting_id`.
- **`EngineServices`** gains direct `storage` + `data_dir` fields (cheap to open; not in the heavy `OnceLock`). `--data-dir <path>` global CLI flag.
- **CLI `notes` mode** registers the meeting in the registry after exporter writes. Default mode (`panops <wav>` JSON to stdout) deliberately does NOT register — see spec §CLI behavior for the ratified deviation. Refactored `register_meeting_in_registry` to take `&dyn Storage` so the unit test uses `InMemoryStorage` and a future shared-handle pattern is a one-line caller change.
- **Domain → wire mapping** (`From<StorageError> for IpcError` behind `domain-conversions` feature). `NotFound` → `InputNotFound { path: "<kind>/<id>" }`; `AlreadyExists` → `InvalidInput`; rest → opaque `Internal`. Five leak-prevention tests asserting paths, ids, schema versions, SQL fragments don't reach the wire.
- **`docs/proto/ipc.md`** updated with all new methods, `Meeting` and `MeetingConfig` shapes, storage section, known limitations.

### Spec deviations (ratified inline)

- `StorageError::Sql { message: String }` instead of `Sql { source: rusqlite::Error }` — keeps `panops-core` rusqlite-free; constructed via `StorageError::sql<E: Display>` helper. Trade-off: callers can't downcast.
- CLI default mode does NOT register a meeting (spec amended; only `notes` mode registers). Reason: default mode produces no notes artifact, so a registry row would point at audio with no `note` row attached — misleading state for the future Mac shell.
- Single-DB layout (one `panops.db`) instead of registry+per-meeting split per the locked design doc — per-meeting DB lands when Anchor B has segment/speaker/screenshot/job content for it.

### Test surface (PR-gating: 18 tests)

- `storage_conformance` × 2 adapters (one suite, run against `InMemoryStorage` + `RusqliteStorage`)
- 10 new IPC integration test files: `ipc_meeting_list_returns_inserted_rows`, `ipc_meeting_start_creates_row_and_dir`, `ipc_meeting_stop_writes_ended_at`, `ipc_meeting_get_returns_full`, `ipc_meeting_set_language_persists`, `ipc_meeting_delete_removes_row_and_dir`, `ipc_notes_generate_auto_creates_meeting`, `ipc_notes_generate_with_existing_meeting_id`, `ipc_notes_generate_with_unknown_meeting_id`, `ipc_persistence_survives_restart`
- 7 retained slice-05 IPC tests (all updated to new `EngineServices::ready` signature)
- Plus `RusqliteStorage::new` schema-mismatch test, 5 `StorageError` → `IpcError` leak-prevention tests, 7 protocol round-trip tests for `Meeting`/`MeetingConfig`/extended `NotesGenerate*`

42 test groups pass workspace-wide; clippy + fmt clean.

## Test plan

- [ ] CI green on the matrix
- [ ] Copilot reviewer runs (per AGENTS.md PR merge rule — do not merge before Copilot has reviewed and threads are resolved)
- [ ] `cargo test --workspace --locked` clean
- [ ] Manual smoke: `panops-engine serve --data-dir /tmp/<x> --socket /tmp/<x>.sock` + `curl --unix-socket /tmp/<x>.sock -d '{...meeting.start...}' http://localhost/` → meeting id back, row in `panops.db`, dir created at `<data_dir>/meetings/<id>/screenshots/`
- [ ] Restart engine pointing at the same `--data-dir`; `meeting.list` returns the prior row (persistence)
- [ ] `meeting.delete` removes registry row + cascades notes + removes the on-disk meeting directory

## Out of slice 06 (deferred to later slices, NOT debt)

- Per-meeting `meeting.db` (segment / speaker / screenshot / job tables) → Anchor B (live capture)
- Schema migration framework → v0.2
- Cross-meeting full-text search → v0.2+
- Push events for storage mutations → no consumer today
- WAL + per-task connections → YAGNI; revisit only if real contention surfaces

## Spec + brainstorm

- Locked spec: `docs/superpowers/specs/2026-05-05-slice-06-storage-design.md`
- Brainstorm: `docs/superpowers/specs/2026-05-05-slice-06-storage-brainstorm.md`