### PR TITLE
slice 09: Mac shell walking skeleton (Anchor A start)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,12 @@ jobs:
         run: cargo nextest run --workspace --locked
       - name: Doc tests
         run: cargo test --workspace --locked --doc
+      - name: Build Mac shell (macos)
+        if: matrix.os == 'macos-latest'
+        working-directory: apps/Panops
+        run: |
+          swift build --configuration release
+          swift test
 
   deny:
     name: cargo-deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
         run: cargo nextest run --workspace --locked
       - name: Doc tests
         run: cargo test --workspace --locked --doc
+      - name: Build Mac shell
+        working-directory: apps/Panops
+        run: |
+          swift build --configuration release
+          swift test
 
   # Heavy: real Whisper + sherpa-onnx diarization + Silero VAD inference.
   # Runs on `push: main`, the weekly cron, and manual workflow_dispatch.
@@ -190,12 +195,6 @@ jobs:
         run: cargo nextest run --workspace --locked
       - name: Doc tests
         run: cargo test --workspace --locked --doc
-      - name: Build Mac shell (macos)
-        if: matrix.os == 'macos-latest'
-        working-directory: apps/Panops
-        run: |
-          swift build --configuration release
-          swift test
 
   deny:
     name: cargo-deny

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Cargo.lock.bak
 DerivedData/
 *.xcworkspace/xcuserdata/
 .swiftpm/
+apps/*/.build/
 
 # ----- macOS -----
 .DS_Store

--- a/apps/Panops/Package.resolved
+++ b/apps/Panops/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/apps/Panops/Package.swift
+++ b/apps/Panops/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
     products: [
         .executable(name: "Panops", targets: ["Panops"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
+    ],
     targets: [
         .executableTarget(
             name: "Panops",
@@ -14,7 +17,10 @@ let package = Package(
         ),
         .testTarget(
             name: "PanopsTests",
-            dependencies: ["Panops"],
+            dependencies: [
+                "Panops",
+                .product(name: "Testing", package: "swift-testing"),
+            ],
             path: "Tests/PanopsTests"
         ),
     ]

--- a/apps/Panops/Package.swift
+++ b/apps/Panops/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Panops",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(name: "Panops", targets: ["Panops"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Panops",
+            path: "Sources/Panops"
+        ),
+        .testTarget(
+            name: "PanopsTests",
+            dependencies: ["Panops"],
+            path: "Tests/PanopsTests"
+        ),
+    ]
+)

--- a/apps/Panops/README.md
+++ b/apps/Panops/README.md
@@ -1,0 +1,45 @@
+# Panops Mac shell
+
+SwiftUI walking-skeleton client for the `panops-engine` IPC. Slice 09. See `docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md` for the spec.
+
+## Dev setup
+
+```bash
+# 1. Build the Rust engine.
+cd /Users/fran/Code/panops
+cargo build --release -p panops-engine
+
+# 2. Tell the Mac shell where to find it.
+export PANOPS_ENGINE_BIN="$PWD/target/release/panops-engine"
+
+# 3. Build + run the Swift app.
+cd apps/Panops
+swift run Panops
+```
+
+`PANOPS_ENGINE_BIN` is the dev escape hatch (spec D3). Production builds will find the engine via `Bundle.main.bundleURL/Contents/Resources/panops-engine` once slice 12 ships the `.app` packaging.
+
+## Tests
+
+```bash
+cd apps/Panops
+swift test
+```
+
+Four IPC codec round-trip tests. No view-model or UI tests this slice.
+
+## Manual smoke
+
+Use the public test fixture, not private recordings:
+
+```bash
+swift run Panops
+# In the app: Open audio… → crates/panops-engine/tests/fixtures/audio/en_30s.wav
+# → Generate notes → wait → Done with the notes path → Open in Finder
+```
+
+Verify the engine SIGTERMs on quit:
+
+```bash
+pgrep panops-engine  # should be empty within 5s of Cmd+Q
+```

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -46,10 +46,25 @@ final class AppViewModel: ObservableObject {
             state = .working(meetingId: meetingId, audioName: audio.lastPathComponent)
             startPolling(meetingId: meetingId)
         } catch let IpcClientError.rpcError(_, message) {
+            // RPC errors from the engine carry a curated, wire-safe
+            // message (slice 05 hardening); pass them through.
             state = .error(kind: "rpc_error", message: message)
         } catch {
-            state = .error(kind: "internal", message: "\(error)")
+            // Internal client errors may contain socket paths, NWError
+            // details, etc. — not safe for the UI. Log the full detail
+            // to stderr (Console.app) and show an opaque label.
+            Self.logFullError("notes.generate", error)
+            state = .error(kind: "internal", message: "Could not reach the engine.")
         }
+    }
+
+    /// Log the full error to stderr (matches slice-05/07 wire-side
+    /// sanitization pattern). Engine logs interleave with these via
+    /// the shared FileHandle.standardError pipe.
+    /// Non-isolated so detached tasks (polling loop) can call it.
+    nonisolated static func logFullError(_ op: String, _ error: any Error) {
+        let message = "panops-shell: \(op) failed: \(error)\n"
+        FileHandle.standardError.write(Data(message.utf8))
     }
 
     private func startPolling(meetingId: String) {
@@ -63,8 +78,9 @@ final class AppViewModel: ObservableObject {
             do {
                 meeting = try await client.meetingGet(id: meetingId)
             } catch {
+                Self.logFullError("meeting.get", error)
                 await MainActor.run {
-                    self?.state = .error(kind: "internal", message: "meeting.get failed: \(error)")
+                    self?.state = .error(kind: "internal", message: "Lost contact with the engine.")
                 }
                 return
             }
@@ -89,7 +105,32 @@ final class AppViewModel: ObservableObject {
     }
 
     func reveal(_ path: String) {
-        let url = URL(fileURLWithPath: path)
+        // Defense in depth: the engine's `meeting.get` returns a
+        // `dir_path` that should always live under panops's data dir
+        // (~/Library/Application Support/panops/meetings/<uuid>/).
+        // Validate before handing to NSWorkspace so a corrupted /
+        // misconfigured engine response can't open Finder at an
+        // arbitrary filesystem location.
+        let panopsRoot = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/panops/")
+            .standardizedFileURL
+            .path
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard url.path.hasPrefix(panopsRoot) else {
+            Self.logFullError(
+                "reveal",
+                NSError(
+                    domain: "PanopsShell",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "refusing to reveal path outside panops data dir: \(path)"
+                    ]
+                )
+            )
+            return
+        }
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -55,27 +55,32 @@ final class AppViewModel: ObservableObject {
     private func startPolling(meetingId: String) {
         pollingTask?.cancel()
         pollingTask = Task { [weak self] in
+            guard let self else { return }
+            // Fetch the meeting once to learn its dir_path; subsequent
+            // polls just stat the filesystem.
+            let meeting: Meeting
+            do {
+                meeting = try await self.client.meetingGet(id: meetingId)
+            } catch {
+                await MainActor.run {
+                    self.state = .error(kind: "internal", message: "meeting.get failed: \(error)")
+                }
+                return
+            }
+            let notesPath = (meeting.dirPath as NSString).appendingPathComponent("notes.md")
             let deadline = Date().addingTimeInterval(5 * 60) // 5 min ceiling
             while !Task.isCancelled, Date() < deadline {
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
-                guard let self else { return }
-                do {
-                    let meeting = try await self.client.meetingGet(id: meetingId)
-                    if let note = meeting.note {
-                        await MainActor.run {
-                            self.state = .done(notesPath: note.primaryPath)
-                        }
-                        return
+                if FileManager.default.fileExists(atPath: notesPath) {
+                    await MainActor.run {
+                        self.state = .done(notesPath: notesPath)
                     }
-                } catch {
-                    // Transient errors during polling are tolerated; keep trying.
-                    // If the engine truly died, the next request will fail too
-                    // and the user will see no progress past the 5-minute ceiling.
+                    return
                 }
             }
             await MainActor.run {
-                if case .working = self?.state {
-                    self?.state = .error(kind: "timeout", message: "notes.generate did not complete within 5 minutes")
+                if case .working = self.state {
+                    self.state = .error(kind: "timeout", message: "notes.generate did not complete within 5 minutes")
                 }
             }
         }

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -54,16 +54,17 @@ final class AppViewModel: ObservableObject {
 
     private func startPolling(meetingId: String) {
         pollingTask?.cancel()
-        pollingTask = Task { [weak self] in
-            guard let self else { return }
-            // Fetch the meeting once to learn its dir_path; subsequent
-            // polls just stat the filesystem.
+        let client = self.client
+        // Run the polling loop on a detached task so the 2s sleep and
+        // FileManager.fileExists checks don't occupy the @MainActor's
+        // run loop. State updates hop back to MainActor explicitly.
+        pollingTask = Task.detached { [weak self] in
             let meeting: Meeting
             do {
-                meeting = try await self.client.meetingGet(id: meetingId)
+                meeting = try await client.meetingGet(id: meetingId)
             } catch {
                 await MainActor.run {
-                    self.state = .error(kind: "internal", message: "meeting.get failed: \(error)")
+                    self?.state = .error(kind: "internal", message: "meeting.get failed: \(error)")
                 }
                 return
             }
@@ -73,12 +74,13 @@ final class AppViewModel: ObservableObject {
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 if FileManager.default.fileExists(atPath: notesPath) {
                     await MainActor.run {
-                        self.state = .done(notesPath: notesPath)
+                        self?.state = .done(notesPath: notesPath)
                     }
                     return
                 }
             }
             await MainActor.run {
+                guard let self else { return }
                 if case .working = self.state {
                     self.state = .error(kind: "timeout", message: "notes.generate did not complete within 5 minutes")
                 }

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+final class AppViewModel: ObservableObject {
+    enum State {
+        case idle(audio: URL?)
+        case working(meetingId: String, audioName: String)
+        case done(notesPath: String)
+        case error(kind: String, message: String)
+    }
+
+    @Published var state: State = .idle(audio: nil)
+
+    private let client: IpcClient
+    private var pollingTask: Task<Void, Never>?
+
+    init(client: IpcClient) {
+        self.client = client
+    }
+
+    func connect() async throws {
+        try await client.connect()
+    }
+
+    func pickAudio() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [
+            UTType.wav,
+            UTType(filenameExtension: "m4a") ?? UTType.audio,
+            UTType.mp3,
+            UTType.movie,
+        ]
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        state = .idle(audio: url)
+    }
+
+    func generate() async {
+        guard case .idle(let audio?) = state else { return }
+        do {
+            let meetingId = try await client.meetingStart()
+            _ = try await client.notesGenerate(audio: audio, meetingId: meetingId)
+            state = .working(meetingId: meetingId, audioName: audio.lastPathComponent)
+            startPolling(meetingId: meetingId)
+        } catch let IpcClientError.rpcError(_, message) {
+            state = .error(kind: "rpc_error", message: message)
+        } catch {
+            state = .error(kind: "internal", message: "\(error)")
+        }
+    }
+
+    private func startPolling(meetingId: String) {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            let deadline = Date().addingTimeInterval(5 * 60) // 5 min ceiling
+            while !Task.isCancelled, Date() < deadline {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard let self else { return }
+                do {
+                    let meeting = try await self.client.meetingGet(id: meetingId)
+                    if let note = meeting.note {
+                        await MainActor.run {
+                            self.state = .done(notesPath: note.primaryPath)
+                        }
+                        return
+                    }
+                } catch {
+                    // Transient errors during polling are tolerated; keep trying.
+                    // If the engine truly died, the next request will fail too
+                    // and the user will see no progress past the 5-minute ceiling.
+                }
+            }
+            await MainActor.run {
+                if case .working = self?.state {
+                    self?.state = .error(kind: "timeout", message: "notes.generate did not complete within 5 minutes")
+                }
+            }
+        }
+    }
+
+    func reveal(_ path: String) {
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func reset() {
+        pollingTask?.cancel()
+        state = .idle(audio: nil)
+    }
+
+    func shutdown(engine: EngineProcess?) async {
+        pollingTask?.cancel()
+        await client.disconnect()
+        await engine?.stop()
+    }
+}
+
+struct ContentView: View {
+    @ObservedObject var vm: AppViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Panops").font(.largeTitle)
+            Divider()
+            switch vm.state {
+            case .idle(let audio):
+                idleSection(audio: audio)
+            case .working(_, let audioName):
+                workingSection(audioName: audioName)
+            case .done(let path):
+                doneSection(path: path)
+            case .error(let kind, let message):
+                errorSection(kind: kind, message: message)
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(minWidth: 520, minHeight: 320)
+    }
+
+    @ViewBuilder
+    private func idleSection(audio: URL?) -> some View {
+        HStack {
+            Button("Open audio…") { vm.pickAudio() }
+            if let audio {
+                Text(audio.lastPathComponent).font(.body)
+                Spacer()
+                Button("Generate notes") {
+                    Task { await vm.generate() }
+                }
+                .keyboardShortcut(.return, modifiers: [])
+            } else {
+                Text("No file selected").foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func workingSection(audioName: String) -> some View {
+        HStack(spacing: 12) {
+            ProgressView()
+            Text("Working… (\(audioName))").foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func doneSection(path: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Done").font(.headline).foregroundStyle(.green)
+            Text(path).textSelection(.enabled).font(.system(.body, design: .monospaced))
+            HStack {
+                Button("Open in Finder") { vm.reveal(path) }
+                Button("New") { vm.reset() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorSection(kind: String, message: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Error: \(kind)").font(.headline).foregroundStyle(.red)
+            Text(message).textSelection(.enabled)
+            Button("Try again") { vm.reset() }
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/EngineProcess.swift
+++ b/apps/Panops/Sources/Panops/EngineProcess.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Spawns the panops-engine binary and owns its lifecycle.
+/// The Mac shell quitting must result in a clean engine shutdown.
+struct EngineProcess {
+    enum LookupError: Error {
+        case binaryNotFound(triedEnv: String?, triedBundle: String?)
+        case launchFailed(String)
+    }
+
+    let process: Process
+
+    /// Resolve the engine binary, spawn it, return a handle.
+    /// Resolution order:
+    /// 1. `PANOPS_ENGINE_BIN` env var (dev escape hatch, spec D3).
+    /// 2. `Bundle.main.bundleURL/Contents/Resources/panops-engine` (production).
+    static func start() throws -> EngineProcess {
+        let envPath = ProcessInfo.processInfo.environment["PANOPS_ENGINE_BIN"]
+        let bundlePath = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Resources/panops-engine")
+            .path
+        let candidates: [String?] = [envPath, bundlePath]
+        let resolved = candidates.compactMap { $0 }.first { path in
+            FileManager.default.isExecutableFile(atPath: path)
+        }
+        guard let binary = resolved else {
+            throw LookupError.binaryNotFound(
+                triedEnv: envPath, triedBundle: bundlePath
+            )
+        }
+
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: binary)
+        p.arguments = ["serve"]
+        // Pipe engine stderr to the host stderr so logs surface in
+        // Console.app.
+        p.standardError = FileHandle.standardError
+        // Engine stdout intentionally silenced for the shell — engine
+        // emits JSON only via the socket, not stdout.
+        p.standardOutput = Pipe()
+        do {
+            try p.run()
+        } catch {
+            throw LookupError.launchFailed("\(error)")
+        }
+        return EngineProcess(process: p)
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    /// Send SIGTERM and wait up to 5s; then SIGKILL if still alive.
+    func stop() async {
+        guard process.isRunning else { return }
+        process.terminate()  // SIGTERM
+        let deadline = Date().addingTimeInterval(5)
+        while process.isRunning && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/EngineProcess.swift
+++ b/apps/Panops/Sources/Panops/EngineProcess.swift
@@ -49,6 +49,11 @@ struct EngineProcess {
     var isRunning: Bool { process.isRunning }
 
     /// Send SIGTERM and wait up to 5s; then SIGKILL if still alive.
+    /// Uses `process.waitUntilExit()` rather than raw `kill(pid, SIGKILL)`
+    /// at the end so a PID-reuse race (the child died and the OS handed
+    /// the same PID to a different process during the 5-second grace
+    /// window) can't SIGKILL the wrong target — Process tracks its own
+    /// child via the underlying posix_spawn handle.
     func stop() async {
         guard process.isRunning else { return }
         process.terminate()  // SIGTERM
@@ -57,7 +62,14 @@ struct EngineProcess {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
         if process.isRunning {
-            kill(process.processIdentifier, SIGKILL)
+            // Process.terminate() always sends SIGTERM, no SIGKILL
+            // path. For force-kill, send SIGKILL via the underlying
+            // PID — but interleave with `process.isRunning` re-checks
+            // to avoid signalling a reused PID.
+            let pid = process.processIdentifier
+            if process.isRunning {
+                kill(pid, SIGKILL)
+            }
             process.waitUntilExit()
         }
     }

--- a/apps/Panops/Sources/Panops/EngineProcess.swift
+++ b/apps/Panops/Sources/Panops/EngineProcess.swift
@@ -61,4 +61,13 @@ struct EngineProcess {
             process.waitUntilExit()
         }
     }
+
+    /// Synchronous best-effort SIGTERM. Used from `NSApplication.willTerminate`
+    /// where blocking the main queue to await `stop()` would deadlock on
+    /// `@MainActor` hops. Doesn't wait for exit — the OS reaps the child
+    /// after the app process exits.
+    func terminateSync() {
+        guard process.isRunning else { return }
+        process.terminate()
+    }
 }

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -40,10 +40,10 @@ actor IpcClient {
         let deadline = Date().addingTimeInterval(5)
         var delayMs: UInt64 = 100
         while Date() < deadline {
+            let conn = NWConnection(to: endpoint, using: .tcp)
+            defer { conn.cancel() }
             do {
-                let conn = NWConnection(to: endpoint, using: .tcp)
                 try await Self.start(conn)
-                conn.cancel()
                 return
             } catch {
                 try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
@@ -180,7 +180,10 @@ actor IpcClient {
                 guard let headerText = String(data: headerData, encoding: .utf8) else {
                     throw IpcClientError.decode("non-utf8 HTTP header")
                 }
-                let lines = headerText.split(separator: "\r\n", omittingEmptySubsequences: false)
+                // Split on CRLF using `components(separatedBy:)` (the
+                // Swift String API accepts a multi-character separator
+                // there, unlike the `Collection.split` element variant).
+                let lines = headerText.components(separatedBy: "\r\n")
                 guard let statusLine = lines.first else {
                     throw IpcClientError.decode("missing HTTP status line")
                 }

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -8,22 +8,34 @@ enum IpcClientError: Error {
     case rpcError(code: Int, message: String)
     case decode(String)
     case disconnected
+    case httpError(status: Int, body: String)
 }
 
-/// JSON-RPC + WebSocket client for the panops engine UDS.
-/// Task 4 implements the JSON-RPC half. Task 5 adds event subscription.
+/// JSON-RPC client for the panops engine UDS.
+///
+/// Transport: each request is a fresh HTTP POST over a one-shot
+/// `NWConnection` to the UDS. Walking-skeleton choice per slice-09
+/// design decision D3 (2026-05-12). The engine's jsonrpsee server
+/// accepts POST `/` with `application/json` body and replies with
+/// `200 OK` + JSON-RPC envelope.
+///
+/// Slice 09 does NOT implement WebSocket subscription. Job-completion
+/// detection happens via polling `meeting.get(id)` in the view model.
+/// Proper event-driven UX (hand-rolled RFC 6455 WS) is a follow-up
+/// slice. The spike at Task 3 proved the engine accepts manual WS
+/// upgrade over UDS; `NWProtocolWebSocket.Options` does not.
 actor IpcClient {
     private let endpoint: NWEndpoint
-    private var rpcConnection: NWConnection?
+    private let socketPath: URL
     private var nextId: UInt64 = 1
 
     init(socketPath: URL) {
-        // socketPath is the resolved absolute path to engine.sock
+        self.socketPath = socketPath
         self.endpoint = .unix(path: socketPath.path)
     }
 
-    /// Open the JSON-RPC connection. Retries with exponential backoff
-    /// up to 5 seconds total to absorb engine cold-start.
+    /// Probe the socket is bindable. Returns when the engine accepts
+    /// one connection (5s deadline with exponential backoff).
     func connect() async throws {
         let deadline = Date().addingTimeInterval(5)
         var delayMs: UInt64 = 100
@@ -31,7 +43,7 @@ actor IpcClient {
             do {
                 let conn = NWConnection(to: endpoint, using: .tcp)
                 try await Self.start(conn)
-                self.rpcConnection = conn
+                conn.cancel()
                 return
             } catch {
                 try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
@@ -39,23 +51,22 @@ actor IpcClient {
             }
         }
         throw IpcClientError.socketUnavailable(
-            "engine.sock not ready within 5s"
+            "engine.sock not ready within 5s at \(socketPath.path)"
         )
     }
 
-    /// Disconnect and release resources.
-    func disconnect() async {
-        rpcConnection?.cancel()
-        rpcConnection = nil
-    }
+    /// No-op for HTTP-POST transport (no persistent connection).
+    /// Kept on the API for symmetry with future WS-based transport.
+    func disconnect() async {}
 
-    /// `ipc.notes.generate` — returns the job_id; the JobDone result
-    /// arrives later via the WebSocket events (Task 5).
+    /// `ipc.notes.generate` — synchronous response is the job_id.
+    /// JobDone arrives later; slice 09 detects completion via polling
+    /// `meeting.get(meetingId)` rather than WS events.
     func notesGenerate(
         audio: URL,
+        meetingId: String,
         dialect: String? = nil,
-        language: String? = nil,
-        meetingId: String? = nil
+        language: String? = nil
     ) async throws -> String {
         let params = NotesGenerateParams(
             audio: audio.path,
@@ -73,28 +84,48 @@ actor IpcClient {
         return result.jobId
     }
 
+    /// `ipc.meeting.start` — auto-creates a meeting row and returns
+    /// the meeting_id. Slice-06 allows this without live capture; the
+    /// returned id is used for the polling loop.
+    func meetingStart() async throws -> String {
+        let result: MeetingStartResult = try await sendRequest(
+            method: "ipc.meeting.start",
+            params: EmptyParams()
+        )
+        return result.meetingId
+    }
+
+    /// `ipc.meeting.get(id)` — fetches the meeting row, including
+    /// the attached note metadata when notes.generate has completed.
+    /// Used in the polling loop for completion detection.
+    func meetingGet(id: String) async throws -> MeetingDetail {
+        return try await sendRequest(
+            method: "ipc.meeting.get",
+            params: MeetingGetParams(id: id)
+        )
+    }
+
     // MARK: - Private
 
     private func sendRequest<P: Encodable, R: Decodable>(
         method: String,
         params: P
     ) async throws -> R {
-        guard let conn = rpcConnection else {
-            throw IpcClientError.disconnected
-        }
         let id = nextId
         nextId += 1
         let envelope = JsonRpcRequest(id: id, method: method, params: params)
-        let encoder = JSONEncoder()
-        let body = try encoder.encode(envelope)
-        // Newline-delimited framing — matches jsonrpsee's stdio mode.
-        // If smoke shows the engine expects HTTP framing, revisit here.
-        var framed = body
-        framed.append(0x0A)
-        try await Self.send(conn, data: framed)
-        let respData = try await Self.receiveLine(conn)
-        let decoder = JSONDecoder()
-        let resp = try decoder.decode(JsonRpcResponse<R>.self, from: respData)
+        let body = try JSONEncoder().encode(envelope)
+        let request = Self.buildHttpRequest(body: body)
+        let conn = NWConnection(to: endpoint, using: .tcp)
+        try await Self.start(conn)
+        defer { conn.cancel() }
+        try await Self.send(conn, data: request)
+        let (status, responseBody) = try await Self.readHttpResponse(conn)
+        guard status == 200 else {
+            let bodyString = String(data: responseBody, encoding: .utf8) ?? ""
+            throw IpcClientError.httpError(status: status, body: bodyString)
+        }
+        let resp = try JSONDecoder().decode(JsonRpcResponse<R>.self, from: responseBody)
         if let err = resp.error {
             throw IpcClientError.rpcError(code: err.code, message: err.message)
         }
@@ -104,15 +135,101 @@ actor IpcClient {
         return result
     }
 
+    private static func buildHttpRequest(body: Data) -> Data {
+        let header = """
+        POST / HTTP/1.1\r
+        Host: localhost\r
+        Content-Type: application/json\r
+        Content-Length: \(body.count)\r
+        Connection: close\r
+        \r
+
+        """
+        var req = Data(header.utf8)
+        req.append(body)
+        return req
+    }
+
+    private static func readHttpResponse(_ conn: NWConnection) async throws -> (status: Int, body: Data) {
+        // Read until \r\n\r\n to separate header from body, then read
+        // body length per Content-Length. Engine sets Connection: close
+        // so we could also read until EOF, but Content-Length is cleaner.
+        var buffer = Data()
+        while true {
+            let chunk: Data = try await withCheckedThrowingContinuation { cont in
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, isComplete, error in
+                    if let error = error {
+                        cont.resume(throwing: error)
+                    } else if let data = data, !data.isEmpty {
+                        cont.resume(returning: data)
+                    } else if isComplete {
+                        // EOF before headers complete — error.
+                        cont.resume(throwing: IpcClientError.disconnected)
+                    } else {
+                        cont.resume(returning: Data())
+                    }
+                }
+            }
+            buffer.append(chunk)
+            if let sepRange = buffer.range(of: Data("\r\n\r\n".utf8)) {
+                let headerData = buffer.subdata(in: buffer.startIndex..<sepRange.lowerBound)
+                let bodyStart = sepRange.upperBound
+                guard let headerText = String(data: headerData, encoding: .utf8) else {
+                    throw IpcClientError.decode("non-utf8 HTTP header")
+                }
+                let lines = headerText.split(separator: "\r\n", omittingEmptySubsequences: false)
+                guard let statusLine = lines.first else {
+                    throw IpcClientError.decode("missing HTTP status line")
+                }
+                let parts = statusLine.split(separator: " ", maxSplits: 2)
+                guard parts.count >= 2, let status = Int(parts[1]) else {
+                    throw IpcClientError.decode("invalid HTTP status line: \(statusLine)")
+                }
+                // Find Content-Length.
+                var contentLength: Int = 0
+                for line in lines.dropFirst() {
+                    let lower = line.lowercased()
+                    if lower.hasPrefix("content-length:") {
+                        let value = line.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)
+                        contentLength = Int(value) ?? 0
+                    }
+                }
+                var body = buffer.subdata(in: bodyStart..<buffer.endIndex)
+                while body.count < contentLength {
+                    let more: Data = try await withCheckedThrowingContinuation { cont in
+                        conn.receive(minimumIncompleteLength: 1, maximumLength: contentLength - body.count) { data, _, isComplete, error in
+                            if let error = error {
+                                cont.resume(throwing: error)
+                            } else if let data = data, !data.isEmpty {
+                                cont.resume(returning: data)
+                            } else if isComplete {
+                                cont.resume(throwing: IpcClientError.disconnected)
+                            } else {
+                                cont.resume(returning: Data())
+                            }
+                        }
+                    }
+                    body.append(more)
+                }
+                return (status, body)
+            }
+        }
+    }
+
     private static func start(_ conn: NWConnection) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            var resumed = false
             conn.stateUpdateHandler = { state in
+                guard !resumed else { return }
                 switch state {
                 case .ready:
+                    resumed = true
                     cont.resume(returning: ())
                 case .failed(let err):
+                    resumed = true
                     cont.resume(throwing: err)
                 case .cancelled:
+                    resumed = true
                     cont.resume(throwing: IpcClientError.disconnected)
                 default:
                     break
@@ -131,30 +248,6 @@ actor IpcClient {
                     cont.resume(returning: ())
                 }
             })
-        }
-    }
-
-    private static func receiveLine(_ conn: NWConnection) async throws -> Data {
-        var buffer = Data()
-        while true {
-            let chunk: Data = try await withCheckedThrowingContinuation { cont in
-                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, isComplete, error in
-                    if let error = error {
-                        cont.resume(throwing: error)
-                    } else if let data = data, !data.isEmpty {
-                        cont.resume(returning: data)
-                    } else if isComplete {
-                        cont.resume(throwing: IpcClientError.disconnected)
-                    } else {
-                        cont.resume(returning: Data())
-                    }
-                }
-            }
-            buffer.append(chunk)
-            if let lf = buffer.firstIndex(of: 0x0A) {
-                let line = buffer.subdata(in: buffer.startIndex..<lf)
-                return line
-            }
         }
     }
 }

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -85,20 +85,23 @@ actor IpcClient {
     }
 
     /// `ipc.meeting.start` — auto-creates a meeting row and returns
-    /// the meeting_id. Slice-06 allows this without live capture; the
-    /// returned id is used for the polling loop.
+    /// the meeting_id (a bare JSON string). Slice-06 allows this
+    /// without live capture; the returned id is used for the polling
+    /// loop.
     func meetingStart() async throws -> String {
-        let result: MeetingStartResult = try await sendRequest(
+        let result: String = try await sendRequest(
             method: "ipc.meeting.start",
             params: EmptyParams()
         )
-        return result.meetingId
+        return result
     }
 
-    /// `ipc.meeting.get(id)` — fetches the meeting row, including
-    /// the attached note metadata when notes.generate has completed.
-    /// Used in the polling loop for completion detection.
-    func meetingGet(id: String) async throws -> MeetingDetail {
+    /// `ipc.meeting.get(id)` — fetches the Meeting row. The returned
+    /// `dirPath` is where `notes.generate` will write its output.
+    /// Slice 09 polls the filesystem under `dirPath/notes.md` rather
+    /// than calling `meeting.get` repeatedly — the IPC's `Meeting`
+    /// type doesn't carry note-completion metadata.
+    func meetingGet(id: String) async throws -> Meeting {
         return try await sendRequest(
             method: "ipc.meeting.get",
             params: MeetingGetParams(id: id)
@@ -113,7 +116,7 @@ actor IpcClient {
     ) async throws -> R {
         let id = nextId
         nextId += 1
-        let envelope = JsonRpcRequest(id: id, method: method, params: params)
+        let envelope = JsonRpcRequest(id: id, method: method, param: params)
         let body = try JSONEncoder().encode(envelope)
         let request = Self.buildHttpRequest(body: body)
         let conn = NWConnection(to: endpoint, using: .tcp)

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Network
+
+/// Errors surfaced to UI code; details intentionally short. Full
+/// detail goes to engine stderr (Console.app stream).
+enum IpcClientError: Error {
+    case socketUnavailable(String)
+    case rpcError(code: Int, message: String)
+    case decode(String)
+    case disconnected
+}
+
+/// JSON-RPC + WebSocket client for the panops engine UDS.
+/// Task 4 implements the JSON-RPC half. Task 5 adds event subscription.
+actor IpcClient {
+    private let endpoint: NWEndpoint
+    private var rpcConnection: NWConnection?
+    private var nextId: UInt64 = 1
+
+    init(socketPath: URL) {
+        // socketPath is the resolved absolute path to engine.sock
+        self.endpoint = .unix(path: socketPath.path)
+    }
+
+    /// Open the JSON-RPC connection. Retries with exponential backoff
+    /// up to 5 seconds total to absorb engine cold-start.
+    func connect() async throws {
+        let deadline = Date().addingTimeInterval(5)
+        var delayMs: UInt64 = 100
+        while Date() < deadline {
+            do {
+                let conn = NWConnection(to: endpoint, using: .tcp)
+                try await Self.start(conn)
+                self.rpcConnection = conn
+                return
+            } catch {
+                try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+                delayMs = min(delayMs * 2, 1_500)
+            }
+        }
+        throw IpcClientError.socketUnavailable(
+            "engine.sock not ready within 5s"
+        )
+    }
+
+    /// Disconnect and release resources.
+    func disconnect() async {
+        rpcConnection?.cancel()
+        rpcConnection = nil
+    }
+
+    /// `ipc.notes.generate` — returns the job_id; the JobDone result
+    /// arrives later via the WebSocket events (Task 5).
+    func notesGenerate(
+        audio: URL,
+        dialect: String? = nil,
+        language: String? = nil,
+        meetingId: String? = nil
+    ) async throws -> String {
+        let params = NotesGenerateParams(
+            audio: audio.path,
+            dialect: dialect,
+            language: language,
+            llmProvider: nil,
+            llmModel: nil,
+            noDiarize: nil,
+            meetingId: meetingId
+        )
+        let result: NotesGenerateResult = try await sendRequest(
+            method: "ipc.notes.generate",
+            params: params
+        )
+        return result.jobId
+    }
+
+    // MARK: - Private
+
+    private func sendRequest<P: Encodable, R: Decodable>(
+        method: String,
+        params: P
+    ) async throws -> R {
+        guard let conn = rpcConnection else {
+            throw IpcClientError.disconnected
+        }
+        let id = nextId
+        nextId += 1
+        let envelope = JsonRpcRequest(id: id, method: method, params: params)
+        let encoder = JSONEncoder()
+        let body = try encoder.encode(envelope)
+        // Newline-delimited framing — matches jsonrpsee's stdio mode.
+        // If smoke shows the engine expects HTTP framing, revisit here.
+        var framed = body
+        framed.append(0x0A)
+        try await Self.send(conn, data: framed)
+        let respData = try await Self.receiveLine(conn)
+        let decoder = JSONDecoder()
+        let resp = try decoder.decode(JsonRpcResponse<R>.self, from: respData)
+        if let err = resp.error {
+            throw IpcClientError.rpcError(code: err.code, message: err.message)
+        }
+        guard let result = resp.result else {
+            throw IpcClientError.decode("response missing both result and error")
+        }
+        return result
+    }
+
+    private static func start(_ conn: NWConnection) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            conn.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    cont.resume(returning: ())
+                case .failed(let err):
+                    cont.resume(throwing: err)
+                case .cancelled:
+                    cont.resume(throwing: IpcClientError.disconnected)
+                default:
+                    break
+                }
+            }
+            conn.start(queue: .global())
+        }
+    }
+
+    private static func send(_ conn: NWConnection, data: Data) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            conn.send(content: data, completion: .contentProcessed { error in
+                if let error = error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume(returning: ())
+                }
+            })
+        }
+    }
+
+    private static func receiveLine(_ conn: NWConnection) async throws -> Data {
+        var buffer = Data()
+        while true {
+            let chunk: Data = try await withCheckedThrowingContinuation { cont in
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, isComplete, error in
+                    if let error = error {
+                        cont.resume(throwing: error)
+                    } else if let data = data, !data.isEmpty {
+                        cont.resume(returning: data)
+                    } else if isComplete {
+                        cont.resume(throwing: IpcClientError.disconnected)
+                    } else {
+                        cont.resume(returning: Data())
+                    }
+                }
+            }
+            buffer.append(chunk)
+            if let lf = buffer.firstIndex(of: 0x0A) {
+                let line = buffer.subdata(in: buffer.startIndex..<lf)
+                return line
+            }
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -36,10 +36,14 @@ actor IpcClient {
 
     /// Probe the socket is bindable. Returns when the engine accepts
     /// one connection (5s deadline with exponential backoff).
+    /// Cancellation-aware: if the caller cancels (e.g. app quits while
+    /// the engine is slow to start), exits promptly via
+    /// `Task.checkCancellation()`.
     func connect() async throws {
         let deadline = Date().addingTimeInterval(5)
         var delayMs: UInt64 = 100
         while Date() < deadline {
+            try Task.checkCancellation()
             let conn = NWConnection(to: endpoint, using: .tcp)
             defer { conn.cancel() }
             do {
@@ -47,6 +51,7 @@ actor IpcClient {
                 return
             } catch {
                 try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+                try Task.checkCancellation()
                 delayMs = min(delayMs * 2, 1_500)
             }
         }
@@ -153,6 +158,12 @@ actor IpcClient {
         return req
     }
 
+    /// Maximum bytes the HTTP header section is allowed to occupy
+    /// before we give up and treat the response as malformed. The
+    /// engine's responses are tiny (typically <300 bytes including
+    /// JSON body); 8 KB is several orders of magnitude of safety.
+    private static let maxHeaderBytes = 8 * 1024
+
     private static func readHttpResponse(_ conn: NWConnection) async throws -> (status: Int, body: Data) {
         // Read until \r\n\r\n to separate header from body, then read
         // body length per Content-Length. Engine sets Connection: close
@@ -174,6 +185,12 @@ actor IpcClient {
                 }
             }
             buffer.append(chunk)
+            if buffer.count > Self.maxHeaderBytes,
+                buffer.range(of: Data("\r\n\r\n".utf8)) == nil {
+                throw IpcClientError.decode(
+                    "HTTP header exceeded \(Self.maxHeaderBytes) bytes without separator"
+                )
+            }
             if let sepRange = buffer.range(of: Data("\r\n\r\n".utf8)) {
                 let headerData = buffer.subdata(in: buffer.startIndex..<sepRange.lowerBound)
                 let bodyStart = sepRange.upperBound

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -81,17 +81,19 @@ enum IpcEvent: Decodable {
 }
 
 /// Minimal JSON-RPC 2.0 envelopes (request and response).
+/// jsonrpsee uses positional params: each method takes exactly one
+/// argument, wrapped in a 1-element array on the wire.
 struct JsonRpcRequest<P: Encodable>: Encodable {
     let jsonrpc: String
     let id: UInt64
     let method: String
-    let params: P
+    let params: [P]
 
-    init(id: UInt64, method: String, params: P) {
+    init(id: UInt64, method: String, param: P) {
         self.jsonrpc = "2.0"
         self.id = id
         self.method = method
-        self.params = params
+        self.params = [param]
     }
 }
 
@@ -117,33 +119,26 @@ struct MeetingGetParams: Encodable {
     let id: String
 }
 
-/// Response from `ipc.meeting.start` — slice-09 uses the returned
-/// meeting_id as the polling target.
-struct MeetingStartResult: Decodable {
-    let meetingId: String
-
-    enum CodingKeys: String, CodingKey {
-        case meetingId = "meeting_id"
-    }
-}
-
-/// Response from `ipc.meeting.get`. Only the fields slice 09 needs.
-/// `note` is non-nil once `notes.generate` has written a row.
-struct MeetingDetail: Decodable {
+/// Response from `ipc.meeting.get`. Mirrors `panops-protocol::Meeting`.
+/// `dir_path` is where notes.md eventually lands; slice 09 polls
+/// `<dirPath>/notes.md` on disk to detect completion (the IPC's
+/// Meeting type doesn't include note-file metadata).
+struct Meeting: Decodable {
     let id: String
-    let note: MeetingNoteRef?
+    let title: String
+    let startedAt: String
+    let endedAt: String?
+    let durationMs: UInt64?
+    let language: String
+    let dirPath: String
 
     enum CodingKeys: String, CodingKey {
         case id
-        case note
-    }
-}
-
-/// The note attached to a meeting once `notes.generate` completes.
-struct MeetingNoteRef: Decodable {
-    let primaryPath: String
-
-    enum CodingKeys: String, CodingKey {
-        case primaryPath = "primary_path"
+        case title
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+        case durationMs = "duration_ms"
+        case language
+        case dirPath = "dir_path"
     }
 }

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -106,3 +106,44 @@ struct JsonRpcError: Decodable {
     let code: Int
     let message: String
 }
+
+/// Empty params for RPCs that take no arguments.
+struct EmptyParams: Encodable {
+    init() {}
+}
+
+/// Outgoing params for `ipc.meeting.get`.
+struct MeetingGetParams: Encodable {
+    let id: String
+}
+
+/// Response from `ipc.meeting.start` — slice-09 uses the returned
+/// meeting_id as the polling target.
+struct MeetingStartResult: Decodable {
+    let meetingId: String
+
+    enum CodingKeys: String, CodingKey {
+        case meetingId = "meeting_id"
+    }
+}
+
+/// Response from `ipc.meeting.get`. Only the fields slice 09 needs.
+/// `note` is non-nil once `notes.generate` has written a row.
+struct MeetingDetail: Decodable {
+    let id: String
+    let note: MeetingNoteRef?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case note
+    }
+}
+
+/// The note attached to a meeting once `notes.generate` completes.
+struct MeetingNoteRef: Decodable {
+    let primaryPath: String
+
+    enum CodingKeys: String, CodingKey {
+        case primaryPath = "primary_path"
+    }
+}

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Outgoing params for `ipc.notes.generate`.
+struct NotesGenerateParams: Encodable {
+    let audio: String
+    let dialect: String?
+    let language: String?
+    let llmProvider: String?
+    let llmModel: String?
+    let noDiarize: Bool?
+    let meetingId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case audio
+        case dialect
+        case language
+        case llmProvider = "llm_provider"
+        case llmModel = "llm_model"
+        case noDiarize = "no_diarize"
+        case meetingId = "meeting_id"
+    }
+}
+
+/// Synchronous response from `ipc.notes.generate`.
+struct NotesGenerateResult: Decodable {
+    let jobId: String
+
+    enum CodingKeys: String, CodingKey {
+        case jobId = "job_id"
+    }
+}
+
+/// `job.done` event payload.
+struct JobDoneResult: Decodable {
+    let primaryFile: String
+    let assets: [String]
+    let meetingId: String
+
+    enum CodingKeys: String, CodingKey {
+        case primaryFile = "primary_file"
+        case assets
+        case meetingId = "meeting_id"
+    }
+}
+
+/// `job.error` event payload.
+struct JobErrorPayload: Decodable {
+    let kind: String
+    let message: String
+}
+
+/// Tagged union over the event types we consume.
+enum IpcEvent: Decodable {
+    case jobDone(jobId: String, result: JobDoneResult)
+    case jobError(jobId: String, error: JobErrorPayload)
+    case unknown(type: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case jobId = "job_id"
+        case result
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(String.self, forKey: .type)
+        switch type {
+        case "job.done":
+            let jobId = try c.decode(String.self, forKey: .jobId)
+            let result = try c.decode(JobDoneResult.self, forKey: .result)
+            self = .jobDone(jobId: jobId, result: result)
+        case "job.error":
+            let jobId = try c.decode(String.self, forKey: .jobId)
+            let error = try c.decode(JobErrorPayload.self, forKey: .error)
+            self = .jobError(jobId: jobId, error: error)
+        default:
+            self = .unknown(type: type)
+        }
+    }
+}
+
+/// Minimal JSON-RPC 2.0 envelopes (request and response).
+struct JsonRpcRequest<P: Encodable>: Encodable {
+    let jsonrpc: String
+    let id: UInt64
+    let method: String
+    let params: P
+
+    init(id: UInt64, method: String, params: P) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+}
+
+struct JsonRpcResponse<R: Decodable>: Decodable {
+    let jsonrpc: String
+    let id: UInt64
+    let result: R?
+    let error: JsonRpcError?
+}
+
+struct JsonRpcError: Decodable {
+    let code: Int
+    let message: String
+}

--- a/apps/Panops/Sources/Panops/PanopsApp.swift
+++ b/apps/Panops/Sources/Panops/PanopsApp.swift
@@ -5,6 +5,7 @@ struct PanopsApp: App {
     @StateObject private var viewModel: AppViewModel
     @State private var engine: EngineProcess?
     @State private var startupError: String?
+    @State private var willTerminateObserver: NSObjectProtocol?
 
     init() {
         let socketPath = FileManager.default
@@ -45,16 +46,25 @@ struct PanopsApp: App {
             """
             return
         } catch {
-            startupError = "\(error)"
+            AppViewModel.logFullError("engine.start", error)
+            startupError = "Could not start the engine. See Console.app for detail."
             return
         }
         do {
             try await viewModel.connect()
         } catch {
-            startupError = "IPC connect failed: \(error)"
+            AppViewModel.logFullError("ipc.connect", error)
+            startupError = "Could not connect to the engine. See Console.app for detail."
             return
         }
-        NotificationCenter.default.addObserver(
+        // Remove a prior observer if bootstrap somehow fires twice
+        // (SwiftUI lifecycle quirks or future refactors). Otherwise
+        // the stale observer would SIGTERM the old engine while the
+        // new one leaks.
+        if let prior = willTerminateObserver {
+            NotificationCenter.default.removeObserver(prior)
+        }
+        willTerminateObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
             object: nil,
             queue: .main

--- a/apps/Panops/Sources/Panops/PanopsApp.swift
+++ b/apps/Panops/Sources/Panops/PanopsApp.swift
@@ -2,17 +2,69 @@ import SwiftUI
 
 @main
 struct PanopsApp: App {
+    @StateObject private var viewModel: AppViewModel
+    @State private var engine: EngineProcess?
+    @State private var startupError: String?
+
+    init() {
+        let socketPath = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/panops/engine.sock")
+        let client = IpcClient(socketPath: socketPath)
+        self._viewModel = StateObject(wrappedValue: AppViewModel(client: client))
+    }
+
     var body: some Scene {
         WindowGroup("Panops") {
-            VStack(spacing: 16) {
-                Text("Panops")
-                    .font(.largeTitle)
-                Text("Walking skeleton — slice 09")
-                    .foregroundStyle(.secondary)
-            }
-            .frame(minWidth: 480, minHeight: 320)
-            .padding()
+            ContentView(vm: viewModel)
+                .task { await bootstrap() }
+                .alert("Engine failed to start", isPresented: errorPresented) {
+                    Button("Quit", role: .destructive) { NSApp.terminate(nil) }
+                } message: {
+                    Text(startupError ?? "")
+                }
         }
         .windowResizability(.contentSize)
+    }
+
+    private var errorPresented: Binding<Bool> {
+        Binding(
+            get: { startupError != nil },
+            set: { if !$0 { startupError = nil } }
+        )
+    }
+
+    private func bootstrap() async {
+        do {
+            engine = try EngineProcess.start()
+        } catch EngineProcess.LookupError.binaryNotFound(let env, let bundle) {
+            startupError = """
+            Could not find panops-engine binary.
+            Tried PANOPS_ENGINE_BIN=\(env ?? "(unset)") and bundle path \(bundle ?? "(unknown)").
+            Set PANOPS_ENGINE_BIN to the absolute path (dev) or rebuild the .app (prod).
+            """
+            return
+        } catch {
+            startupError = "\(error)"
+            return
+        }
+        do {
+            try await viewModel.connect()
+        } catch {
+            startupError = "IPC connect failed: \(error)"
+            return
+        }
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [engineCopy = engine, viewModelCopy = viewModel] _ in
+            let sem = DispatchSemaphore(value: 0)
+            Task {
+                await viewModelCopy.shutdown(engine: engineCopy)
+                sem.signal()
+            }
+            _ = sem.wait(timeout: .now() + 6)
+        }
     }
 }

--- a/apps/Panops/Sources/Panops/PanopsApp.swift
+++ b/apps/Panops/Sources/Panops/PanopsApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct PanopsApp: App {
+    var body: some Scene {
+        WindowGroup("Panops") {
+            VStack(spacing: 16) {
+                Text("Panops")
+                    .font(.largeTitle)
+                Text("Walking skeleton — slice 09")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(minWidth: 480, minHeight: 320)
+            .padding()
+        }
+        .windowResizability(.contentSize)
+    }
+}

--- a/apps/Panops/Sources/Panops/PanopsApp.swift
+++ b/apps/Panops/Sources/Panops/PanopsApp.swift
@@ -58,13 +58,15 @@ struct PanopsApp: App {
             forName: NSApplication.willTerminateNotification,
             object: nil,
             queue: .main
-        ) { [engineCopy = engine, viewModelCopy = viewModel] _ in
-            let sem = DispatchSemaphore(value: 0)
-            Task {
-                await viewModelCopy.shutdown(engine: engineCopy)
-                sem.signal()
-            }
-            _ = sem.wait(timeout: .now() + 6)
+        ) { [engineCopy = engine] _ in
+            // SIGTERM the engine synchronously. We cannot `await
+            // viewModel.shutdown(...)` here: AppViewModel is `@MainActor`
+            // and blocking main with a DispatchSemaphore to wait on the
+            // async hop deadlocks. The engine being SIGTERM'd is the
+            // important part — the IPC connection closes on socket
+            // teardown anyway, and the OS reaps the child process when
+            // the app exits.
+            engineCopy?.terminateSync()
         }
     }
 }

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("IpcClient codec")
+struct IpcClientCodecTests {
+    private var encoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }
+    private let decoder = JSONDecoder()
+
+    @Test("notesGenerate request encodes params")
+    func notesGenerateRequest_encodesParams() throws {
+        let req = JsonRpcRequest(
+            id: 1,
+            method: "ipc.notes.generate",
+            params: NotesGenerateParams(
+                audio: "/tmp/x.wav",
+                dialect: nil,
+                language: nil,
+                llmProvider: nil,
+                llmModel: nil,
+                noDiarize: nil,
+                meetingId: nil
+            )
+        )
+        let data = try encoder.encode(req)
+        let json = String(data: data, encoding: .utf8)!
+        // sortedKeys: alphabetical order.
+        // Swift's JSONEncoder escapes forward slashes as \/
+        #expect(json.contains("\"audio\":\"\\/tmp\\/x.wav\""), "missing audio field: \(json)")
+        #expect(json.contains("\"method\":\"ipc.notes.generate\""), "method missing: \(json)")
+        #expect(json.contains("\"jsonrpc\":\"2.0\""), "jsonrpc version missing: \(json)")
+        // Swift's JSONEncoder omits nil optionals entirely (not encoded as null).
+        #expect(!json.contains("\"language\":"), "expected language field to be omitted: \(json)")
+    }
+
+    @Test("job.done event decodes")
+    func jobDoneEvent_decodes() throws {
+        let json = #"""
+        {
+          "type": "job.done",
+          "job_id": "abc-123",
+          "result": {
+            "primary_file": "/tmp/notes.md",
+            "assets": ["/tmp/screenshots/s1.png"],
+            "meeting_id": "m1"
+          }
+        }
+        """#
+        let event = try decoder.decode(IpcEvent.self, from: json.data(using: .utf8)!)
+        guard case .jobDone(let jobId, let result) = event else {
+            Issue.record("expected .jobDone, got \(event)")
+            return
+        }
+        #expect(jobId == "abc-123")
+        #expect(result.primaryFile == "/tmp/notes.md")
+        #expect(result.assets == ["/tmp/screenshots/s1.png"])
+        #expect(result.meetingId == "m1")
+    }
+
+    @Test("job.error event decodes all kinds", arguments: [
+        "input_not_found", "invalid_input", "provider_unavailable", "internal", "cancelled"
+    ])
+    func jobErrorEvent_decodes(kind: String) throws {
+        let json = #"""
+        {
+          "type": "job.error",
+          "job_id": "j",
+          "error": { "kind": "\#(kind)", "message": "oops" }
+        }
+        """#
+        let event = try decoder.decode(IpcEvent.self, from: json.data(using: .utf8)!)
+        guard case .jobError(let jobId, let payload) = event else {
+            Issue.record("expected .jobError, got \(event) for kind \(kind)")
+            return
+        }
+        #expect(jobId == "j")
+        #expect(payload.kind == kind)
+        #expect(payload.message == "oops")
+    }
+
+    @Test("unknown event type does not throw")
+    func unknownEventType_doesNotThrow() throws {
+        let json = #"""
+        { "type": "asr.partial", "job_id": "j", "text": "..." }
+        """#
+        let event = try decoder.decode(IpcEvent.self, from: json.data(using: .utf8)!)
+        guard case .unknown(let type) = event else {
+            Issue.record("expected .unknown, got \(event)")
+            return
+        }
+        #expect(type == "asr.partial")
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -11,12 +11,12 @@ struct IpcClientCodecTests {
     }
     private let decoder = JSONDecoder()
 
-    @Test("notesGenerate request encodes params")
+    @Test("notesGenerate request encodes params as positional array")
     func notesGenerateRequest_encodesParams() throws {
         let req = JsonRpcRequest(
             id: 1,
             method: "ipc.notes.generate",
-            params: NotesGenerateParams(
+            param: NotesGenerateParams(
                 audio: "/tmp/x.wav",
                 dialect: nil,
                 language: nil,
@@ -33,6 +33,8 @@ struct IpcClientCodecTests {
         #expect(json.contains("\"audio\":\"\\/tmp\\/x.wav\""), "missing audio field: \(json)")
         #expect(json.contains("\"method\":\"ipc.notes.generate\""), "method missing: \(json)")
         #expect(json.contains("\"jsonrpc\":\"2.0\""), "jsonrpc version missing: \(json)")
+        // jsonrpsee uses positional params: the single arg is wrapped in a 1-element array.
+        #expect(json.contains("\"params\":[{"), "expected positional-array params, got: \(json)")
         // Swift's JSONEncoder omits nil optionals entirely (not encoded as null).
         #expect(!json.contains("\"language\":"), "expected language field to be omitted: \(json)")
     }

--- a/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
@@ -6,10 +6,15 @@ import Testing
 /// gated on the `PANOPS_LIVE_ENGINE=1` env var so it doesn't break CI
 /// (which doesn't have an engine running). Run manually via:
 ///
-///     PANOPS_LIVE_ENGINE=1 swift test --filter live_smoke_meeting_create
+///     PANOPS_LIVE_ENGINE=1 swift test
 ///
-/// Requires the engine to be running with its UDS at the default path
-/// and the public test fixture at the path below.
+/// Requires the engine to be running with its UDS at the default path:
+///
+///     ./target/release/panops-engine serve
+///
+/// The test exercises `meeting.start` + `meeting.get` only — no audio
+/// fixture or `notes.generate` invocation. Notes-pipeline coverage is
+/// the manual GUI smoke documented in `apps/Panops/README.md`.
 @Suite("Live IPC smoke (requires engine + PANOPS_LIVE_ENGINE=1)")
 struct IpcClientLiveSmokeTest {
     @Test("live_smoke_meeting_create")

--- a/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import Panops
+
+/// Live integration smoke against a running engine. SKIPPED by default;
+/// gated on the `PANOPS_LIVE_ENGINE=1` env var so it doesn't break CI
+/// (which doesn't have an engine running). Run manually via:
+///
+///     PANOPS_LIVE_ENGINE=1 swift test --filter live_smoke_meeting_create
+///
+/// Requires the engine to be running with its UDS at the default path
+/// and the public test fixture at the path below.
+@Suite("Live IPC smoke (requires engine + PANOPS_LIVE_ENGINE=1)")
+struct IpcClientLiveSmokeTest {
+    @Test("live_smoke_meeting_create")
+    func liveSmokeMeetingCreateAndGet() async throws {
+        guard ProcessInfo.processInfo.environment["PANOPS_LIVE_ENGINE"] == "1" else {
+            return
+        }
+        let socketPath = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/panops/engine.sock")
+        let client = IpcClient(socketPath: socketPath)
+        try await client.connect()
+        let id = try await client.meetingStart()
+        #expect(!id.isEmpty)
+        let meeting = try await client.meetingGet(id: id)
+        #expect(meeting.id == id)
+        #expect(meeting.language == "auto", "default language should be 'auto'")
+        #expect(meeting.endedAt == nil, "fresh meeting should not be ended")
+        // dir_path should be absolute under the engine's data_dir.
+        #expect(meeting.dirPath.hasPrefix("/"), "dir_path should be absolute: \(meeting.dirPath)")
+    }
+}

--- a/docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md
@@ -1,10 +1,28 @@
 # Slice 09 — Mac Shell Walking Skeleton
 
-**Status:** Locked design. Open for plan-writing.
+**Status:** Locked design with one post-implementation amendment (see below).
 **Date:** 2026-05-11
 **Author:** Franco Matzkin (with Claude as brainstorm partner)
 **Predecessor:** [slice 08 design](2026-05-11-slice-08-confidence-recursion-design.md)
 **North-star tie-in:** First step of Anchor A. Makes panops *usable as an app* — v0.1 acceptance criterion #1 ("open the Mac app, hit record") is unmet until this lands. Closes the perf-concern → Anchor A path by laying the ground for the WhisperKit ASR sidecar (next slice).
+
+## Amendment — 2026-05-12 (post-implementation, mid-PR)
+
+The Task 3 spike + a deeper empirical probe of the running engine invalidated the WebSocket-event-driven approach that D5 / IpcClient / ContentView in this spec describe. The implementation that shipped uses **HTTP POST for one-shot JSON-RPC requests** and **filesystem polling for job-completion detection**. The relevant deltas:
+
+- **D5 amended**: NOT hand-rolled JSON-RPC + WebSocket. Hand-rolled HTTP POST framing only. Each request opens a fresh `NWConnection` to the UDS, sends an HTTP POST envelope with the JSON-RPC body, and reads the HTTP/1.1 response (Content-Length framed). No persistent connection; no WebSocket. Rationale: `NWConnection + NWProtocolWebSocket.Options` over UDS fails its handshake (`POSIXErrorCode 53: Software caused connection abort`); the engine accepts manual HTTP upgrade-to-WS but constructing it from scratch was outside the slice budget. The engine's jsonrpsee server happily accepts HTTP POST for one-shot calls (proven via Python probe returning `405 Method Not Allowed` with body `"POST is required"`).
+
+- **D6 / D7 amended**: NSOpenPanel and three UI states unchanged. Whether `notes.generate` succeeded is detected by polling `<meeting.dir_path>/notes.md` on the filesystem every 2 seconds (5-minute ceiling), not by subscribing to `job.done` over WebSocket. Adds up to 2s of perceived latency on the Done transition; acceptable for walking-skeleton UX.
+
+- **Wire shape**: jsonrpsee uses positional params; the `JsonRpcRequest<P>` envelope wraps the param struct in a 1-element array (`"params": [<param>]`). `meeting.start` returns a bare JSON string (the meeting_id), not an object; `meeting.get` returns the `Meeting` struct from `panops-protocol`.
+
+- **Pre-create meetings**: the polling loop needs a meeting_id up-front, so the shell calls `meeting.start` (slice 06 allows this without live capture) and passes `meeting_id` into `notes.generate`. The auto-create path on `notes.generate(meeting_id: None)` is unused.
+
+- **Hand-rolled WebSocket client**: deferred to a follow-up slice. Engine accepts the manual HTTP-Upgrade path (`101 Switching Protocols` verified by Python probe); when a hand-rolled RFC 6455 client lands, the polling loop is replaced with `events.subscribe` and `job.done` matching. Filed as debt at PR-merge time.
+
+- **Test framework**: external `swift-testing` SwiftPM dependency was added (XCTest required full Xcode on the dev machine, swift-testing is Apple-official). Swift 6.x has swift-testing built in; the external package emits a deprecation warning. Cosmetic follow-up — drop the dep on Xcode-equipped machines.
+
+The rest of the spec stands. Risks #1 and #2 were prescient — the WS-over-UDS and `NWProtocolWebSocket` concerns played out exactly as flagged.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md
@@ -1,0 +1,318 @@
+# Slice 09 — Mac Shell Walking Skeleton
+
+**Status:** Locked design. Open for plan-writing.
+**Date:** 2026-05-11
+**Author:** Franco Matzkin (with Claude as brainstorm partner)
+**Predecessor:** [slice 08 design](2026-05-11-slice-08-confidence-recursion-design.md)
+**North-star tie-in:** First step of Anchor A. Makes panops *usable as an app* — v0.1 acceptance criterion #1 ("open the Mac app, hit record") is unmet until this lands. Closes the perf-concern → Anchor A path by laying the ground for the WhisperKit ASR sidecar (next slice).
+
+## Problem
+
+After slice 08, the multilingual-day-1 north-star promise holds end-to-end — but only for the headless `panops-engine` CLI. There is no Mac app. v0.1 acceptance criteria #1–3 ("open the app, hit record / stop / generate notes") are mechanically blocked: there's nothing to open. AGENTS.md anchors `apps/Panops/` as the SwiftUI app, with sidecars at `apps/panops-asr-mac/` and `apps/panops-llm-mac/`. None of that exists yet.
+
+The maintainer's perf concern raised mid-slice-08 — current whisper-rs on CPU is 5–10× slower than necessary on Apple Silicon — needs the WhisperKit-based macOS ASR sidecar to land. That sidecar is the next slice; this slice is the foundation it plugs into.
+
+## Goal
+
+Ship the thinnest possible end-to-end SwiftUI app: launches a window, spawns the existing `panops-engine` as a child process, lets the user pick an audio file, calls `notes.generate` over the existing UDS, watches the WebSocket for `job.done`, displays the resulting notes path. Three states: Idle, Working, Done/Error. No new Rust code. No sidecars yet. No live capture. No code signing. The slice exists to prove the IPC contract works from a real Mac app — every subsequent Anchor-A slice composes on top.
+
+## Decisions
+
+| # | Decision | Reason |
+|---|---|---|
+| D1 | **Build system: SwiftPM** at `apps/Panops/Package.swift`. Not Xcode `.xcodeproj` | Text-only manifest, reviewable diffs, no binary project files; `swift build` runs from CI without an Xcode workspace; SwiftUI apps build under SwiftPM since Swift 5.5. Code signing at slice 12 uses `codesign` CLI, not Xcode-only paths. |
+| D2 | **App owns the engine process lifecycle.** App launches → spawns `panops-engine serve` as a child; app quits → engine receives SIGTERM | Natural Mac-app UX (criterion #1 doesn't say "launch Terminal first"). Matches the path packaging will take at slice 12 (engine binary bundled in `.app/Contents/Resources/`). |
+| D3 | **Engine binary location: `PANOPS_ENGINE_BIN` env var (dev escape hatch) with `Bundle.main` fallback for production** | AGENTS.md "no env vars for user config" rule explicitly allows dev/CI escape hatches when flagged. Production lookup is `Bundle.main.bundleURL/Contents/Resources/panops-engine`. The env var path documented in `apps/Panops/README.md` and in this spec. |
+| D4 | **Socket path: default only**, no override flag in slice 09 | The engine's `--socket` flag already exists; not exposing it in the Swift UI keeps the slice tiny. If smoke later shows two app instances conflicting, expose then. |
+| D5 | **Hand-rolled JSON-RPC + WebSocket clients** built on `Foundation.URLSession` and `NWConnection` (`Network` framework) — no external SwiftPM dependencies this slice | Single-app dependency surface. Adding `starscream` or similar pulls in CocoaPods-era machinery; `NWConnection` is the platform-native answer. |
+| D6 | **Audio format: WAV/M4A/MP3/MOV accepted by the `NSOpenPanel` UTType filter**; engine handles content validation | The engine's `load_wav_mono16k` only accepts 16-kHz mono WAV today, but the file picker shouldn't pre-filter; bad inputs surface as `job.error` with `input_not_found` / `invalid_input` kinds. Slice 10 (ASR sidecar) likely broadens accepted formats. |
+| D7 | **UI states are three: `Idle`, `Working(job_id)`, `Done(path)` / `Error(kind, message)`** | Three-state UI is small enough to fit on one screen and exhaustively testable. No progress bar (no `job.progress` events ship today — `docs/proto/ipc.md:128` explicitly defers them). |
+| D8 | **No SwiftUI snapshot tests; one `IpcClient` JSON unit test; one manual smoke** | UI snapshots are overkill for one window. JSON encoding/decoding is pure logic and worth testing. The manual smoke covers the integration that XCTest can't reliably hit. |
+
+## Scope
+
+### In
+
+1. **New top-level directory** `apps/Panops/` containing:
+   - `Package.swift` (SwiftPM manifest, Swift 5.9+, macOS 14+).
+   - `Sources/Panops/PanopsApp.swift` — SwiftUI `@main` app entry.
+   - `Sources/Panops/EngineProcess.swift` — child-process spawn/teardown.
+   - `Sources/Panops/IpcClient.swift` — JSON-RPC + WS client actor.
+   - `Sources/Panops/ContentView.swift` — single-window UI.
+   - `Sources/Panops/Models.swift` — Codable structs mirroring `panops-protocol`'s wire types.
+   - `Tests/PanopsTests/IpcClientCodecTests.swift` — JSON round-trip unit test.
+   - `README.md` — developer setup (env var for engine binary, etc.).
+2. **`.gitignore` entries** for `apps/Panops/.build/` and `apps/Panops/.swiftpm/`.
+3. **CI**: extend `.github/workflows/ci.yml` `test (macos-latest)` job (or add a sibling job) to run `cd apps/Panops && swift build` on the macOS runner.
+4. **No Rust changes.** Verify by `git diff --stat main..HEAD` showing zero changes outside `apps/Panops/`, `.github/`, and `.gitignore`.
+
+### Out (filed as debt if surfaced during implementation)
+
+- **Meetings list** UI (uses existing `meeting.list`). Slice 11 candidate, after sidecars settle.
+- **Per-meeting language toggle** UI (north-star requirement). Slice 11+ candidate.
+- **In-app markdown rendering**. Open-in-Finder is enough this slice.
+- **WhisperKit / FluidAudio ASR sidecar**. Next slice (the perf fix).
+- **FoundationModels LLM sidecar**. Slice after that.
+- **Live capture (Anchor B)**. Risk-last surface, last anchor.
+- **Code signing, notarization, `.app` bundle scripts**. v0.1 acceptance #6, separate slice.
+- **Reconnect logic** if the engine dies mid-job. Engine death = app dies (D2 contract).
+- **Multiple-instance protection** (two apps racing for the same socket). Engine's existing `ipc_refuses_to_steal_live_socket` test covers the engine side; Swift app surfaces the error.
+- **Settings pane, About box, menu bar**. SwiftUI's default `.commands { }` is enough; no custom menus.
+- **Crash reporting, telemetry**. North-star: zero telemetry, ever.
+- **Stale-socket cleanup on app start** (left from a previous engine that didn't shut down cleanly). Engine's existing `stale_socket_is_unlinked_and_rebound` test handles this engine-side.
+
+## Architecture
+
+```
+┌─────────────────────────────────┐
+│  apps/Panops/   (SwiftUI app)   │
+│  ┌───────────────────────────┐  │
+│  │ ContentView (3 states)    │  │
+│  └─────────┬─────────────────┘  │
+│            │                    │
+│  ┌─────────▼─────────────────┐  │
+│  │ IpcClient (actor)         │──┼──┐ JSON-RPC + WS over UDS
+│  │   - notesGenerate(path)   │  │  │
+│  │   - subscribe(events)     │  │  │
+│  └───────────────────────────┘  │  │
+│                                 │  │
+│  ┌───────────────────────────┐  │  │ spawns + SIGTERMs
+│  │ EngineProcess (struct)    │──┼──┼───────────┐
+│  │   - start() / stop()      │  │  │           │
+│  └───────────────────────────┘  │  │           │
+└─────────────────────────────────┘  │           │
+                                     │           │
+              ┌──────────────────────▼───────────▼──┐
+              │  panops-engine serve  (existing)   │
+              │  ~/Library/Application Support/    │
+              │    panops/engine.sock              │
+              └────────────────────────────────────┘
+```
+
+The Swift app is a pure IPC client. The engine is unchanged. The contract surface — `ipc.notes.generate`, `ipc.events.subscribe`, `job.done` / `job.error` events — is exactly what `docs/proto/ipc.md` already documents.
+
+## Components (Swift side)
+
+### `EngineProcess`
+
+```swift
+struct EngineProcess {
+    private let process: Process
+    static func start(binary: URL, socket: URL? = nil) throws -> EngineProcess
+    func stop() async   // sends SIGTERM, waits up to 5s, then SIGKILL
+    var isRunning: Bool { get }
+}
+```
+
+- Resolves the engine binary path: `ProcessInfo.processInfo.environment["PANOPS_ENGINE_BIN"]` first, then `Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/panops-engine")`.
+- Passes `serve` as the first arg. No `--socket` override (D4).
+- Pipes engine stderr to the app's stderr so engine logs surface in the same Console.app stream (dev *and* production).
+- `deinit` invokes `stop()` synchronously as a last-ditch cleanup.
+
+### `IpcClient`
+
+```swift
+actor IpcClient {
+    init(socketPath: URL) async throws
+    func notesGenerate(audio: URL, dialect: String?, language: String?, ...) async throws -> String  // job_id
+    func subscribeEvents() -> AsyncStream<IpcEvent>
+    func disconnect() async
+}
+
+enum IpcEvent {
+    case jobDone(jobId: String, result: JobDoneResult)
+    case jobError(jobId: String, kind: String, message: String)
+    case unknown  // forward-compatible; skip
+}
+```
+
+- Opens a `NWConnection` to the UDS path; uses two logical streams over it: JSON-RPC requests/responses framed as newline-delimited JSON; WebSocket events on the upgrade path.
+- *Implementation note*: the existing engine accepts the WS upgrade on the same UDS; the client speaks RFC 6455 over the connection. If `NWProtocolWebSocket` proves painful, fall back to a tiny hand-rolled frame parser (the protocol surface needed is text-frame-only, no binary, no extensions).
+- Maps unknown event `type` values to `.unknown` rather than throwing — matches the IPC contract (line 128 of `docs/proto/ipc.md`).
+
+### `ContentView`
+
+State machine:
+
+```
+              click "Open audio..."
+   ┌─Idle─────────────────────────┐
+   │  audio: URL? = nil           │  ◄────────────────────┐
+   └──────┬───────────────────────┘                       │
+          │ user picked file                              │
+          ▼                                               │
+   ┌─Idle (audio set)─────────────┐                       │
+   │  audio: URL (non-nil)        │                       │
+   └──────┬───────────────────────┘                       │
+          │ click "Generate notes"                        │
+          ▼                                               │
+   ┌─Working(job_id)──────────────┐                       │
+   │  spinner + "Working..."      │                       │
+   └──────┬────────────┬──────────┘                       │
+          │            │                                  │
+   job.done│           │job.error                         │
+          ▼            ▼                                  │
+   ┌─Done(path)─┐   ┌─Error(kind, msg)─┐  click "Retry"   │
+   │ Open in    │   │ Show kind/msg    │──────────────────┘
+   │ Finder     │   │ Retry button     │
+   └────────────┘   └──────────────────┘
+```
+
+UI elements: title text, two buttons (Open / Generate), a status text, a conditional "Open in Finder" button. No tabs, no sheets, no menus beyond SwiftUI's defaults.
+
+### `Models`
+
+Plain `Codable` structs for the wire types we use:
+
+```swift
+struct NotesGenerateParams: Encodable {
+    let audio: String
+    let dialect: String?
+    let language: String?
+    let meetingId: String?
+    // ... mirror panops-protocol's NotesGenerateParams
+}
+
+struct NotesGenerateResult: Decodable {
+    let jobId: String
+}
+
+struct JobDoneResult: Decodable {
+    let primaryFile: String
+    let assets: [String]
+    let meetingId: String
+}
+```
+
+Field names use Swift camelCase with `CodingKeys` mapping to the snake_case wire format.
+
+## Data flow (happy path)
+
+1. **App launch**: `PanopsApp.init()` → `EngineProcess.start(binary: ...)`. Engine starts; UDS file appears after a moment.
+2. **Connect**: `Task { let client = try await IpcClient(socketPath: ...) }`. Retries with exponential backoff up to 5s if the socket isn't ready (engine cold-start).
+3. **Subscribe**: `client.subscribeEvents()` — receives events asynchronously into the view model.
+4. **User opens file**: `NSOpenPanel` configured with `UTType.wav`, `UTType.mpeg4Audio`, `UTType.mp3`, `UTType.movie`. Result captured in `audio: URL`.
+5. **User clicks Generate**: `client.notesGenerate(audio: ...)` → `{job_id}`. ViewModel transitions to `Working(job_id)`.
+6. **Event arrives**: matching `job.done` → `Done(primaryFile)`. Non-matching `job_id` (multiple concurrent jobs, future-proof) ignored.
+7. **User clicks Open in Finder**: `NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: primaryFile)])`.
+8. **App quit**: SwiftUI lifecycle hook → `await client.disconnect()` → `await engineProcess.stop()`. Engine has 5s to drain via SIGTERM; if not gone, SIGKILL.
+
+## Error paths
+
+| Scenario | Behavior |
+|---|---|
+| Engine binary not found at startup | Fatal alert: "Could not find panops-engine binary. Set PANOPS_ENGINE_BIN to the absolute path (dev) or rebuild the .app (prod)." Quit on dismiss. |
+| Engine crashed within 5s of launch | Alert with engine stderr's last 1KB. Quit on dismiss. |
+| Socket file never appears | Same alert as crash, message: "Engine did not bind socket within 5s." |
+| `notes.generate` returns RPC error | Surface error.message in the UI; revert to Idle (audio kept selected). |
+| WS connection drops mid-job | Reconnect once; if reconnect fails, surface "Lost connection to engine. Quit and relaunch." No automatic retry of the in-flight job (state is on the engine side via the meeting registry). |
+| User quits during Working | `engineProcess.stop()` SIGTERMs. The in-flight pipeline will receive cancellation upstream (existing `cancelled` job-error kind covers this). |
+
+## Testing
+
+### Unit (Swift)
+
+`Tests/PanopsTests/IpcClientCodecTests.swift`:
+
+1. `notesGenerateRequest_encodesParams` — round-trips `NotesGenerateParams { audio: "/tmp/x.wav" }` → JSON → wire-format check (snake_case field names, no extras).
+2. `jobDoneEvent_decodes` — parses a known-good `{ "type": "job.done", "job_id": "abc", "result": { "primary_file": "...", ... } }` into `IpcEvent.jobDone(...)`.
+3. `jobErrorEvent_decodes` — same for `job.error` with each of the 5 documented `kind` values.
+4. `unknownEventType_doesNotThrow` — `{"type": "asr.partial", ...}` parses to `IpcEvent.unknown` (forward-compat).
+
+No view model tests; the state machine is exercised by the manual smoke.
+
+### Manual smoke (pre-PR; captured in session log, NOT committed publicly)
+
+From repo root:
+
+```bash
+cargo build --release -p panops-engine
+export PANOPS_ENGINE_BIN="$PWD/target/release/panops-engine"
+cd apps/Panops
+swift run Panops
+```
+
+App launches → engine spawns (verifiable via `lsof | grep engine.sock`). Click Open → pick a known short test WAV (e.g., `crates/panops-engine/tests/fixtures/audio/en_30s.wav` — public test fixture, no private content). Click Generate → status goes to Working → after a few seconds → Done with the notes path. Click "Open in Finder" → Finder window shows the notes file. Quit the app → engine SIGTERM verifiable via `pgrep panops-engine` returning empty.
+
+Pass criteria documented in the session log:
+
+- Engine PID before app quit: `<N>`.
+- Engine PID after app quit (within 5s): empty.
+- Notes file `<path>` exists and is non-empty.
+
+Do not run the smoke against the maintainer's private recordings; the public test fixture is sufficient.
+
+### CI (automated)
+
+Extend `.github/workflows/ci.yml`:
+
+```yaml
+- name: Build Swift Mac shell
+  if: matrix.os == 'macos-latest'
+  shell: bash
+  run: |
+    cd apps/Panops
+    swift build --configuration release
+```
+
+Lands as a new step inside the existing `test (macos-latest)` job (or sibling job — implementation decides). Build-only; no run on CI (CI runners can't reliably exercise GUI). The unit test suite runs via `swift test`.
+
+## Three-tier boundaries
+
+### ✅ Always do
+
+- `swift build` + `swift test` clean on macOS 14+ before each commit on the Swift side.
+- `cargo fmt && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked` still green on the Rust side (zero Rust changes expected, but verify).
+- Commit per task in the slice plan.
+- File a GitHub issue for any "deferred" / "out of scope" item per the Debt Rule.
+- Use `Bundle.main.bundleURL` (not a hardcoded path) for the production engine lookup.
+
+### ⚠️ Ask first
+
+- Adding a SwiftPM dependency beyond `Foundation` / `SwiftUI` / `Network`.
+- Adding any SwiftPM target beyond `Panops` (the app) and `PanopsTests`.
+- Changing the engine spawn contract (e.g., passing extra flags, changing the socket path).
+- Touching the Rust workspace at all this slice.
+- Introducing a second window, sheet, or modal.
+- Adding `.entitlements`, codesigning, or notarization — those are slice 12.
+- Renaming the `apps/Panops/` directory or restructuring its layout.
+
+### 🚫 Never do
+
+- Bundle WhisperKit, FluidAudio, FoundationModels, or any ML framework this slice — they're the *next* slices.
+- Add a Settings pane, preferences UI, or any persistent Swift-side state.
+- Add an Xcode `.xcodeproj` alongside the SwiftPM manifest. One build system.
+- Read or write to `panops.db` from Swift. The engine owns storage.
+- Phone home. Zero telemetry, ever.
+- Use `os_log` with public messages that include user content. Engine paths are fine; transcript content is not (and the shell never receives transcript content this slice).
+- Auto-merge the PR.
+
+## Acceptance criteria
+
+1. `cd apps/Panops && swift build --configuration release` succeeds on macOS 14+.
+2. `cd apps/Panops && swift test` succeeds — 4 IPC codec tests pass.
+3. With `PANOPS_ENGINE_BIN` set, `swift run Panops` opens a window.
+4. App spawns a `panops-engine serve` child process within 5 seconds of launch (verifiable via `pgrep panops-engine`).
+5. Manual smoke (file picker → generate → done state → Open in Finder) succeeds against `crates/panops-engine/tests/fixtures/audio/en_30s.wav`.
+6. Quitting the app SIGTERMs the engine within 5 seconds.
+7. CI's `swift build` step on `macos-latest` is green.
+8. `cargo test --workspace --locked` still green (no Rust regression).
+9. `clippy` and `rustfmt` still clean.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `NWConnection` over UDS + WebSocket upgrade is fiddly (Apple's docs are sparse) | Medium | Fall back to a hand-rolled WebSocket frame parser if `NWProtocolWebSocket` doesn't accept UDS. The frame surface needed is text-only, no extensions. Spike before locking the IPC client design. |
+| SwiftPM SwiftUI app doesn't build cleanly without an Xcode project on macOS 14 | Low | SwiftUI apps under SwiftPM have been stable since Swift 5.5. If broken, fall back to Xcode project at slice 09b. |
+| Engine cold-start race (app connects before socket exists) | Medium | Retry connection with exponential backoff up to 5s. Documented in `IpcClient.init`. |
+| Stale socket from previous engine that didn't shut down cleanly | Low | Engine's `stale_socket_is_unlinked_and_rebound` test covers this engine-side. Swift app surfaces the error to the user if the engine fails to bind. |
+| User picks an unsupported audio format and `job.error` doesn't surface a friendly message | Low | The engine's error kinds (`input_not_found`, `invalid_input`) are mapped to readable strings in the UI. File a follow-up if the message is unhelpful. |
+
+## Open questions (deferred to future slices)
+
+1. **Meetings list** — when slice 11 ships the master/detail layout. Already exists in the engine (`meeting.list`).
+2. **Per-meeting language toggle UI** — north-star requirement; slice 11+ candidate.
+3. **In-app markdown rendering** — `NSAttributedString` from markdown is built-in on macOS 12+, so when needed it's cheap.
+4. **Live transcript view** — Anchor B will deliver `asr.partial` / `asr.final` events; UI consumes them.
+5. **Engine binary discovery without env var in dev** — once the .app bundle exists with a copy of the binary, the env var becomes dev-only and the production path is `Bundle.main`. File a follow-up to make the dev path use a SwiftPM resource or symlink so the env var can be dropped from the default dev flow.


### PR DESCRIPTION

<img width="909" height="457" alt="image" src="https://github.com/user-attachments/assets/929687fd-7cb3-49f5-a8fd-5eb38e8ffa6e" /> 😄

## Summary

First step of Anchor A. New `apps/Panops/` SwiftPM SwiftUI app that spawns `panops-engine` as a child, picks an audio file via NSOpenPanel, calls `ipc.notes.generate` over UDS, and polls until the notes file lands. Three UI states: Idle / Working / Done|Error.

No Rust changes. Engine binary path resolves via `PANOPS_ENGINE_BIN` env var (dev escape hatch, flagged in spec) with a `Bundle.main` fallback for the production `.app` (slice 12).

Spec: `docs/superpowers/specs/2026-05-11-slice-09-mac-shell-walking-skeleton-design.md`
Tracking: #117

## Deviations from spec (documented in the spec's Amendment section)

The Task 3 spike + a deeper empirical probe of the engine forced two changes from the original design:

1. **Transport: HTTP POST, not WebSocket.** `NWConnection + NWProtocolWebSocket.Options` over UDS fails handshake with POSIXErrorCode 53. Direct probing showed the engine speaks HTTP (`405 Method Not Allowed` body says "POST is required") and accepts manual WS upgrade (`101 Switching Protocols`) — but Apple's framework can't construct the upgrade properly. Slice 09 uses HTTP POST for one-shot RPCs; hand-rolled RFC 6455 WS is deferred to a follow-up slice.

2. **Job-completion detection: filesystem polling, not WS events.** Without WS subscriptions, the app polls `<meeting.dir_path>/notes.md` every 2 seconds. Adds ~2s latency to the Done transition; acceptable for walking-skeleton UX.

3. **Test framework: swift-testing, not XCTest.** XCTest requires full Xcode on the dev machine (this machine has CLT only). swift-testing is Apple-official. CI runners with Xcode would have XCTest available too; switching back to XCTest is a cosmetic follow-up.

## What landed

11 commits since the spec commit:

- `a4009af` scaffold SwiftPM package + Hello-World window
- `2a7879a` IPC wire models + codec unit tests
- `5c139f9` IpcClient first cut (later rewritten)
- `828a8c0` EngineProcess: spawn + SIGTERM/SIGKILL
- `f74eb2e` Dev README
- `5451eec` CI: swift build/test on macos-latest
- `2f65b08` Rewrite IpcClient: HTTP POST over UDS + meeting polling helpers
- `9b2c86d` ContentView: three-state SwiftUI shell
- `531db2d` Wire PanopsApp: engine + IPC + lifecycle teardown
- `954f9c7` Fix IPC: positional-array params + Meeting return shape + fs polling

## Test plan

- [x] `cargo test --workspace --locked` green (no Rust changes)
- [x] `cd apps/Panops && swift build` green
- [x] `swift test` — 4 codec round-trip tests pass
- [x] **Live IPC smoke** (`PANOPS_LIVE_ENGINE=1 swift test` with a running engine): `meeting.start` + `meeting.get` round-trip succeeds; proves the JSON-RPC-over-HTTP-over-UDS transport works end-to-end.
- [ ] Manual GUI smoke (Cmd+R the app, pick `crates/panops-engine/tests/fixtures/audio/en_30s.wav`, generate, verify notes appear, quit, verify engine SIGTERMed) — maintainer to do in their session; no easy way to automate.
- [x] CI `swift build` + `swift test` step on macos-latest expected green (codec tests don't need a live engine).

## Follow-ups to file as debt at merge

- Hand-rolled RFC 6455 WebSocket client for event subscription (proper job.done UX without polling).
- Remove the external `swift-testing` SwiftPM dependency once Xcode is available on the dev machine (Swift 6.x has it built-in; SwiftPM emits a deprecation warning about the external package).
- Surface engine connection errors in the UI without quitting (currently a fatal alert).