### PR TITLE
fix dead jsonrpc validator + truncated-read error

### DIFF
--- a/crates/panops-engine/src/asr_resolver.rs
+++ b/crates/panops-engine/src/asr_resolver.rs
@@ -37,9 +37,12 @@ fn sidecar_binary() -> Option<std::path::PathBuf> {
     use std::os::unix::fs::PermissionsExt;
 
     let bin = std::env::var("PANOPS_ASR_SIDECAR_BIN").ok()?;
-    // Canonicalize before the metadata check so a symlink can't be
-    // swapped between validation and `Command::spawn` (TOCTOU). The
-    // resolved path is what we hand to `Command::new` below.
+    // Canonicalize before the metadata check to narrow the symlink-swap
+    // window between validation and `Command::spawn`. Note this is
+    // best-effort UX (clean fallback to whisper-rs on bad input), not
+    // a security boundary — a sufficiently fast swap *after* canonicalize
+    // can still race the spawn. The path is local-only and operator-set,
+    // so the threat model accepts this.
     let path = std::fs::canonicalize(bin).ok()?;
     let meta = std::fs::metadata(&path).ok()?;
     if !meta.is_file() {

--- a/crates/panops-mac/src/whisperkit_asr.rs
+++ b/crates/panops-mac/src/whisperkit_asr.rs
@@ -62,7 +62,7 @@ struct RpcRequest<'a> {
 
 #[derive(Deserialize)]
 struct RpcResponse {
-    #[serde(default, deserialize_with = "deserialize_jsonrpc_version")]
+    #[serde(rename = "jsonrpc", deserialize_with = "deserialize_jsonrpc_version")]
     _jsonrpc: (),
     /// `Option` so a sidecar parse-error response with `id: null`
     /// (JSON-RPC 2.0 §4) decodes instead of failing — we still
@@ -232,12 +232,19 @@ impl WhisperKitAsr {
             ));
         }
         if buf.last() != Some(&b'\n') {
-            // Hit the byte cap without finding a newline — framing is
-            // corrupt or the sidecar is producing pathological output.
+            // No trailing newline means either (a) the sidecar died
+            // mid-line (EOF before completing the response) or (b) the
+            // line hit the `MAX_RESPONSE_BYTES` cap. Distinguish so the
+            // error message points at the right failure mode during
+            // debugging — wedged-sidecar vs framing-corrupt look very
+            // different in practice.
             *slot = None;
-            return Err(AsrError::Transcription(format!(
-                "sidecar response exceeded {MAX_RESPONSE_BYTES} bytes without newline"
-            )));
+            let msg = if (n as u64) >= MAX_RESPONSE_BYTES {
+                format!("sidecar response exceeded {MAX_RESPONSE_BYTES} bytes without newline")
+            } else {
+                format!("sidecar response truncated at {n} bytes (EOF mid-line)")
+            };
+            return Err(AsrError::Transcription(msg));
         }
         let line = std::str::from_utf8(&buf)
             .map_err(|e| AsrError::Transcription(format!("response not utf-8: {e}")))?;


### PR DESCRIPTION
Slice 10 post-merge audit (via `mcp__claude-review__audit_pr`) caught one blocker and two suggestions in the freshly-merged WhisperKit sidecar. Fixing in this small follow-up before queueing the next slice.

## Changes

- **BLOCKER**: `whisperkit_asr.rs` — the `_jsonrpc` field used `#[serde(default)]` with the Rust field name `_jsonrpc`, so serde looked for the literal JSON key `_jsonrpc` (which never exists) and the strict version validator was dead code. Added `#[serde(rename = "jsonrpc", ...)]` and dropped `default` so a missing field now fails decode too.
- **SUGGESTION**: distinguish "sidecar response exceeded N bytes" from "truncated at N bytes (EOF mid-line)". A wedged sidecar and a framing-corrupt sidecar look very different in practice; the error message now points at the right failure mode.
- **SUGGESTION**: clarify in `asr_resolver.rs` that `canonicalize`-then-spawn narrows but doesn't eliminate the symlink-swap window — this is best-effort UX, not a security boundary. One-line comment, no behavior change.

CI-cache for `apps/panops-asr-mac/.build/` and tighter WER cap on `multi_speaker_60s` filed as debt issues separately (medium severity, not blocking).

## Verification

- `cargo build --workspace --locked` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `PANOPS_SKIP_HEAVY=1 cargo test --workspace --locked` — pass
- Conformance with WhisperKit sidecar (`en_30s` + `multi_speaker_60s`) — 2/2 pass in 6.56s