### PR TITLE
Fix ASR sidecar build under Swift 6 strict concurrency

### DIFF
--- a/apps/panops-asr-mac/Sources/PanopsAsrMac/Transcriber.swift
+++ b/apps/panops-asr-mac/Sources/PanopsAsrMac/Transcriber.swift
@@ -20,7 +20,14 @@ private func stripSpecialTokens(_ s: String) -> String {
 }
 
 actor Transcriber {
-    private let whisperKit: WhisperKit
+    // `nonisolated(unsafe)`: WhisperKit is not Sendable, so calling its
+    // nonisolated `transcribe` from this actor would "send" actor-isolated
+    // state across isolation (a hard error under newer Swift toolchains).
+    // The sidecar's stdio loop is single-flight (one request awaited at a
+    // time), so transcribe is never invoked concurrently — the access is
+    // serialized in practice. Marking the immutable handle nonisolated is
+    // the minimal, safe fix.
+    private nonisolated(unsafe) let whisperKit: WhisperKit
     private let modelName: String
 
     private init(modelName: String, whisperKit: WhisperKit) {

--- a/apps/panops-asr-mac/Sources/PanopsAsrMac/Transcriber.swift
+++ b/apps/panops-asr-mac/Sources/PanopsAsrMac/Transcriber.swift
@@ -23,10 +23,12 @@ actor Transcriber {
     // `nonisolated(unsafe)`: WhisperKit is not Sendable, so calling its
     // nonisolated `transcribe` from this actor would "send" actor-isolated
     // state across isolation (a hard error under newer Swift toolchains).
-    // The sidecar's stdio loop is single-flight (one request awaited at a
-    // time), so transcribe is never invoked concurrently — the access is
-    // serialized in practice. Marking the immutable handle nonisolated is
-    // the minimal, safe fix.
+    // Safety does NOT come from actor isolation — an actor can re-enter
+    // `transcribe` at its `await` suspension, so isolation alone would not
+    // prevent concurrent use of the handle. It comes from the caller: the
+    // sidecar's stdio loop (main.swift) reads and fully awaits one request
+    // before reading the next, so `transcribe` is single-flight in practice.
+    // Revisit (e.g. a serial executor) if that loop ever becomes concurrent.
     private nonisolated(unsafe) let whisperKit: WhisperKit
     private let modelName: String
 


### PR DESCRIPTION
Fixes #139.

`heavy-test (macos)` went red on `main` (7a318d9): the WhisperKit sidecar no longer compiles under the `macos-latest` runner's now-stricter Swift toolchain — the `Transcriber` actor sends its non-Sendable `whisperKit` into WhisperKit's nonisolated `transcribe`, now a hard error (`sending 'self.whisperKit' risks causing data races`).

**Fix:** mark the immutable handle `nonisolated(unsafe) let whisperKit`. The sidecar's stdio loop is single-flight (one request awaited at a time), so `transcribe` is never invoked concurrently — the access is serialized in practice.

**Verification:** `swift build` passes locally on Apple Swift 6.3.1 (a strict 6.x toolchain, target macOS 26), compiling `Transcriber.swift` cleanly. Note: `heavy-test` is `if: github.event_name != 'pull_request'`, so it does not run on this PR — verified locally; the post-merge `main` run will confirm on CI.

**Not bundled (deferred, see #139):** running the sidecar build as a PR gate so this class can't reach `main` is a CI-cost decision tied to #128 (heavy-test caching) — left for the maintainer.

Root cause + context: #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)