### PR TITLE
Slice 11: Live capture (Anchor B) — audio + screenshot recording

### DIFF
--- a/crates/panops-core/src/capture.rs
+++ b/crates/panops-core/src/capture.rs
@@ -1,0 +1,167 @@
+//! Capture port. Real impl: `panops_mac::ScreenCaptureKitCapture` (slice 11+).
+//! Fake: `panops_core::conformance::fakes::FakeCapture`.
+//!
+//! The trait is sync; async wrapping happens at the handler layer via
+//! `tokio::task::spawn_blocking`. Matches the shape of the other ports
+//! (`AsrProvider`, `Vad`, `Storage`).
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Audio sources to capture. Passed to `start_capture`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioSources {
+    /// System audio output only.
+    SystemOnly,
+    /// Microphone only.
+    MicOnly,
+    /// Both system audio and microphone, mixed.
+    SystemAndMic,
+}
+
+/// Configuration for a capture session.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaptureConfig {
+    /// Audio sources to capture.
+    pub audio_sources: AudioSources,
+    /// Screenshot sampling interval in milliseconds.
+    pub screenshot_interval_ms: u64,
+    /// Vision FeaturePrint cosine distance threshold for change detection.
+    pub screenshot_threshold: f32,
+}
+
+impl Default for CaptureConfig {
+    fn default() -> Self {
+        Self {
+            audio_sources: AudioSources::SystemAndMic,
+            screenshot_interval_ms: 500,
+            screenshot_threshold: 0.15,
+        }
+    }
+}
+
+/// Handle returned by `start_capture`. Used to identify the session
+/// for `stop_capture`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureSession {
+    pub meeting_id: String,
+    pub started_at_ms: u64,
+}
+
+/// Result returned by `stop_capture`. Contains paths to captured artifacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureResult {
+    /// Path to the captured audio WAV file.
+    pub audio_path: PathBuf,
+    /// Paths to captured screenshot JPEG files.
+    pub screenshot_paths: Vec<PathBuf>,
+    /// Duration of the recording in milliseconds.
+    pub duration_ms: u64,
+}
+
+/// Domain error for capture operations. NEVER derive `Serialize` (per
+/// AGENTS.md: domain errors stay platform-agnostic; transport conversion
+/// lives in `panops-protocol` behind the `domain-conversions` feature).
+#[derive(Debug, Error)]
+pub enum CaptureError {
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+    #[error("capture failed: {0}")]
+    Capture(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("sidecar error: {0}")]
+    Sidecar(String),
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
+}
+
+/// Capture trait for audio + screenshot capture. One combined trait per
+/// D2 (YAGNI: no pre-split for AudioCapture/VideoCapture).
+///
+/// Real adapters (ScreenCaptureKitCapture) spawn a Swift sidecar that
+/// runs ScreenCaptureKit + AVFoundation. Fake adapters (FakeCapture)
+/// yield synthetic PCM frames and pre-generated screenshot fixtures.
+pub trait Capture: Send + Sync {
+    /// Start capturing audio + screenshots for a meeting.
+    /// Returns a session handle. Audio + screenshots stream as IPC events
+    /// (implemented at the engine layer, not here).
+    fn start_capture(
+        &self,
+        meeting_id: &str,
+        meeting_dir: &std::path::Path,
+        config: &CaptureConfig,
+    ) -> Result<CaptureSession, CaptureError>;
+
+    /// Stop capturing, finalize audio file, return paths.
+    fn stop_capture(&self, session: &CaptureSession) -> Result<CaptureResult, CaptureError>;
+
+    /// Marker for conformance harness; production impls leave the default.
+    fn is_fake(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_config_default_values() {
+        let cfg = CaptureConfig::default();
+        assert_eq!(cfg.audio_sources, AudioSources::SystemAndMic);
+        assert_eq!(cfg.screenshot_interval_ms, 500);
+        assert!(cfg.screenshot_threshold > 0.0 && cfg.screenshot_threshold < 1.0);
+    }
+
+    #[test]
+    fn audio_sources_equality() {
+        assert_eq!(AudioSources::SystemOnly, AudioSources::SystemOnly);
+        assert_ne!(AudioSources::SystemOnly, AudioSources::MicOnly);
+        assert_ne!(AudioSources::MicOnly, AudioSources::SystemAndMic);
+    }
+
+    #[test]
+    fn capture_session_fields() {
+        let s = CaptureSession {
+            meeting_id: "abc123".into(),
+            started_at_ms: 1_700_000_000_000,
+        };
+        assert_eq!(s.meeting_id, "abc123");
+        assert_eq!(s.started_at_ms, 1_700_000_000_000);
+    }
+
+    #[test]
+    fn capture_result_paths() {
+        let r = CaptureResult {
+            audio_path: PathBuf::from("/tmp/audio.wav"),
+            screenshot_paths: vec![
+                PathBuf::from("/tmp/screenshots/001.jpg"),
+                PathBuf::from("/tmp/screenshots/002.jpg"),
+            ],
+            duration_ms: 60_000,
+        };
+        assert_eq!(r.audio_path.display().to_string(), "/tmp/audio.wav");
+        assert_eq!(r.screenshot_paths.len(), 2);
+    }
+
+    #[test]
+    fn capture_error_display() {
+        let e = CaptureError::PermissionDenied("microphone".into());
+        assert!(format!("{e}").contains("permission denied"));
+        let e = CaptureError::Capture("device busy".into());
+        assert!(format!("{e}").contains("capture failed"));
+        let e = CaptureError::Sidecar("process exited".into());
+        assert!(format!("{e}").contains("sidecar error"));
+    }
+
+    #[test]
+    fn capture_error_io_from() {
+        let io = std::io::Error::other("disk full");
+        let e: CaptureError = io.into();
+        assert!(matches!(e, CaptureError::Io(..)));
+    }
+}

--- a/crates/panops-core/src/capture.rs
+++ b/crates/panops-core/src/capture.rs
@@ -1,9 +1,13 @@
-//! Capture port. Real impl: `panops_mac::ScreenCaptureKitCapture` (slice 11+).
-//! Fake: `panops_core::conformance::fakes::FakeCapture`.
+//! Capture port for audio + screenshot capture.
 //!
 //! The trait is sync; async wrapping happens at the handler layer via
 //! `tokio::task::spawn_blocking`. Matches the shape of the other ports
 //! (`AsrProvider`, `Vad`, `Storage`).
+//!
+//! Real adapter: the forthcoming macOS ScreenCaptureKit sidecar
+//! (slice 11 scaffolding; trait + fake + conformance land now,
+//! real capture gated on manual Mac smoke).
+//! Fake: `panops_core::conformance::fakes::FakeCapture`.
 
 use std::path::PathBuf;
 

--- a/crates/panops-core/src/conformance/capture.rs
+++ b/crates/panops-core/src/conformance/capture.rs
@@ -15,32 +15,67 @@ use std::path::Path;
 use crate::capture::{Capture, CaptureConfig, CaptureError, CaptureSession};
 
 /// Run the full conformance suite against a `Capture` implementation.
+///
+/// Creates a fresh temp directory for each test to avoid mutating fixtures.
+/// Screenshots are read from `fixtures_dir` (if needed by the adapter),
+/// but all output goes to a temp location that is cleaned up after the test.
 pub fn run_suite<C: Capture>(adapter: &C, fixtures_dir: &Path) {
     start_returns_session(adapter, fixtures_dir);
     stop_returns_valid_audio(adapter, fixtures_dir);
     stop_returns_screenshot_paths(adapter, fixtures_dir);
     stop_session_not_found(adapter);
-    is_fake_marker(adapter);
+    is_fake_marker(adapter, true); // Fakes should return true
 }
 
-fn start_returns_session<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+fn temp_meeting_dir() -> std::path::PathBuf {
+    // Create temp dir under workspace target/ so FakeCapture can find
+    // fixtures by walking ancestors (meeting_dir.ancestors() must include
+    // workspace root with tests/fixtures/screenshots).
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2) // panops-core is at crates/panops-core, nth(2) is workspace root
+        .expect("workspace root")
+        .to_path_buf();
+
+    let tmp_dir = workspace_root.join("target").join("tmp");
+    std::fs::create_dir_all(&tmp_dir).expect("create target/tmp");
+
+    tmp_dir.join(format!(
+        "capture_test_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn start_returns_session<C: Capture>(adapter: &C, _fixtures_dir: &Path) {
     let meeting_id = "test_meeting_001";
+    let meeting_dir = temp_meeting_dir();
+    std::fs::create_dir_all(&meeting_dir).expect("create temp meeting dir");
+
     let config = CaptureConfig::default();
     let session = adapter
-        .start_capture(meeting_id, fixtures_dir, &config)
+        .start_capture(meeting_id, &meeting_dir, &config)
         .expect("start_capture should succeed");
     assert_eq!(session.meeting_id, meeting_id);
     assert!(session.started_at_ms > 0, "started_at_ms should be set");
 
     // Clean up the session.
     let _ = adapter.stop_capture(&session);
+
+    // Clean up temp dir.
+    let _ = std::fs::remove_dir_all(&meeting_dir);
 }
 
-fn stop_returns_valid_audio<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+fn stop_returns_valid_audio<C: Capture>(adapter: &C, _fixtures_dir: &Path) {
     let meeting_id = "test_meeting_audio";
+    let meeting_dir = temp_meeting_dir();
+    std::fs::create_dir_all(&meeting_dir).expect("create temp meeting dir");
+
     let config = CaptureConfig::default();
     let session = adapter
-        .start_capture(meeting_id, fixtures_dir, &config)
+        .start_capture(meeting_id, &meeting_dir, &config)
         .expect("start_capture should succeed");
 
     let result = adapter
@@ -70,13 +105,19 @@ fn stop_returns_valid_audio<C: Capture>(adapter: &C, fixtures_dir: &Path) {
         result.duration_ms,
         computed_ms
     );
+
+    // Clean up temp dir.
+    let _ = std::fs::remove_dir_all(&meeting_dir);
 }
 
-fn stop_returns_screenshot_paths<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+fn stop_returns_screenshot_paths<C: Capture>(adapter: &C, _fixtures_dir: &Path) {
     let meeting_id = "test_meeting_screenshots";
+    let meeting_dir = temp_meeting_dir();
+    std::fs::create_dir_all(&meeting_dir).expect("create temp meeting dir");
+
     let config = CaptureConfig::default();
     let session = adapter
-        .start_capture(meeting_id, fixtures_dir, &config)
+        .start_capture(meeting_id, &meeting_dir, &config)
         .expect("start_capture should succeed");
 
     let result = adapter
@@ -88,6 +129,9 @@ fn stop_returns_screenshot_paths<C: Capture>(adapter: &C, fixtures_dir: &Path) {
     for path in &result.screenshot_paths {
         assert!(path.exists(), "screenshot {} should exist", path.display());
     }
+
+    // Clean up temp dir.
+    let _ = std::fs::remove_dir_all(&meeting_dir);
 }
 
 fn stop_session_not_found<C: Capture>(adapter: &C) {
@@ -106,9 +150,13 @@ fn stop_session_not_found<C: Capture>(adapter: &C) {
     }
 }
 
-fn is_fake_marker<C: Capture>(adapter: &C) {
+fn is_fake_marker<C: Capture>(adapter: &C, expected_is_fake: bool) {
     // The trait default is `false`. Fakes should override to `true`.
-    // This test simply asserts that the marker is set correctly for
-    // the adapter type — it's a sanity check, not a functional test.
-    let _ = adapter.is_fake(); // Just verify the method exists and doesn't panic.
+    // This test asserts that the marker is set correctly for the adapter.
+    assert_eq!(
+        adapter.is_fake(),
+        expected_is_fake,
+        "is_fake() should return {} for this adapter",
+        expected_is_fake
+    );
 }

--- a/crates/panops-core/src/conformance/capture.rs
+++ b/crates/panops-core/src/conformance/capture.rs
@@ -1,0 +1,114 @@
+//! Conformance harness for [`crate::capture::Capture`] adapters.
+//!
+//! Every Capture impl (real `ScreenCaptureKitCapture`, fake `FakeCapture`)
+//! must pass this same suite. The harness asserts the contract documented
+//! on the trait:
+//!
+//! - `start_capture` returns a session with the correct meeting_id.
+//! - `stop_capture` returns paths to audio + screenshots.
+//! - Audio path is a valid WAV file (parses with `hound`).
+//! - Screenshots are valid JPEGs (paths exist; contents not verified).
+//! - `is_fake` marker is set correctly.
+
+use std::path::Path;
+
+use crate::capture::{Capture, CaptureConfig, CaptureError, CaptureSession};
+
+/// Run the full conformance suite against a `Capture` implementation.
+pub fn run_suite<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+    start_returns_session(adapter, fixtures_dir);
+    stop_returns_valid_audio(adapter, fixtures_dir);
+    stop_returns_screenshot_paths(adapter, fixtures_dir);
+    stop_session_not_found(adapter);
+    is_fake_marker(adapter);
+}
+
+fn start_returns_session<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+    let meeting_id = "test_meeting_001";
+    let config = CaptureConfig::default();
+    let session = adapter
+        .start_capture(meeting_id, fixtures_dir, &config)
+        .expect("start_capture should succeed");
+    assert_eq!(session.meeting_id, meeting_id);
+    assert!(session.started_at_ms > 0, "started_at_ms should be set");
+
+    // Clean up the session.
+    let _ = adapter.stop_capture(&session);
+}
+
+fn stop_returns_valid_audio<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+    let meeting_id = "test_meeting_audio";
+    let config = CaptureConfig::default();
+    let session = adapter
+        .start_capture(meeting_id, fixtures_dir, &config)
+        .expect("start_capture should succeed");
+
+    let result = adapter
+        .stop_capture(&session)
+        .expect("stop_capture should succeed");
+
+    // Audio path must be a valid WAV that `hound` can parse.
+    assert!(
+        result.audio_path.exists(),
+        "audio_path {} should exist",
+        result.audio_path.display()
+    );
+    let reader = hound::WavReader::open(&result.audio_path).expect("audio should be valid WAV");
+    let spec = reader.spec();
+    assert_eq!(spec.sample_rate, 16_000, "audio must be 16 kHz");
+    assert_eq!(spec.channels, 1, "audio must be mono");
+
+    // Duration should match what the adapter reports.
+    let samples_count = reader.len() as u64;
+    let computed_ms = (samples_count * 1000) / (16_000);
+    assert!(result.duration_ms > 0, "duration_ms should be positive");
+    // Allow small tolerance for rounding differences.
+    let diff = (result.duration_ms as i64 - computed_ms as i64).abs();
+    assert!(
+        diff < 100,
+        "duration mismatch: reported {} vs computed {}",
+        result.duration_ms,
+        computed_ms
+    );
+}
+
+fn stop_returns_screenshot_paths<C: Capture>(adapter: &C, fixtures_dir: &Path) {
+    let meeting_id = "test_meeting_screenshots";
+    let config = CaptureConfig::default();
+    let session = adapter
+        .start_capture(meeting_id, fixtures_dir, &config)
+        .expect("start_capture should succeed");
+
+    let result = adapter
+        .stop_capture(&session)
+        .expect("stop_capture should succeed");
+
+    // Screenshots may be empty (fast stop) or have at least one.
+    // Each path must exist on disk.
+    for path in &result.screenshot_paths {
+        assert!(path.exists(), "screenshot {} should exist", path.display());
+    }
+}
+
+fn stop_session_not_found<C: Capture>(adapter: &C) {
+    let fake_session = CaptureSession {
+        meeting_id: "nonexistent_session".into(),
+        started_at_ms: 0,
+    };
+    let err = adapter
+        .stop_capture(&fake_session)
+        .expect_err("stop_capture of unknown session should fail");
+    match err {
+        CaptureError::SessionNotFound(id) => {
+            assert_eq!(id, "nonexistent_session");
+        }
+        other => panic!("expected SessionNotFound, got {other:?}"),
+    }
+}
+
+fn is_fake_marker<C: Capture>(adapter: &C) {
+    // The trait default is `false`. Fakes should override to `true`.
+    // This test simply asserts that the marker is set correctly for
+    // the adapter type — it's a sanity check, not a functional test.
+    let _ = adapter.is_fake(); // Just verify the method exists and doesn't panic.
+}

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -732,7 +732,7 @@ impl Capture for FakeCapture {
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| CaptureError::Capture(e.to_string()))?
             .as_millis() as u64;
-        let duration_ms = (ended_at_ms - started_at_ms).max(1000);
+        let duration_ms = ended_at_ms.saturating_sub(started_at_ms).max(1000);
 
         // Generate synthetic 440 Hz sine wave WAV at 16 kHz mono.
         let audio_path = meeting_dir.join("audio.wav");
@@ -760,27 +760,24 @@ impl Capture for FakeCapture {
             .finalize()
             .map_err(|e| CaptureError::Capture(e.to_string()))?;
 
-        // Copy screenshot fixtures from tests/fixtures/screenshots/.
+        // Write self-contained synthetic screenshot placeholders. The fake
+        // must NOT depend on tests/fixtures being an ancestor of meeting_dir
+        // (the engine's per-meeting dir lives outside the workspace, so the
+        // old ancestor-walk failed there). Emit a minimal embedded JPEG
+        // (SOI + JFIF APP0 + EOI) instead — enough for the contract, which
+        // only requires the screenshot paths to exist.
         let screenshots_dir = meeting_dir.join("screenshots");
         std::fs::create_dir_all(&screenshots_dir).map_err(CaptureError::Io)?;
 
-        let workspace_root = meeting_dir
-            .ancestors()
-            .find(|p| p.join("tests/fixtures/screenshots").is_dir())
-            .ok_or_else(|| CaptureError::Capture("workspace fixtures not found".into()))?;
-
-        let fixtures_screenshots = workspace_root.join("tests/fixtures/screenshots");
+        const FAKE_JPEG: &[u8] = &[
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+        ];
         let mut screenshot_paths: Vec<PathBuf> = Vec::new();
-
-        // Copy first 3 fixture screenshots (or fewer if not available).
         for i in 1..=3 {
-            let fixture_name = format!("{:03}.jpg", i);
-            let fixture_path = fixtures_screenshots.join(&fixture_name);
-            if fixture_path.exists() {
-                let dest_path = screenshots_dir.join(&fixture_name);
-                std::fs::copy(&fixture_path, &dest_path).map_err(CaptureError::Io)?;
-                screenshot_paths.push(dest_path);
-            }
+            let dest_path = screenshots_dir.join(format!("{:03}.jpg", i));
+            std::fs::write(&dest_path, FAKE_JPEG).map_err(CaptureError::Io)?;
+            screenshot_paths.push(dest_path);
         }
 
         Ok(CaptureResult {

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -815,3 +815,188 @@ mod capture_fake_tests {
         run_suite(&adapter, &fixtures_dir());
     }
 }
+
+// === InMemoryMeetingStore ============================================
+
+use crate::meeting_store::{
+    MeetingStore, MeetingStoreError, ScreenshotDraft, ScreenshotRow, SegmentDraft, SegmentRow,
+    SpeakerDraft, SpeakerRow,
+};
+
+/// In-process `MeetingStore` fake. Used by `panops-core`'s own tests and
+/// by engine integration tests where opening a real SQLite DB would be
+/// unnecessary friction.
+pub struct InMemoryMeetingStore {
+    inner: Mutex<InMemoryMeetingInner>,
+}
+
+struct InMemoryMeetingInner {
+    segments: std::collections::HashMap<i64, SegmentRow>,
+    screenshots: std::collections::HashMap<i64, ScreenshotRow>,
+    speakers: std::collections::HashMap<i64, SpeakerRow>,
+    next_id: i64,
+}
+
+impl Default for InMemoryMeetingStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryMeetingStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(InMemoryMeetingInner {
+                segments: std::collections::HashMap::new(),
+                screenshots: std::collections::HashMap::new(),
+                speakers: std::collections::HashMap::new(),
+                next_id: 1,
+            }),
+        }
+    }
+
+    fn next_id(inner: &mut InMemoryMeetingInner) -> i64 {
+        let id = inner.next_id;
+        inner.next_id += 1;
+        id
+    }
+}
+
+impl MeetingStore for InMemoryMeetingStore {
+    fn create_segment(&self, draft: SegmentDraft) -> Result<SegmentRow, MeetingStoreError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let id = Self::next_id(&mut inner);
+        let row = SegmentRow {
+            id,
+            meeting_id: draft.meeting_id,
+            start_ms: draft.start_ms,
+            end_ms: draft.end_ms,
+            text: draft.text,
+            language: draft.language,
+            confidence: draft.confidence,
+            speaker_id: draft.speaker_id,
+            source: draft.source,
+        };
+        inner.segments.insert(id, row.clone());
+        Ok(row)
+    }
+
+    fn list_segments(&self, meeting_id: &str) -> Result<Vec<SegmentRow>, MeetingStoreError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let mut segments: Vec<SegmentRow> = inner
+            .segments
+            .values()
+            .filter(|s| s.meeting_id == meeting_id)
+            .cloned()
+            .collect();
+        segments.sort_by_key(|s| s.start_ms);
+        Ok(segments)
+    }
+
+    fn create_screenshot(
+        &self,
+        draft: ScreenshotDraft,
+    ) -> Result<ScreenshotRow, MeetingStoreError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let id = Self::next_id(&mut inner);
+        let row = ScreenshotRow {
+            id,
+            meeting_id: draft.meeting_id,
+            timestamp_ms: draft.timestamp_ms,
+            path: draft.path,
+            feature_print: draft.feature_print,
+            caption: draft.caption,
+        };
+        inner.screenshots.insert(id, row.clone());
+        Ok(row)
+    }
+
+    fn list_screenshots(&self, meeting_id: &str) -> Result<Vec<ScreenshotRow>, MeetingStoreError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let mut screenshots: Vec<ScreenshotRow> = inner
+            .screenshots
+            .values()
+            .filter(|s| s.meeting_id == meeting_id)
+            .cloned()
+            .collect();
+        screenshots.sort_by_key(|s| s.timestamp_ms);
+        Ok(screenshots)
+    }
+
+    fn create_speaker(&self, draft: SpeakerDraft) -> Result<SpeakerRow, MeetingStoreError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let id = Self::next_id(&mut inner);
+        let row = SpeakerRow {
+            id,
+            meeting_id: draft.meeting_id,
+            label: draft.label,
+            embedding: draft.embedding,
+        };
+        inner.speakers.insert(id, row.clone());
+        Ok(row)
+    }
+
+    fn list_speakers(&self, meeting_id: &str) -> Result<Vec<SpeakerRow>, MeetingStoreError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        Ok(inner
+            .speakers
+            .values()
+            .filter(|s| s.meeting_id == meeting_id)
+            .cloned()
+            .collect())
+    }
+
+    fn get_speaker(&self, id: i64) -> Result<SpeakerRow, MeetingStoreError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        inner
+            .speakers
+            .get(&id)
+            .cloned()
+            .ok_or(MeetingStoreError::SpeakerNotFound { id })
+    }
+
+    fn update_speaker_label(&self, id: i64, label: &str) -> Result<SpeakerRow, MeetingStoreError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| MeetingStoreError::sql("mutex poisoned"))?;
+        let speaker = inner
+            .speakers
+            .get_mut(&id)
+            .ok_or(MeetingStoreError::SpeakerNotFound { id })?;
+        speaker.label = label.into();
+        Ok(speaker.clone())
+    }
+}
+
+#[cfg(test)]
+mod meeting_store_fake_tests {
+    use super::InMemoryMeetingStore;
+    use crate::conformance::meeting_store::run_suite;
+
+    #[test]
+    fn in_memory_meeting_store_passes_conformance() {
+        run_suite(&InMemoryMeetingStore::new());
+    }
+}

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -659,3 +659,159 @@ mod storage_fake_tests {
         run_suite(&InMemoryStorage::new());
     }
 }
+
+// === FakeCapture ============================================
+
+use std::f32::consts::PI;
+use std::path::PathBuf;
+
+use crate::capture::{Capture, CaptureConfig, CaptureError, CaptureResult, CaptureSession};
+
+/// A fake `Capture` adapter for testing. Produces:
+/// - A synthetic 440 Hz sine wave PCM written to a WAV file via `hound`.
+/// - Pre-generated screenshot fixtures from `tests/fixtures/screenshots/`.
+///
+/// Thread-safe: sessions are tracked in an internal `Mutex<HashMap>`.
+pub struct FakeCapture {
+    sessions: Mutex<std::collections::HashMap<String, (PathBuf, u64)>>,
+}
+
+impl Default for FakeCapture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FakeCapture {
+    pub fn new() -> Self {
+        Self {
+            sessions: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl Capture for FakeCapture {
+    fn start_capture(
+        &self,
+        meeting_id: &str,
+        meeting_dir: &std::path::Path,
+        _config: &CaptureConfig,
+    ) -> Result<CaptureSession, CaptureError> {
+        let started_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| CaptureError::Capture(e.to_string()))?
+            .as_millis() as u64;
+
+        // Store session info for stop_capture.
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| CaptureError::Capture("mutex poisoned".into()))?;
+        sessions.insert(
+            meeting_id.to_string(),
+            (meeting_dir.to_path_buf(), started_at_ms),
+        );
+
+        Ok(CaptureSession {
+            meeting_id: meeting_id.to_string(),
+            started_at_ms,
+        })
+    }
+
+    fn stop_capture(&self, session: &CaptureSession) -> Result<CaptureResult, CaptureError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| CaptureError::Capture("mutex poisoned".into()))?;
+        let (meeting_dir, started_at_ms) = sessions
+            .remove(&session.meeting_id)
+            .ok_or_else(|| CaptureError::SessionNotFound(session.meeting_id.clone()))?;
+
+        // Compute duration (at least 1s for valid WAV).
+        let ended_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| CaptureError::Capture(e.to_string()))?
+            .as_millis() as u64;
+        let duration_ms = (ended_at_ms - started_at_ms).max(1000);
+
+        // Generate synthetic 440 Hz sine wave WAV at 16 kHz mono.
+        let audio_path = meeting_dir.join("audio.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&audio_path, spec)
+            .map_err(|e| CaptureError::Capture(e.to_string()))?;
+
+        // Compute number of samples for the duration.
+        let num_samples = (16_000 * duration_ms / 1000) as usize;
+        let freq = 440.0;
+        for i in 0..num_samples {
+            let t = i as f32 / 16_000.0_f32;
+            let sample = (2.0_f32 * PI * freq * t).sin();
+            let amplitude = (sample * 0.3 * i16::MAX as f32) as i16; // 30% volume
+            writer
+                .write_sample(amplitude)
+                .map_err(|e| CaptureError::Capture(e.to_string()))?;
+        }
+        writer
+            .finalize()
+            .map_err(|e| CaptureError::Capture(e.to_string()))?;
+
+        // Copy screenshot fixtures from tests/fixtures/screenshots/.
+        let screenshots_dir = meeting_dir.join("screenshots");
+        std::fs::create_dir_all(&screenshots_dir).map_err(CaptureError::Io)?;
+
+        let workspace_root = meeting_dir
+            .ancestors()
+            .find(|p| p.join("tests/fixtures/screenshots").is_dir())
+            .ok_or_else(|| CaptureError::Capture("workspace fixtures not found".into()))?;
+
+        let fixtures_screenshots = workspace_root.join("tests/fixtures/screenshots");
+        let mut screenshot_paths: Vec<PathBuf> = Vec::new();
+
+        // Copy first 3 fixture screenshots (or fewer if not available).
+        for i in 1..=3 {
+            let fixture_name = format!("{:03}.jpg", i);
+            let fixture_path = fixtures_screenshots.join(&fixture_name);
+            if fixture_path.exists() {
+                let dest_path = screenshots_dir.join(&fixture_name);
+                std::fs::copy(&fixture_path, &dest_path).map_err(CaptureError::Io)?;
+                screenshot_paths.push(dest_path);
+            }
+        }
+
+        Ok(CaptureResult {
+            audio_path,
+            screenshot_paths,
+            duration_ms,
+        })
+    }
+
+    fn is_fake(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod capture_fake_tests {
+    use super::FakeCapture;
+    use crate::conformance::capture::run_suite;
+    use std::path::PathBuf;
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .find(|p| p.join("tests/fixtures/screenshots").is_dir())
+            .expect("workspace root with fixtures")
+            .join("tests/fixtures")
+    }
+
+    #[test]
+    fn fake_capture_passes_conformance() {
+        let adapter = FakeCapture::new();
+        run_suite(&adapter, &fixtures_dir());
+    }
+}

--- a/crates/panops-core/src/conformance/meeting_store.rs
+++ b/crates/panops-core/src/conformance/meeting_store.rs
@@ -1,0 +1,191 @@
+//! Conformance harness for [`crate::meeting_store::MeetingStore`] adapters.
+//!
+//! Every MeetingStore impl (real `RusqliteMeetingStore`, fake
+//! `InMemoryMeetingStore`) must pass this same suite. The harness asserts
+//! the contract documented on the trait:
+//!
+//! - `create_segment` returns a row with auto-generated id.
+//! - `list_segments` returns segments ordered by start_ms.
+//! - `create_screenshot` returns a row with auto-generated id.
+//! - `list_screenshots` returns screenshots ordered by timestamp_ms.
+//! - `create_speaker` returns a row with auto-generated id.
+//! - `list_speakers` returns speakers for the meeting.
+//! - `get_speaker` returns a speaker by id.
+//! - `update_speaker_label` mutates the label.
+
+use crate::meeting_store::{
+    MeetingStore, MeetingStoreError, ScreenshotDraft, SegmentDraft, SpeakerDraft,
+};
+
+/// Run the full conformance suite against a `MeetingStore` implementation.
+pub fn run_suite<M: MeetingStore>(adapter: &M) {
+    create_and_list_segments(adapter);
+    create_and_list_screenshots(adapter);
+    create_and_list_speakers(adapter);
+    get_speaker(adapter);
+    update_speaker_label(adapter);
+    get_nonexistent_speaker(adapter);
+}
+
+fn create_and_list_segments<M: MeetingStore>(adapter: &M) {
+    let meeting_id = "test_meeting_001";
+
+    // Create two segments.
+    let s1 = adapter
+        .create_segment(SegmentDraft {
+            meeting_id: meeting_id.into(),
+            start_ms: 0,
+            end_ms: 1000,
+            text: "hello world".into(),
+            language: Some("en".into()),
+            confidence: Some(0.9),
+            speaker_id: None,
+            source: "post_pass".into(),
+        })
+        .expect("create_segment should succeed");
+    assert!(s1.id > 0, "segment id should be auto-generated");
+    assert_eq!(s1.meeting_id, meeting_id);
+    assert_eq!(s1.text, "hello world");
+
+    let s2 = adapter
+        .create_segment(SegmentDraft {
+            meeting_id: meeting_id.into(),
+            start_ms: 2000,
+            end_ms: 3000,
+            text: "goodbye".into(),
+            language: Some("en".into()),
+            confidence: Some(0.8),
+            speaker_id: None,
+            source: "post_pass".into(),
+        })
+        .expect("create_segment should succeed");
+
+    // List segments, ordered by start_ms.
+    let segments = adapter
+        .list_segments(meeting_id)
+        .expect("list_segments should succeed");
+    assert_eq!(segments.len(), 2);
+    assert_eq!(segments[0].id, s1.id);
+    assert_eq!(segments[1].id, s2.id);
+}
+
+fn create_and_list_screenshots<M: MeetingStore>(adapter: &M) {
+    let meeting_id = "test_meeting_screenshots";
+
+    // Create two screenshots.
+    let sc1 = adapter
+        .create_screenshot(ScreenshotDraft {
+            meeting_id: meeting_id.into(),
+            timestamp_ms: 5000,
+            path: "/tmp/screenshots/001.jpg".into(),
+            feature_print: None,
+            caption: None,
+        })
+        .expect("create_screenshot should succeed");
+    assert!(sc1.id > 0, "screenshot id should be auto-generated");
+    assert_eq!(sc1.meeting_id, meeting_id);
+
+    let sc2 = adapter
+        .create_screenshot(ScreenshotDraft {
+            meeting_id: meeting_id.into(),
+            timestamp_ms: 10_000,
+            path: "/tmp/screenshots/002.jpg".into(),
+            feature_print: None,
+            caption: None,
+        })
+        .expect("create_screenshot should succeed");
+
+    // List screenshots, ordered by timestamp_ms.
+    let screenshots = adapter
+        .list_screenshots(meeting_id)
+        .expect("list_screenshots should succeed");
+    assert_eq!(screenshots.len(), 2);
+    assert_eq!(screenshots[0].id, sc1.id);
+    assert_eq!(screenshots[1].id, sc2.id);
+}
+
+fn create_and_list_speakers<M: MeetingStore>(adapter: &M) {
+    let meeting_id = "test_meeting_speakers";
+
+    // Create two speakers.
+    let sp1 = adapter
+        .create_speaker(SpeakerDraft {
+            meeting_id: meeting_id.into(),
+            label: "Speaker A".into(),
+            embedding: None,
+        })
+        .expect("create_speaker should succeed");
+    assert!(sp1.id > 0, "speaker id should be auto-generated");
+    assert_eq!(sp1.meeting_id, meeting_id);
+    assert_eq!(sp1.label, "Speaker A");
+
+    let sp2 = adapter
+        .create_speaker(SpeakerDraft {
+            meeting_id: meeting_id.into(),
+            label: "Speaker B".into(),
+            embedding: None,
+        })
+        .expect("create_speaker should succeed");
+
+    // List speakers.
+    let speakers = adapter
+        .list_speakers(meeting_id)
+        .expect("list_speakers should succeed");
+    assert_eq!(speakers.len(), 2);
+    // Order is not guaranteed; check both exist.
+    let ids: Vec<i64> = speakers.iter().map(|s| s.id).collect();
+    assert!(ids.contains(&sp1.id));
+    assert!(ids.contains(&sp2.id));
+}
+
+fn get_speaker<M: MeetingStore>(adapter: &M) {
+    let meeting_id = "test_meeting_get_speaker";
+
+    let sp = adapter
+        .create_speaker(SpeakerDraft {
+            meeting_id: meeting_id.into(),
+            label: "Speaker X".into(),
+            embedding: None,
+        })
+        .expect("create_speaker should succeed");
+
+    let fetched = adapter
+        .get_speaker(sp.id)
+        .expect("get_speaker should succeed");
+    assert_eq!(fetched.id, sp.id);
+    assert_eq!(fetched.label, "Speaker X");
+}
+
+fn update_speaker_label<M: MeetingStore>(adapter: &M) {
+    let meeting_id = "test_meeting_update_speaker";
+
+    let sp = adapter
+        .create_speaker(SpeakerDraft {
+            meeting_id: meeting_id.into(),
+            label: "Original Label".into(),
+            embedding: None,
+        })
+        .expect("create_speaker should succeed");
+
+    let updated = adapter
+        .update_speaker_label(sp.id, "New Label")
+        .expect("update_speaker_label should succeed");
+    assert_eq!(updated.id, sp.id);
+    assert_eq!(updated.label, "New Label");
+
+    // Verify persisted.
+    let fetched = adapter
+        .get_speaker(sp.id)
+        .expect("get_speaker should succeed");
+    assert_eq!(fetched.label, "New Label");
+}
+
+fn get_nonexistent_speaker<M: MeetingStore>(adapter: &M) {
+    let err = adapter
+        .get_speaker(999999)
+        .expect_err("get_speaker of nonexistent id should fail");
+    match err {
+        MeetingStoreError::SpeakerNotFound { id } => assert_eq!(id, 999999),
+        other => panic!("expected SpeakerNotFound, got {other:?}"),
+    }
+}

--- a/crates/panops-core/src/conformance/mod.rs
+++ b/crates/panops-core/src/conformance/mod.rs
@@ -9,5 +9,6 @@ pub mod diar;
 pub mod exporter;
 pub mod fakes;
 pub mod llm;
+pub mod meeting_store;
 pub mod storage;
 pub mod vad;

--- a/crates/panops-core/src/conformance/mod.rs
+++ b/crates/panops-core/src/conformance/mod.rs
@@ -4,6 +4,7 @@
 //! from their own integration tests.
 
 pub mod asr;
+pub mod capture;
 pub mod diar;
 pub mod exporter;
 pub mod fakes;

--- a/crates/panops-core/src/lib.rs
+++ b/crates/panops-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! panops-core: domain types and ports. Zero platform code.
 
 pub mod asr;
+pub mod capture;
 pub mod conformance;
 pub mod diar;
 pub mod exporter;
@@ -13,6 +14,9 @@ pub mod vad;
 pub mod wer;
 
 pub use asr::{AsrError, AsrProvider};
+pub use capture::{
+    AudioSources, Capture, CaptureConfig, CaptureError, CaptureResult, CaptureSession,
+};
 pub use diar::{DiarError, Diarizer, SpeakerTurn};
 pub use exporter::{ExportArtifact, ExportError, NotesExporter};
 pub use llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};

--- a/crates/panops-core/src/lib.rs
+++ b/crates/panops-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod conformance;
 pub mod diar;
 pub mod exporter;
 pub mod llm;
+pub mod meeting_store;
 pub mod merge;
 pub mod notes;
 pub mod segment;
@@ -20,6 +21,10 @@ pub use capture::{
 pub use diar::{DiarError, Diarizer, SpeakerTurn};
 pub use exporter::{ExportArtifact, ExportError, NotesExporter};
 pub use llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
+pub use meeting_store::{
+    MeetingStore, MeetingStoreError, ScreenshotDraft, ScreenshotRow, SegmentDraft, SegmentRow,
+    SpeakerDraft, SpeakerRow,
+};
 pub use merge::merge_speaker_turns;
 pub use notes::dialect::MarkdownDialect;
 pub use notes::error::NotesError;

--- a/crates/panops-core/src/meeting_store.rs
+++ b/crates/panops-core/src/meeting_store.rs
@@ -1,0 +1,203 @@
+//! Per-meeting content storage port. Stores segments, screenshots, and speakers
+//! in a per-meeting SQLite database at `meetings/<uuid>/meeting.db`.
+//!
+//! Real impl: `panops_portable::RusqliteMeetingStore`.
+//! Fake: `panops_core::conformance::fakes::InMemoryMeetingStore`.
+//!
+//! This port is distinct from the cross-meeting registry `Storage` trait:
+//! - `Storage` = meeting lifecycle + note registry (`panops.db`)
+//! - `MeetingStore` = segment + screenshot + speaker content (`meeting.db`)
+//!
+//! The trait is sync; async wrapping happens at the handler layer via
+//! `tokio::task::spawn_blocking`. Matches the shape of the other ports.
+
+use thiserror::Error;
+
+/// A transcribed segment from ASR/post-pass. Stored in `meeting.db`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SegmentRow {
+    pub id: i64,
+    pub meeting_id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+    pub language: Option<String>,
+    pub confidence: Option<f32>,
+    pub speaker_id: Option<i64>,
+    /// Source of the segment: "post_pass" or "live".
+    pub source: String,
+}
+
+/// Draft for inserting a new segment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SegmentDraft {
+    pub meeting_id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+    pub language: Option<String>,
+    pub confidence: Option<f32>,
+    pub speaker_id: Option<i64>,
+    pub source: String,
+}
+
+/// A captured screenshot. Stored in `meeting.db`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScreenshotRow {
+    pub id: i64,
+    pub meeting_id: String,
+    pub timestamp_ms: u64,
+    pub path: String,
+    /// Vision FeaturePrint blob for dedup/search.
+    pub feature_print: Option<Vec<u8>>,
+    /// LLM-generated caption (future slice).
+    pub caption: Option<String>,
+}
+
+/// Draft for inserting a new screenshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScreenshotDraft {
+    pub meeting_id: String,
+    pub timestamp_ms: u64,
+    pub path: String,
+    pub feature_print: Option<Vec<u8>>,
+    pub caption: Option<String>,
+}
+
+/// A identified speaker. Stored in `meeting.db`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpeakerRow {
+    pub id: i64,
+    pub meeting_id: String,
+    pub label: String,
+    /// Speaker embedding vector (future slice).
+    pub embedding: Option<Vec<u8>>,
+}
+
+/// Draft for inserting a new speaker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpeakerDraft {
+    pub meeting_id: String,
+    pub label: String,
+    pub embedding: Option<Vec<u8>>,
+}
+
+/// Domain error for meeting store operations. NEVER derive `Serialize`
+/// (per AGENTS.md: domain errors stay platform-agnostic; transport conversion
+/// lives in `panops-protocol` behind the `domain-conversions` feature).
+#[derive(Debug, Error)]
+pub enum MeetingStoreError {
+    #[error("meeting not found: {meeting_id}")]
+    MeetingNotFound { meeting_id: String },
+    #[error("segment not found: {id}")]
+    SegmentNotFound { id: i64 },
+    #[error("screenshot not found: {id}")]
+    ScreenshotNotFound { id: i64 },
+    #[error("speaker not found: {id}")]
+    SpeakerNotFound { id: i64 },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("sql error: {message}")]
+    Sql { message: String },
+}
+
+impl MeetingStoreError {
+    /// Construct a `Sql` variant from anything `Display`. Used by
+    /// `RusqliteMeetingStore` to keep `panops-core` rusqlite-free.
+    pub fn sql<E: std::fmt::Display>(e: E) -> Self {
+        Self::Sql {
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Per-meeting content storage trait. One instance per meeting;
+/// each meeting has its own SQLite DB at `<meeting_dir>/meeting.db`.
+pub trait MeetingStore: Send + Sync {
+    /// Insert a segment row. Returns the inserted row with its auto-generated id.
+    fn create_segment(&self, draft: SegmentDraft) -> Result<SegmentRow, MeetingStoreError>;
+
+    /// List all segments for a meeting, ordered by start_ms.
+    fn list_segments(&self, meeting_id: &str) -> Result<Vec<SegmentRow>, MeetingStoreError>;
+
+    /// Insert a screenshot row. Returns the inserted row with its auto-generated id.
+    fn create_screenshot(&self, draft: ScreenshotDraft)
+    -> Result<ScreenshotRow, MeetingStoreError>;
+
+    /// List all screenshots for a meeting, ordered by timestamp_ms.
+    fn list_screenshots(&self, meeting_id: &str) -> Result<Vec<ScreenshotRow>, MeetingStoreError>;
+
+    /// Insert a speaker row. Returns the inserted row with its auto-generated id.
+    fn create_speaker(&self, draft: SpeakerDraft) -> Result<SpeakerRow, MeetingStoreError>;
+
+    /// List all speakers for a meeting.
+    fn list_speakers(&self, meeting_id: &str) -> Result<Vec<SpeakerRow>, MeetingStoreError>;
+
+    /// Get a speaker by id.
+    fn get_speaker(&self, id: i64) -> Result<SpeakerRow, MeetingStoreError>;
+
+    /// Update a speaker's label.
+    fn update_speaker_label(&self, id: i64, label: &str) -> Result<SpeakerRow, MeetingStoreError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_draft_can_be_constructed() {
+        let d = SegmentDraft {
+            meeting_id: "m1".into(),
+            start_ms: 0,
+            end_ms: 1000,
+            text: "hello".into(),
+            language: Some("en".into()),
+            confidence: Some(0.9),
+            speaker_id: None,
+            source: "post_pass".into(),
+        };
+        assert_eq!(d.meeting_id, "m1");
+        assert_eq!(d.text, "hello");
+    }
+
+    #[test]
+    fn screenshot_draft_can_be_constructed() {
+        let d = ScreenshotDraft {
+            meeting_id: "m1".into(),
+            timestamp_ms: 5000,
+            path: "/tmp/screenshots/001.jpg".into(),
+            feature_print: None,
+            caption: None,
+        };
+        assert_eq!(d.meeting_id, "m1");
+        assert_eq!(d.timestamp_ms, 5000);
+    }
+
+    #[test]
+    fn speaker_draft_can_be_constructed() {
+        let d = SpeakerDraft {
+            meeting_id: "m1".into(),
+            label: "Speaker A".into(),
+            embedding: None,
+        };
+        assert_eq!(d.meeting_id, "m1");
+        assert_eq!(d.label, "Speaker A");
+    }
+
+    #[test]
+    fn meeting_store_error_display_includes_context() {
+        let e = MeetingStoreError::MeetingNotFound {
+            meeting_id: "abc".into(),
+        };
+        assert!(format!("{e}").contains("abc"));
+        let e = MeetingStoreError::SegmentNotFound { id: 42 };
+        assert!(format!("{e}").contains("42"));
+    }
+
+    #[test]
+    fn meeting_store_error_io_via_from() {
+        let io = std::io::Error::other("disk full");
+        let e: MeetingStoreError = io.into();
+        assert!(matches!(e, MeetingStoreError::Io(..)));
+    }
+}

--- a/crates/panops-engine/src/capture_resolver.rs
+++ b/crates/panops-engine/src/capture_resolver.rs
@@ -2,10 +2,10 @@
 //!
 //! For slice 11, no macOS ScreenCaptureKit sidecar exists yet (that's the
 //! live-capture path gated on manual Mac smoke). We return `FakeCapture`
-//! under `#[cfg(test)]` so the IPC handlers are unit-testable.
+//! when `PANOPS_TEST_CAPTURE=1` is set (for unit tests and integration tests).
 //!
-//! For non-test builds, we return a clear error since the real adapter
-//! is pending (mirrors `asr_resolver`'s pattern).
+//! For non-test builds without the env var, we return a clear error since
+//! the real adapter is pending (mirrors `asr_resolver`'s pattern).
 //!
 //! Once `apps/panops-capture-mac/` exists, this resolver will mirror
 //! `asr_resolver`:
@@ -26,18 +26,15 @@ static CAPTURE: OnceLock<Arc<dyn Capture + Send + Sync>> = OnceLock::new();
 
 /// Resolve the capture adapter.
 ///
-/// Under `#[cfg(test)]`, returns a cached `FakeCapture` for unit tests.
-/// For non-test builds, returns a capture that errors on `start_capture`
-/// since the ScreenCaptureKit sidecar is not yet implemented.
+/// When `PANOPS_TEST_CAPTURE=1` is set, returns a cached `FakeCapture` for tests.
+/// Otherwise, returns a capture that errors on `start_capture` since the
+/// ScreenCaptureKit sidecar is not yet implemented.
 pub fn pick_capture() -> Arc<dyn Capture + Send + Sync> {
     CAPTURE
         .get_or_init(|| {
-            #[cfg(test)]
-            {
+            if std::env::var("PANOPS_TEST_CAPTURE").as_deref() == Ok("1") {
                 Arc::new(panops_core::conformance::fakes::FakeCapture::new())
-            }
-            #[cfg(not(test))]
-            {
+            } else {
                 Arc::new(NotYetImplementedCapture)
             }
         })
@@ -46,10 +43,8 @@ pub fn pick_capture() -> Arc<dyn Capture + Send + Sync> {
 
 /// Placeholder capture that returns a clear error for real/non-test use.
 /// The macOS ScreenCaptureKit sidecar is not yet implemented.
-#[cfg(not(test))]
 struct NotYetImplementedCapture;
 
-#[cfg(not(test))]
 impl Capture for NotYetImplementedCapture {
     fn start_capture(
         &self,

--- a/crates/panops-engine/src/capture_resolver.rs
+++ b/crates/panops-engine/src/capture_resolver.rs
@@ -2,26 +2,76 @@
 //!
 //! For slice 11, no macOS ScreenCaptureKit sidecar exists yet (that's the
 //! live-capture path gated on manual Mac smoke). We return `FakeCapture`
-//! unconditionally so the IPC handlers are unit-testable and CI-verifiable.
+//! under `#[cfg(test)]` so the IPC handlers are unit-testable.
+//!
+//! For non-test builds, we return a clear error since the real adapter
+//! is pending (mirrors `asr_resolver`'s pattern).
 //!
 //! Once `apps/panops-capture-mac/` exists, this resolver will mirror
 //! `asr_resolver`:
 //!   - macOS: check `PANOPS_CAPTURE_SIDECAR_BIN` env var; if set and executable,
 //!     use `ScreenCaptureKitCapture` sidecar adapter.
-//!   - Otherwise: fall back to `FakeCapture` (tests) or error in production.
+//!   - Otherwise: fall back to error in production.
 //!
 //! Design: `docs/superpowers/specs/2026-06-05-slice-11-live-capture-design.md`.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use panops_core::capture::Capture;
 
-/// Resolve the capture adapter. For slice 11 scaffolding, returns
-/// `FakeCapture` unconditionally (no real ScreenCaptureKit adapter yet).
+/// Cached capture adapter. `OnceLock` ensures the same instance is returned
+/// on every call, so `start_capture` and `stop_capture` share the same
+/// session map (critical for FakeCapture's internal HashMap).
+static CAPTURE: OnceLock<Arc<dyn Capture + Send + Sync>> = OnceLock::new();
+
+/// Resolve the capture adapter.
+///
+/// Under `#[cfg(test)]`, returns a cached `FakeCapture` for unit tests.
+/// For non-test builds, returns a capture that errors on `start_capture`
+/// since the ScreenCaptureKit sidecar is not yet implemented.
 pub fn pick_capture() -> Arc<dyn Capture + Send + Sync> {
-    // Slice 11 scaffolding: no macOS sidecar exists yet. Return FakeCapture
-    // so the IPC handlers are unit-testable. The real ScreenCaptureKit adapter
-    // will be gated on a manual Mac smoke test and the PANOPS_CAPTURE_SIDECAR_BIN
-    // env var (mirroring asr_resolver).
-    Arc::new(panops_core::conformance::fakes::FakeCapture::new())
+    CAPTURE
+        .get_or_init(|| {
+            #[cfg(test)]
+            {
+                Arc::new(panops_core::conformance::fakes::FakeCapture::new())
+            }
+            #[cfg(not(test))]
+            {
+                Arc::new(NotYetImplementedCapture)
+            }
+        })
+        .clone()
+}
+
+/// Placeholder capture that returns a clear error for real/non-test use.
+/// The macOS ScreenCaptureKit sidecar is not yet implemented.
+#[cfg(not(test))]
+struct NotYetImplementedCapture;
+
+#[cfg(not(test))]
+impl Capture for NotYetImplementedCapture {
+    fn start_capture(
+        &self,
+        _meeting_id: &str,
+        _meeting_dir: &std::path::Path,
+        _config: &panops_core::capture::CaptureConfig,
+    ) -> Result<panops_core::capture::CaptureSession, panops_core::capture::CaptureError> {
+        Err(panops_core::capture::CaptureError::Capture(
+            "live capture not yet implemented — ScreenCaptureKit sidecar pending".into(),
+        ))
+    }
+
+    fn stop_capture(
+        &self,
+        _session: &panops_core::capture::CaptureSession,
+    ) -> Result<panops_core::capture::CaptureResult, panops_core::capture::CaptureError> {
+        Err(panops_core::capture::CaptureError::Capture(
+            "live capture not yet implemented — ScreenCaptureKit sidecar pending".into(),
+        ))
+    }
+
+    fn is_fake(&self) -> bool {
+        false
+    }
 }

--- a/crates/panops-engine/src/capture_resolver.rs
+++ b/crates/panops-engine/src/capture_resolver.rs
@@ -1,0 +1,27 @@
+//! Resolve which `Capture` impl the engine uses at runtime.
+//!
+//! For slice 11, no macOS ScreenCaptureKit sidecar exists yet (that's the
+//! live-capture path gated on manual Mac smoke). We return `FakeCapture`
+//! unconditionally so the IPC handlers are unit-testable and CI-verifiable.
+//!
+//! Once `apps/panops-capture-mac/` exists, this resolver will mirror
+//! `asr_resolver`:
+//!   - macOS: check `PANOPS_CAPTURE_SIDECAR_BIN` env var; if set and executable,
+//!     use `ScreenCaptureKitCapture` sidecar adapter.
+//!   - Otherwise: fall back to `FakeCapture` (tests) or error in production.
+//!
+//! Design: `docs/superpowers/specs/2026-06-05-slice-11-live-capture-design.md`.
+
+use std::sync::Arc;
+
+use panops_core::capture::Capture;
+
+/// Resolve the capture adapter. For slice 11 scaffolding, returns
+/// `FakeCapture` unconditionally (no real ScreenCaptureKit adapter yet).
+pub fn pick_capture() -> Arc<dyn Capture + Send + Sync> {
+    // Slice 11 scaffolding: no macOS sidecar exists yet. Return FakeCapture
+    // so the IPC handlers are unit-testable. The real ScreenCaptureKit adapter
+    // will be gated on a manual Mac smoke test and the PANOPS_CAPTURE_SIDECAR_BIN
+    // env var (mirroring asr_resolver).
+    Arc::new(panops_core::conformance::fakes::FakeCapture::new())
+}

--- a/crates/panops-engine/src/lib.rs
+++ b/crates/panops-engine/src/lib.rs
@@ -1,4 +1,5 @@
 //! Library facade for `panops-engine` so integration tests can drive
 //! the server in-process. The binary entry point lives in `main.rs`.
 pub mod asr_resolver;
+pub mod capture_resolver;
 pub mod server;

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -10,23 +10,34 @@
 //! `ipc_error_to_obj`, matching the slice spec's "Error mapping at the
 //! RPC boundary" section.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use jsonrpsee::PendingSubscriptionSink;
 use jsonrpsee::core::SubscriptionResult;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
+use panops_core::capture::CaptureSession;
 use panops_core::merge::merge_speaker_turns;
 use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_protocol::{
-    Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig,
-    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
-    RecordingStartParams, RecordingStopParams, RecordingStopped,
+    AudioSourcesWire, Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting,
+    MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    RecordingAccepted, RecordingStartParams, RecordingStopParams, RecordingStopped,
 };
 use tokio::sync::broadcast;
+
+/// Convert wire AudioSources to domain AudioSources.
+fn audio_sources_wire_to_domain(wire: AudioSourcesWire) -> panops_core::capture::AudioSources {
+    match wire {
+        AudioSourcesWire::SystemOnly => panops_core::capture::AudioSources::SystemOnly,
+        AudioSourcesWire::MicOnly => panops_core::capture::AudioSources::MicOnly,
+        AudioSourcesWire::SystemAndMic => panops_core::capture::AudioSources::SystemAndMic,
+    }
+}
 
 /// Wrapper for `meeting.{stop,get,delete,set_language}` request params.
 /// jsonrpsee's `#[rpc]` macro accepts strongly-typed params via a single
@@ -95,6 +106,12 @@ pub(super) trait Ipc {
 pub(super) struct IpcImpl {
     pub(super) services: Arc<crate::server::EngineServices>,
     pub(super) events_tx: broadcast::Sender<Event>,
+    /// Active capture sessions keyed by recording_id (meeting_id).
+    /// Persisted from `recording.start` and looked up in `recording.stop`
+    /// so the real session (with correct started_at_ms) is passed to
+    /// `stop_capture` instead of a fabricated placeholder.
+    /// Wrapped in Arc<Mutex> so it can be cloned and passed to spawn_blocking.
+    pub(super) sessions: Arc<Mutex<HashMap<String, CaptureSession>>>,
 }
 
 #[async_trait::async_trait]
@@ -296,25 +313,37 @@ impl IpcServer for IpcImpl {
     ) -> Result<RecordingAccepted, ErrorObjectOwned> {
         let capture = crate::capture_resolver::pick_capture();
         let storage = self.services.storage.clone();
-        let _data_dir = self.services.data_dir.clone();
+        let data_dir = self.services.data_dir.clone();
         let meeting_id = params.meeting_id;
+        let audio_sources = params.audio_sources;
+
+        // Clone self.sessions for use in spawn_blocking.
+        let sessions = self.sessions.clone();
 
         spawn_blocking_into_ipc("recording.start", move || {
             // Verify meeting exists.
             let m = storage.get_meeting(&meeting_id).map_err(IpcError::from)?;
-            let meeting_dir = PathBuf::from(&m.dir_path);
+            let meeting_dir = validate_meeting_dir(&data_dir, &m.dir_path)?;
 
-            // Start capture.
+            // Start capture with config from wire params.
             let config = panops_core::capture::CaptureConfig {
-                audio_sources: panops_core::capture::AudioSources::SystemAndMic,
+                audio_sources: audio_sources_wire_to_domain(audio_sources),
                 screenshot_interval_ms: params.screenshot_interval_ms,
                 screenshot_threshold: params.screenshot_threshold,
             };
-            let _session = capture
+            let session = capture
                 .start_capture(&meeting_id, &meeting_dir, &config)
                 .map_err(IpcError::from)?;
 
-            // Return recording_id as meeting_id for now (simplified for scaffolding).
+            // Persist session for recording.stop to look up.
+            sessions
+                .lock()
+                .map_err(|_| IpcError::Internal {
+                    message: "sessions mutex poisoned".into(),
+                })?
+                .insert(meeting_id.clone(), session);
+
+            // Return recording_id as meeting_id.
             Ok(RecordingAccepted {
                 recording_id: meeting_id,
             })
@@ -329,11 +358,21 @@ impl IpcServer for IpcImpl {
         let capture = crate::capture_resolver::pick_capture();
         let recording_id = params.recording_id;
 
+        // Clone self.sessions for use in spawn_blocking.
+        let sessions = self.sessions.clone();
+
         spawn_blocking_into_ipc("recording.stop", move || {
-            let session = panops_core::capture::CaptureSession {
-                meeting_id: recording_id.clone(),
-                started_at_ms: 0, // Placeholder; not used by FakeCapture
-            };
+            // Look up the real session persisted by recording.start.
+            let session = sessions
+                .lock()
+                .map_err(|_| IpcError::Internal {
+                    message: "sessions mutex poisoned".into(),
+                })?
+                .remove(&recording_id)
+                .ok_or_else(|| IpcError::InputNotFound {
+                    path: format!("session/{recording_id}"),
+                })?;
+
             let result = capture.stop_capture(&session).map_err(IpcError::from)?;
 
             Ok(RecordingStopped {

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -23,7 +23,8 @@ use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_protocol::{
     Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig,
-    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
+    RecordingStartParams, RecordingStopParams, RecordingStopped,
 };
 use tokio::sync::broadcast;
 
@@ -70,6 +71,18 @@ pub(super) trait Ipc {
 
     #[method(name = "meeting.delete")]
     async fn meeting_delete(&self, params: MeetingIdParam) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "recording.start")]
+    async fn recording_start(
+        &self,
+        params: RecordingStartParams,
+    ) -> Result<RecordingAccepted, ErrorObjectOwned>;
+
+    #[method(name = "recording.stop")]
+    async fn recording_stop(
+        &self,
+        params: RecordingStopParams,
+    ) -> Result<RecordingStopped, ErrorObjectOwned>;
 
     #[subscription(
         name = "events.subscribe" => "events",
@@ -273,6 +286,65 @@ impl IpcServer for IpcImpl {
                 );
             }
             Ok(())
+        })
+        .await
+    }
+
+    async fn recording_start(
+        &self,
+        params: RecordingStartParams,
+    ) -> Result<RecordingAccepted, ErrorObjectOwned> {
+        let capture = crate::capture_resolver::pick_capture();
+        let storage = self.services.storage.clone();
+        let _data_dir = self.services.data_dir.clone();
+        let meeting_id = params.meeting_id;
+
+        spawn_blocking_into_ipc("recording.start", move || {
+            // Verify meeting exists.
+            let m = storage.get_meeting(&meeting_id).map_err(IpcError::from)?;
+            let meeting_dir = PathBuf::from(&m.dir_path);
+
+            // Start capture.
+            let config = panops_core::capture::CaptureConfig {
+                audio_sources: panops_core::capture::AudioSources::SystemAndMic,
+                screenshot_interval_ms: params.screenshot_interval_ms,
+                screenshot_threshold: params.screenshot_threshold,
+            };
+            let _session = capture
+                .start_capture(&meeting_id, &meeting_dir, &config)
+                .map_err(IpcError::from)?;
+
+            // Return recording_id as meeting_id for now (simplified for scaffolding).
+            Ok(RecordingAccepted {
+                recording_id: meeting_id,
+            })
+        })
+        .await
+    }
+
+    async fn recording_stop(
+        &self,
+        params: RecordingStopParams,
+    ) -> Result<RecordingStopped, ErrorObjectOwned> {
+        let capture = crate::capture_resolver::pick_capture();
+        let recording_id = params.recording_id;
+
+        spawn_blocking_into_ipc("recording.stop", move || {
+            let session = panops_core::capture::CaptureSession {
+                meeting_id: recording_id.clone(),
+                started_at_ms: 0, // Placeholder; not used by FakeCapture
+            };
+            let result = capture.stop_capture(&session).map_err(IpcError::from)?;
+
+            Ok(RecordingStopped {
+                audio_path: result.audio_path.display().to_string(),
+                screenshot_paths: result
+                    .screenshot_paths
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect(),
+                duration_ms: result.duration_ms,
+            })
         })
         .await
     }

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -21,10 +21,11 @@ mod events;
 mod handlers;
 mod socket;
 
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use futures_util::FutureExt;
 use jsonrpsee::Methods;
@@ -363,6 +364,7 @@ pub async fn run_serve_in_process(
     let ipc_impl = IpcImpl {
         services: services_arc,
         events_tx,
+        sessions: Arc::new(Mutex::new(HashMap::new())),
     };
     let methods: Methods = ipc_impl.into_rpc().into();
 

--- a/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
+++ b/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
@@ -94,6 +94,11 @@ async fn notes_generate_emits_job_error_with_input_not_found_kind() {
         }
         Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d),
         Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
+        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+        // in this notes pipeline test.
+        Event::Screenshot(_) | Event::RecordingProgress(_) => {
+            panic!("expected JobError, got Screenshot/Progress event")
+        }
     }
 
     let _ = shutdown_tx.send(true);

--- a/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
+++ b/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
@@ -72,34 +72,37 @@ async fn notes_generate_emits_job_error_with_input_not_found_kind() {
     .await
     .expect("call notes.generate");
 
-    let event = tokio::time::timeout(Duration::from_secs(10), subscription.next())
-        .await
-        .expect("event arrived within 10s")
-        .expect("subscription not closed")
-        .expect("event payload deserialised");
+    let err = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let ev = subscription
+                .next()
+                .await
+                .expect("subscription open")
+                .expect("payload deserialises");
+            match ev {
+                Event::JobError(err) => return err,
+                Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d),
+                Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
+                // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+                // in this notes pipeline test (they may arrive from concurrent tests).
+                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+            }
+        }
+    })
+    .await
+    .expect("event arrived within 10s");
 
-    match event {
-        Event::JobError(err) => {
-            assert!(
-                matches!(err.error, IpcError::InputNotFound { .. }),
-                "expected InputNotFound, got {:?}",
-                err.error
-            );
-            // Wire-level check: serialised payload carries `kind: "input_not_found"`.
-            let json = serde_json::to_value(&err.error).unwrap();
-            assert_eq!(
-                json.get("kind").and_then(|v| v.as_str()),
-                Some("input_not_found")
-            );
-        }
-        Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d),
-        Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
-        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
-        // in this notes pipeline test.
-        Event::Screenshot(_) | Event::RecordingProgress(_) => {
-            panic!("expected JobError, got Screenshot/Progress event")
-        }
-    }
+    assert!(
+        matches!(err.error, IpcError::InputNotFound { .. }),
+        "expected InputNotFound, got {:?}",
+        err.error
+    );
+    // Wire-level check: serialised payload carries `kind: "input_not_found"`.
+    let json = serde_json::to_value(&err.error).unwrap();
+    assert_eq!(
+        json.get("kind").and_then(|v| v.as_str()),
+        Some("input_not_found")
+    );
 
     let _ = shutdown_tx.send(true);
     let _ = server.await;

--- a/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
@@ -66,22 +66,27 @@ async fn notes_generate_without_meeting_id_auto_creates_one() {
     .await
     .expect("call notes.generate");
 
-    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
-        .await
-        .expect("event arrived within 60s")
-        .expect("subscription not closed")
-        .expect("event payload deserialised");
-
-    let (primary_file, meeting_id) = match event {
-        Event::JobDone(d) => (PathBuf::from(d.result.primary_file), d.result.meeting_id),
-        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
-        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
-        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
-        // in this notes pipeline test.
-        Event::Screenshot(_) | Event::RecordingProgress(_) => {
-            panic!("expected JobDone, got Screenshot/Progress event")
+    let (primary_file, meeting_id) = tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let event = subscription
+                .next()
+                .await
+                .expect("subscription open")
+                .expect("payload deserialises");
+            match event {
+                Event::JobDone(d) => {
+                    return (PathBuf::from(d.result.primary_file), d.result.meeting_id);
+                }
+                Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
+                Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+                // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+                // in this notes pipeline test (they may arrive from concurrent tests).
+                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+            }
         }
-    };
+    })
+    .await
+    .expect("event arrived within 60s");
 
     assert!(
         primary_file.exists(),

--- a/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
@@ -76,6 +76,11 @@ async fn notes_generate_without_meeting_id_auto_creates_one() {
         Event::JobDone(d) => (PathBuf::from(d.result.primary_file), d.result.meeting_id),
         Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
         Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+        // in this notes pipeline test.
+        Event::Screenshot(_) | Event::RecordingProgress(_) => {
+            panic!("expected JobDone, got Screenshot/Progress event")
+        }
     };
 
     assert!(

--- a/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
@@ -71,22 +71,25 @@ async fn notes_generate_round_trip_emits_job_done() {
     .await
     .expect("call notes.generate");
 
-    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
-        .await
-        .expect("event arrived within 60s")
-        .expect("subscription not closed")
-        .expect("event payload deserialised");
-
-    let primary_file = match event {
-        Event::JobDone(d) => PathBuf::from(d.result.primary_file),
-        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
-        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
-        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
-        // in this notes pipeline test.
-        Event::Screenshot(_) | Event::RecordingProgress(_) => {
-            panic!("expected JobDone, got Screenshot/Progress event")
+    let primary_file = tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let event = subscription
+                .next()
+                .await
+                .expect("subscription open")
+                .expect("payload deserialises");
+            match event {
+                Event::JobDone(d) => return PathBuf::from(d.result.primary_file),
+                Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
+                Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+                // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+                // in this notes pipeline test (they may arrive from concurrent tests).
+                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+            }
         }
-    };
+    })
+    .await
+    .expect("event arrived within 60s");
     assert!(
         primary_file.exists(),
         "primary_file does not exist: {primary_file:?}"

--- a/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
@@ -81,6 +81,11 @@ async fn notes_generate_round_trip_emits_job_done() {
         Event::JobDone(d) => PathBuf::from(d.result.primary_file),
         Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
         Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+        // in this notes pipeline test.
+        Event::Screenshot(_) | Event::RecordingProgress(_) => {
+            panic!("expected JobDone, got Screenshot/Progress event")
+        }
     };
     assert!(
         primary_file.exists(),

--- a/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
@@ -74,22 +74,25 @@ async fn notes_generate_with_existing_meeting_id_attaches_note() {
     .await
     .expect("notes.generate");
 
-    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
-        .await
-        .expect("event within 60s")
-        .expect("subscription open")
-        .expect("payload deserialises");
-
-    let result_meeting_id = match event {
-        Event::JobDone(d) => d.result.meeting_id,
-        Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
-        Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
-        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
-        // in this notes pipeline test.
-        Event::Screenshot(_) | Event::RecordingProgress(_) => {
-            panic!("expected JobDone, got Screenshot/Progress event")
+    let result_meeting_id = tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let event = subscription
+                .next()
+                .await
+                .expect("subscription open")
+                .expect("payload deserialises");
+            match event {
+                Event::JobDone(d) => return d.result.meeting_id,
+                Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
+                Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+                // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+                // in this notes pipeline test (they may arrive from concurrent tests).
+                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+            }
         }
-    };
+    })
+    .await
+    .expect("event within 60s");
 
     assert_eq!(
         result_meeting_id, meeting_id,

--- a/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
@@ -84,6 +84,11 @@ async fn notes_generate_with_existing_meeting_id_attaches_note() {
         Event::JobDone(d) => d.result.meeting_id,
         Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
         Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
+        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+        // in this notes pipeline test.
+        Event::Screenshot(_) | Event::RecordingProgress(_) => {
+            panic!("expected JobDone, got Screenshot/Progress event")
+        }
     };
 
     assert_eq!(

--- a/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
@@ -66,30 +66,34 @@ async fn notes_generate_with_unknown_meeting_id_returns_input_not_found() {
     .await
     .expect("notes.generate accepts the request even for unknown id");
 
-    let event = tokio::time::timeout(Duration::from_secs(60), subscription.next())
-        .await
-        .expect("event within 60s")
-        .expect("subscription open")
-        .expect("payload deserialises");
-
-    match event {
-        Event::JobError(e) => match e.error {
-            IpcError::InputNotFound { path } => {
-                assert!(
-                    path.contains("meeting"),
-                    "expected meeting in path, got: {path}"
-                );
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let event = subscription
+                .next()
+                .await
+                .expect("subscription open")
+                .expect("payload deserialises");
+            match event {
+                Event::JobError(e) => match e.error {
+                    IpcError::InputNotFound { path } => {
+                        assert!(
+                            path.contains("meeting"),
+                            "expected meeting in path, got: {path}"
+                        );
+                        return;
+                    }
+                    other => panic!("expected InputNotFound, got {other:?}"),
+                },
+                Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d.result),
+                Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
+                // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+                // in this notes pipeline test (they may arrive from concurrent tests).
+                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
             }
-            other => panic!("expected InputNotFound, got {other:?}"),
-        },
-        Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d.result),
-        Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
-        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
-        // in this notes pipeline test.
-        Event::Screenshot(_) | Event::RecordingProgress(_) => {
-            panic!("expected JobError, got Screenshot/Progress event")
         }
-    }
+    })
+    .await
+    .expect("event within 60s");
 
     // No meeting was created (the lookup failed before any side effects).
     let list = storage.list_meetings().unwrap();

--- a/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
@@ -84,6 +84,11 @@ async fn notes_generate_with_unknown_meeting_id_returns_input_not_found() {
         },
         Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d.result),
         Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
+        // Slice 11 adds Screenshot and RecordingProgress events; ignore them
+        // in this notes pipeline test.
+        Event::Screenshot(_) | Event::RecordingProgress(_) => {
+            panic!("expected JobError, got Screenshot/Progress event")
+        }
     }
 
     // No meeting was created (the lookup failed before any side effects).

--- a/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
@@ -1,0 +1,226 @@
+//! Slice 11 — `recording.start` → `recording.stop` IPC round-trip.
+//!
+//! Uses `FakeCapture` via cfg(test) resolver. Verifies that:
+//! - recording.start creates a session and persists it
+//! - recording.stop looks up the real session (not a fabricated one)
+//! - The shared capture instance is used (same FakeCapture via OnceLock)
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownRegionsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::{RecordingAccepted, RecordingStopped};
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recording_start_stop_round_trip() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(panops_core::conformance::fakes::KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    // Create a meeting first (recording.start requires an existing meeting).
+    let meeting_id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![serde_json::json!({
+            "title": "Test Recording",
+            "language": "en"
+        })],
+    )
+    .await
+    .expect("meeting.start");
+
+    // Start recording.
+    let accepted: RecordingAccepted = ClientT::request(
+        &client,
+        "ipc.recording.start",
+        rpc_params![serde_json::json!({
+            "meeting_id": meeting_id,
+            "audio_sources": "system_and_mic",
+            "screenshot_interval_ms": 500,
+            "screenshot_threshold": 0.15
+        })],
+    )
+    .await
+    .expect("recording.start");
+
+    assert_eq!(accepted.recording_id, meeting_id);
+
+    // Stop recording after a brief pause.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stopped: RecordingStopped = ClientT::request(
+        &client,
+        "ipc.recording.stop",
+        rpc_params![serde_json::json!({
+            "recording_id": meeting_id
+        })],
+    )
+    .await
+    .expect("recording.stop");
+
+    // Verify audio path exists and is a valid WAV.
+    assert!(!stopped.audio_path.is_empty());
+    assert!(stopped.duration_ms > 0, "duration should be positive");
+
+    // Verify screenshot paths are present (FakeCapture copies fixtures).
+    assert!(
+        !stopped.screenshot_paths.is_empty(),
+        "should have screenshots"
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recording_start_with_audio_sources_wire() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(panops_core::conformance::fakes::KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    // Create a meeting.
+    let meeting_id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![serde_json::json!({
+            "title": "Test Audio Sources"
+        })],
+    )
+    .await
+    .expect("meeting.start");
+
+    // Start recording with explicit audio_sources = mic_only.
+    let accepted: RecordingAccepted = ClientT::request(
+        &client,
+        "ipc.recording.start",
+        rpc_params![serde_json::json!({
+            "meeting_id": meeting_id,
+            "audio_sources": "mic_only"
+        })],
+    )
+    .await
+    .expect("recording.start with audio_sources");
+
+    assert_eq!(accepted.recording_id, meeting_id);
+
+    // Stop recording.
+    let stopped: RecordingStopped = ClientT::request(
+        &client,
+        "ipc.recording.stop",
+        rpc_params![serde_json::json!({
+            "recording_id": meeting_id
+        })],
+    )
+    .await
+    .expect("recording.stop");
+
+    assert!(!stopped.audio_path.is_empty());
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recording_stop_unknown_session_returns_input_not_found() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage.clone(),
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(panops_core::conformance::fakes::KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    // Try to stop a recording that was never started.
+    let result: Result<RecordingStopped, _> = ClientT::request(
+        &client,
+        "ipc.recording.stop",
+        rpc_params![serde_json::json!({
+            "recording_id": "nonexistent_session"
+        })],
+    )
+    .await;
+
+    // Expect error with kind = input_not_found.
+    let err = result.expect_err("recording.stop should fail for unknown session");
+    // JSON-RPC error code -32000 with IpcError in data.
+    assert!(err.to_string().contains("input_not_found") || err.to_string().contains("not found"));
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
@@ -1,6 +1,6 @@
 //! Slice 11 — `recording.start` → `recording.stop` IPC round-trip.
 //!
-//! Uses `FakeCapture` via cfg(test) resolver. Verifies that:
+//! Uses `FakeCapture` via PANOPS_TEST_CAPTURE=1 env var resolver. Verifies that:
 //! - recording.start creates a session and persists it
 //! - recording.stop looks up the real session (not a fabricated one)
 //! - The shared capture instance is used (same FakeCapture via OnceLock)
@@ -22,8 +22,23 @@ use tokio::sync::watch;
 
 use common::{tempdir_storage, uds_ws_client, wait_for_socket};
 
+/// Set PANOPS_TEST_CAPTURE=1 before any tests run so the resolver
+/// picks FakeCapture. This must happen before the OnceLock is initialized.
+static TEST_CAPTURE_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_test_capture() {
+    TEST_CAPTURE_INIT.call_once(|| {
+        // SAFETY: setting an env var before any tests run is safe; no other
+        // thread can read it before initialization completes.
+        unsafe {
+            std::env::set_var("PANOPS_TEST_CAPTURE", "1");
+        }
+    });
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn recording_start_stop_round_trip() {
+    ensure_test_capture();
     let dir = tempdir().unwrap();
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -108,6 +123,7 @@ async fn recording_start_stop_round_trip() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn recording_start_with_audio_sources_wire() {
+    ensure_test_capture();
     let dir = tempdir().unwrap();
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -179,6 +195,7 @@ async fn recording_start_with_audio_sources_wire() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn recording_stop_unknown_session_returns_input_not_found() {
+    ensure_test_capture();
     let dir = tempdir().unwrap();
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/crates/panops-portable/src/lib.rs
+++ b/crates/panops-portable/src/lib.rs
@@ -6,6 +6,7 @@ pub mod genai_llm;
 pub mod markdown_exporter;
 pub mod model;
 pub mod recursive_asr;
+pub mod rusqlite_meeting_store;
 pub mod rusqlite_storage;
 
 mod sherpa_diarizer;
@@ -14,6 +15,7 @@ pub mod whisper_vad;
 
 pub use genai_llm::GenaiLlm;
 pub use markdown_exporter::MarkdownExporter;
+pub use rusqlite_meeting_store::RusqliteMeetingStore;
 pub use rusqlite_storage::RusqliteStorage;
 pub use sherpa_diarizer::SherpaDiarizer;
 pub use whisper_adapter::WhisperRsAsr;

--- a/crates/panops-portable/src/rusqlite_meeting_store.rs
+++ b/crates/panops-portable/src/rusqlite_meeting_store.rs
@@ -1,0 +1,319 @@
+//! `MeetingStore` real adapter backed by `rusqlite` against a per-meeting
+//! SQLite file at `<meeting_dir>/meeting.db`. Stores segments, screenshots,
+//! and speakers.
+//!
+//! One instance per meeting; each meeting has its own DB file.
+//! Thread-safe via `Arc<Mutex<Connection>>`.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use panops_core::meeting_store::{
+    MeetingStore, MeetingStoreError, ScreenshotDraft, ScreenshotRow, SegmentDraft, SegmentRow,
+    SpeakerDraft, SpeakerRow,
+};
+
+/// Lock the connection mutex, mapping a poisoned mutex to a
+/// `MeetingStoreError::Sql` instead of panicking.
+fn lock<'a>(m: &'a Mutex<Connection>) -> Result<MutexGuard<'a, Connection>, MeetingStoreError> {
+    m.lock()
+        .map_err(|e| MeetingStoreError::sql(format!("meeting store mutex poisoned: {e}")))
+}
+
+const EXPECTED_SCHEMA_VERSION: u32 = 1;
+
+const DDL: &str = r"
+CREATE TABLE IF NOT EXISTS segment (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    meeting_id TEXT NOT NULL,
+    start_ms INTEGER NOT NULL,
+    end_ms INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    language TEXT,
+    confidence REAL,
+    speaker_id INTEGER,
+    source TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_segment_meeting_id ON segment(meeting_id);
+CREATE INDEX IF NOT EXISTS idx_segment_start_ms ON segment(start_ms);
+
+CREATE TABLE IF NOT EXISTS screenshot (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    meeting_id TEXT NOT NULL,
+    timestamp_ms INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    feature_print BLOB,
+    caption TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_screenshot_meeting_id ON screenshot(meeting_id);
+CREATE INDEX IF NOT EXISTS idx_screenshot_timestamp_ms ON screenshot(timestamp_ms);
+
+CREATE TABLE IF NOT EXISTS speaker (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    meeting_id TEXT NOT NULL,
+    label TEXT NOT NULL,
+    embedding BLOB
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_meeting_id ON speaker(meeting_id);
+";
+
+pub struct RusqliteMeetingStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl RusqliteMeetingStore {
+    /// Open or create the DB at `path`. Runs DDL if the file is fresh
+    /// (`user_version = 0`) or already at the expected version.
+    /// Errors with `MeetingStoreError::Sql` if `user_version` doesn't match.
+    pub fn new(path: &Path) -> Result<Self, MeetingStoreError> {
+        let conn = Connection::open(path).map_err(MeetingStoreError::sql)?;
+
+        let actual: u32 = conn
+            .query_row("PRAGMA user_version;", [], |r| r.get::<_, u32>(0))
+            .map_err(MeetingStoreError::sql)?;
+
+        if actual == 0 {
+            conn.execute_batch(DDL).map_err(MeetingStoreError::sql)?;
+            conn.execute_batch(&format!("PRAGMA user_version = {EXPECTED_SCHEMA_VERSION};"))
+                .map_err(MeetingStoreError::sql)?;
+        } else if actual != EXPECTED_SCHEMA_VERSION {
+            return Err(MeetingStoreError::Sql {
+                message: format!(
+                    "meeting.db schema mismatch: expected {EXPECTED_SCHEMA_VERSION}, got {actual}"
+                ),
+            });
+        }
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+}
+
+impl MeetingStore for RusqliteMeetingStore {
+    fn create_segment(&self, draft: SegmentDraft) -> Result<SegmentRow, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let id = conn.query_row(
+            "INSERT INTO segment (meeting_id, start_ms, end_ms, text, language, confidence, speaker_id, source)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             RETURNING id",
+            params![
+                draft.meeting_id,
+                draft.start_ms as i64,
+                draft.end_ms as i64,
+                draft.text,
+                draft.language,
+                draft.confidence,
+                draft.speaker_id,
+                draft.source,
+            ],
+            |r| r.get::<_, i64>(0),
+        )
+        .map_err(MeetingStoreError::sql)?;
+
+        Ok(SegmentRow {
+            id,
+            meeting_id: draft.meeting_id,
+            start_ms: draft.start_ms,
+            end_ms: draft.end_ms,
+            text: draft.text,
+            language: draft.language,
+            confidence: draft.confidence,
+            speaker_id: draft.speaker_id,
+            source: draft.source,
+        })
+    }
+
+    fn list_segments(&self, meeting_id: &str) -> Result<Vec<SegmentRow>, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, meeting_id, start_ms, end_ms, text, language, confidence, speaker_id, source
+                 FROM segment WHERE meeting_id = ?1 ORDER BY start_ms ASC",
+            )
+            .map_err(MeetingStoreError::sql)?;
+
+        let rows = stmt
+            .query_map(params![meeting_id], |r| {
+                Ok(SegmentRow {
+                    id: r.get(0)?,
+                    meeting_id: r.get(1)?,
+                    // Clamp negative values to 0 (defense against DB corruption).
+                    start_ms: r.get::<_, i64>(2)?.max(0) as u64,
+                    end_ms: r.get::<_, i64>(3)?.max(0) as u64,
+                    text: r.get(4)?,
+                    language: r.get(5)?,
+                    confidence: r.get(6)?,
+                    speaker_id: r.get(7)?,
+                    source: r.get(8)?,
+                })
+            })
+            .map_err(MeetingStoreError::sql)?;
+
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(MeetingStoreError::sql)?);
+        }
+        Ok(out)
+    }
+
+    fn create_screenshot(
+        &self,
+        draft: ScreenshotDraft,
+    ) -> Result<ScreenshotRow, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let id = conn
+            .query_row(
+                "INSERT INTO screenshot (meeting_id, timestamp_ms, path, feature_print, caption)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             RETURNING id",
+                params![
+                    draft.meeting_id,
+                    draft.timestamp_ms as i64,
+                    draft.path,
+                    draft.feature_print,
+                    draft.caption,
+                ],
+                |r| r.get::<_, i64>(0),
+            )
+            .map_err(MeetingStoreError::sql)?;
+
+        Ok(ScreenshotRow {
+            id,
+            meeting_id: draft.meeting_id,
+            timestamp_ms: draft.timestamp_ms,
+            path: draft.path,
+            feature_print: draft.feature_print,
+            caption: draft.caption,
+        })
+    }
+
+    fn list_screenshots(&self, meeting_id: &str) -> Result<Vec<ScreenshotRow>, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, meeting_id, timestamp_ms, path, feature_print, caption
+                 FROM screenshot WHERE meeting_id = ?1 ORDER BY timestamp_ms ASC",
+            )
+            .map_err(MeetingStoreError::sql)?;
+
+        let rows = stmt
+            .query_map(params![meeting_id], |r| {
+                Ok(ScreenshotRow {
+                    id: r.get(0)?,
+                    meeting_id: r.get(1)?,
+                    timestamp_ms: r.get::<_, i64>(2)?.max(0) as u64,
+                    path: r.get(3)?,
+                    feature_print: r.get(4)?,
+                    caption: r.get(5)?,
+                })
+            })
+            .map_err(MeetingStoreError::sql)?;
+
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(MeetingStoreError::sql)?);
+        }
+        Ok(out)
+    }
+
+    fn create_speaker(&self, draft: SpeakerDraft) -> Result<SpeakerRow, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let id = conn
+            .query_row(
+                "INSERT INTO speaker (meeting_id, label, embedding)
+             VALUES (?1, ?2, ?3)
+             RETURNING id",
+                params![draft.meeting_id, draft.label, draft.embedding],
+                |r| r.get::<_, i64>(0),
+            )
+            .map_err(MeetingStoreError::sql)?;
+
+        Ok(SpeakerRow {
+            id,
+            meeting_id: draft.meeting_id,
+            label: draft.label,
+            embedding: draft.embedding,
+        })
+    }
+
+    fn list_speakers(&self, meeting_id: &str) -> Result<Vec<SpeakerRow>, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, meeting_id, label, embedding
+                 FROM speaker WHERE meeting_id = ?1",
+            )
+            .map_err(MeetingStoreError::sql)?;
+
+        let rows = stmt
+            .query_map(params![meeting_id], |r| {
+                Ok(SpeakerRow {
+                    id: r.get(0)?,
+                    meeting_id: r.get(1)?,
+                    label: r.get(2)?,
+                    embedding: r.get(3)?,
+                })
+            })
+            .map_err(MeetingStoreError::sql)?;
+
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(MeetingStoreError::sql)?);
+        }
+        Ok(out)
+    }
+
+    fn get_speaker(&self, id: i64) -> Result<SpeakerRow, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        conn.query_row(
+            "SELECT id, meeting_id, label, embedding FROM speaker WHERE id = ?1",
+            params![id],
+            |r| {
+                Ok(SpeakerRow {
+                    id: r.get(0)?,
+                    meeting_id: r.get(1)?,
+                    label: r.get(2)?,
+                    embedding: r.get(3)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(MeetingStoreError::sql)?
+        .ok_or(MeetingStoreError::SpeakerNotFound { id })
+    }
+
+    fn update_speaker_label(&self, id: i64, label: &str) -> Result<SpeakerRow, MeetingStoreError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute(
+                "UPDATE speaker SET label = ?2 WHERE id = ?1",
+                params![id, label],
+            )
+            .map_err(MeetingStoreError::sql)?;
+        if n == 0 {
+            return Err(MeetingStoreError::SpeakerNotFound { id });
+        }
+        drop(conn);
+        self.get_speaker(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use panops_core::conformance::meeting_store::run_suite;
+
+    #[test]
+    fn rusqlite_meeting_store_passes_conformance() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("meeting.db");
+        let store = RusqliteMeetingStore::new(&db).unwrap();
+        run_suite(&store);
+    }
+}

--- a/crates/panops-protocol/src/error.rs
+++ b/crates/panops-protocol/src/error.rs
@@ -269,6 +269,39 @@ mod from_domain {
             }
         }
     }
+
+    impl From<panops_core::meeting_store::MeetingStoreError> for IpcError {
+        fn from(e: panops_core::meeting_store::MeetingStoreError) -> Self {
+            match e {
+                panops_core::meeting_store::MeetingStoreError::MeetingNotFound { meeting_id } => {
+                    IpcError::InputNotFound {
+                        path: format!("meeting/{meeting_id}"),
+                    }
+                }
+                panops_core::meeting_store::MeetingStoreError::SegmentNotFound { id } => {
+                    IpcError::InputNotFound {
+                        path: format!("segment/{id}"),
+                    }
+                }
+                panops_core::meeting_store::MeetingStoreError::ScreenshotNotFound { id } => {
+                    IpcError::InputNotFound {
+                        path: format!("screenshot/{id}"),
+                    }
+                }
+                panops_core::meeting_store::MeetingStoreError::SpeakerNotFound { id } => {
+                    IpcError::InputNotFound {
+                        path: format!("speaker/{id}"),
+                    }
+                }
+                panops_core::meeting_store::MeetingStoreError::Io(io) => IpcError::Internal {
+                    message: io.to_string(),
+                },
+                panops_core::meeting_store::MeetingStoreError::Sql { message } => {
+                    IpcError::Internal { message }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(all(test, feature = "domain-conversions"))]

--- a/crates/panops-protocol/src/error.rs
+++ b/crates/panops-protocol/src/error.rs
@@ -240,6 +240,35 @@ mod from_domain {
             }
         }
     }
+
+    impl From<panops_core::capture::CaptureError> for IpcError {
+        fn from(e: panops_core::capture::CaptureError) -> Self {
+            match e {
+                panops_core::capture::CaptureError::PermissionDenied(msg) => {
+                    IpcError::InvalidInput {
+                        message: format!("permission denied: {msg}"),
+                    }
+                }
+                panops_core::capture::CaptureError::Capture(msg) => {
+                    IpcError::Internal { message: msg }
+                }
+                panops_core::capture::CaptureError::Io(io) => IpcError::Internal {
+                    message: io.to_string(),
+                },
+                panops_core::capture::CaptureError::Sidecar(msg) => {
+                    IpcError::Internal { message: msg }
+                }
+                panops_core::capture::CaptureError::SessionNotFound(id) => {
+                    IpcError::InputNotFound {
+                        path: format!("session/{id}"),
+                    }
+                }
+                panops_core::capture::CaptureError::InvalidConfig(msg) => {
+                    IpcError::InvalidInput { message: msg }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(all(test, feature = "domain-conversions"))]
@@ -517,5 +546,35 @@ mod from_domain_tests {
         };
         assert_eq!(message, "vad io error");
         assert!(!message.contains("/Users/fran"));
+    }
+
+    #[test]
+    fn capture_permission_denied_maps_to_invalid_input() {
+        let e: IpcError =
+            panops_core::capture::CaptureError::PermissionDenied("microphone".into()).into();
+        let IpcError::InvalidInput { message } = e else {
+            panic!("expected InvalidInput");
+        };
+        assert!(message.contains("permission denied"), "got: {message}");
+    }
+
+    #[test]
+    fn capture_session_not_found_maps_to_input_not_found() {
+        let e: IpcError =
+            panops_core::capture::CaptureError::SessionNotFound("abc123".into()).into();
+        let IpcError::InputNotFound { path } = e else {
+            panic!("expected InputNotFound");
+        };
+        assert!(path.contains("session"), "got: {path}");
+        assert!(path.contains("abc123"), "got: {path}");
+    }
+
+    #[test]
+    fn capture_capture_maps_to_internal() {
+        let e: IpcError = panops_core::capture::CaptureError::Capture("device busy".into()).into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "device busy");
     }
 }

--- a/crates/panops-protocol/src/error.rs
+++ b/crates/panops-protocol/src/error.rs
@@ -252,8 +252,10 @@ mod from_domain {
                 panops_core::capture::CaptureError::Capture(msg) => {
                     IpcError::Internal { message: msg }
                 }
-                panops_core::capture::CaptureError::Io(io) => IpcError::Internal {
-                    message: io.to_string(),
+                // Wire stays opaque for Io errors — paths never reach the client.
+                // Full detail logged at call site where tracing is available.
+                panops_core::capture::CaptureError::Io(_) => IpcError::Internal {
+                    message: "capture io error".into(),
                 },
                 panops_core::capture::CaptureError::Sidecar(msg) => {
                     IpcError::Internal { message: msg }
@@ -293,12 +295,14 @@ mod from_domain {
                         path: format!("speaker/{id}"),
                     }
                 }
-                panops_core::meeting_store::MeetingStoreError::Io(io) => IpcError::Internal {
-                    message: io.to_string(),
+                // Wire stays opaque for Io/Sql errors — paths/SQL never reach client.
+                // Full detail logged at call site where tracing is available.
+                panops_core::meeting_store::MeetingStoreError::Io(_) => IpcError::Internal {
+                    message: "meeting store io error".into(),
                 },
-                panops_core::meeting_store::MeetingStoreError::Sql { message } => {
-                    IpcError::Internal { message }
-                }
+                panops_core::meeting_store::MeetingStoreError::Sql { .. } => IpcError::Internal {
+                    message: "meeting store error".into(),
+                },
             }
         }
     }
@@ -609,5 +613,62 @@ mod from_domain_tests {
             panic!("expected Internal");
         };
         assert_eq!(message, "device busy");
+    }
+
+    #[test]
+    fn capture_invalid_config_maps_to_invalid_input() {
+        let e: IpcError =
+            panops_core::capture::CaptureError::InvalidConfig("negative threshold".into()).into();
+        let IpcError::InvalidInput { message } = e else {
+            panic!("expected InvalidInput");
+        };
+        assert!(message.contains("negative threshold"), "got: {message}");
+    }
+
+    #[test]
+    fn capture_io_does_not_leak_path() {
+        let io =
+            std::io::Error::other("/Users/fran/Library/Application Support/panops/write failed");
+        let e: IpcError = panops_core::capture::CaptureError::Io(io).into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "capture io error");
+        assert!(!message.contains("/Users/fran"), "path leaked: {message}");
+    }
+
+    #[test]
+    fn capture_sidecar_maps_to_internal() {
+        let e: IpcError =
+            panops_core::capture::CaptureError::Sidecar("process exited with code 1".into()).into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert!(message.contains("process exited"), "got: {message}");
+    }
+
+    #[test]
+    fn meeting_store_io_does_not_leak_path() {
+        let io = std::io::Error::other("/Users/fran/Library/Application Support/panops/meeting.db");
+        let e: IpcError = panops_core::meeting_store::MeetingStoreError::Io(io).into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "meeting store io error");
+        assert!(!message.contains("/Users/fran"), "path leaked: {message}");
+    }
+
+    #[test]
+    fn meeting_store_sql_does_not_leak_query() {
+        let e: IpcError = panops_core::meeting_store::MeetingStoreError::Sql {
+            message: "near 'SELECT': syntax error at line 42".into(),
+        }
+        .into();
+        let IpcError::Internal { message } = e else {
+            panic!("expected Internal");
+        };
+        assert_eq!(message, "meeting store error");
+        assert!(!message.contains("SELECT"), "SQL leaked: {message}");
+        assert!(!message.contains("42"), "line leaked: {message}");
     }
 }

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -14,6 +14,8 @@ pub mod methods;
 
 pub use error::IpcError;
 pub use methods::{
-    Event, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig, MeetingSummary,
-    NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig,
+    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
+    RecordingProgressEvent, RecordingStartParams, RecordingStopParams, RecordingStopped,
+    ScreenshotEvent,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -180,11 +180,12 @@ pub struct MeetingConfig {
 // === Recording IPC types (slice 11) ===
 
 /// Audio source selection for `recording.start`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioSourcesWire {
     SystemOnly,
     MicOnly,
+    #[default]
     SystemAndMic,
 }
 
@@ -200,6 +201,9 @@ fn default_screenshot_threshold() -> f32 {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RecordingStartParams {
     pub meeting_id: String,
+    /// Audio sources to capture. Defaults to SystemAndMic.
+    #[serde(default)]
+    pub audio_sources: AudioSourcesWire,
     #[serde(default = "default_screenshot_interval")]
     pub screenshot_interval_ms: u64,
     #[serde(default = "default_screenshot_threshold")]
@@ -433,6 +437,7 @@ mod tests {
     fn recording_start_params_round_trips() {
         let p = RecordingStartParams {
             meeting_id: "m1".into(),
+            audio_sources: AudioSourcesWire::SystemAndMic,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
         };
@@ -446,6 +451,7 @@ mod tests {
         let json = r#"{"meeting_id":"m1"}"#;
         let p: RecordingStartParams = serde_json::from_str(json).unwrap();
         assert_eq!(p.meeting_id, "m1");
+        assert_eq!(p.audio_sources, AudioSourcesWire::SystemAndMic); // default
         assert_eq!(p.screenshot_interval_ms, 500); // default
         assert_eq!(p.screenshot_threshold, 0.15); // default
     }

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -7,9 +7,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Type-tagged so the same `events` subscription multiplexes job lifecycle.
-/// Future event kinds (`asr.partial`, `screenshot`, ...) extend this enum;
-/// clients running an older `panops-protocol` deserialise the new tag as
-/// `Event::Unknown(<original JSON>)` and keep the subscription alive.
+/// Future event kinds extend this enum; clients running an older
+/// `panops-protocol` deserialise the new tag as `Event::Unknown(<original
+/// JSON>)` and keep the subscription alive.
 ///
 /// The `Deserialize` impl is hand-written because serde's `#[serde(other)]`
 /// only accepts unit variants — it can't represent a tuple variant that
@@ -23,6 +23,12 @@ pub enum Event {
     JobDone(JobDoneEvent),
     #[serde(rename = "job.error")]
     JobError(JobErrorEvent),
+    /// Screenshot captured during recording (slice 11).
+    #[serde(rename = "screenshot")]
+    Screenshot(ScreenshotEvent),
+    /// Recording progress update (slice 11).
+    #[serde(rename = "recording.progress")]
+    RecordingProgress(RecordingProgressEvent),
     /// Forward-compat fallback: a future engine emits an event type this
     /// build doesn't know about. The original JSON object is kept so the
     /// caller can still inspect it (e.g. log + skip) without tearing down
@@ -45,6 +51,12 @@ impl<'de> Deserialize<'de> for Event {
             "job.error" => serde_json::from_value::<JobErrorEvent>(value)
                 .map(Event::JobError)
                 .map_err(serde::de::Error::custom),
+            "screenshot" => serde_json::from_value::<ScreenshotEvent>(value)
+                .map(Event::Screenshot)
+                .map_err(serde::de::Error::custom),
+            "recording.progress" => serde_json::from_value::<RecordingProgressEvent>(value)
+                .map(Event::RecordingProgress)
+                .map_err(serde::de::Error::custom),
             _ => Ok(Event::Unknown(value)),
         }
     }
@@ -60,6 +72,24 @@ pub struct JobDoneEvent {
 pub struct JobErrorEvent {
     pub job_id: String,
     pub error: crate::IpcError,
+}
+
+/// Screenshot captured during a recording session. Emitted via WebSocket
+/// each time the capture sidecar detects a screen change and writes a JPEG.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScreenshotEvent {
+    pub meeting_id: String,
+    pub timestamp_ms: u64,
+    pub path: String,
+}
+
+/// Recording progress update. Emitted periodically during active capture
+/// to inform clients of audio bytes captured and elapsed duration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordingProgressEvent {
+    pub meeting_id: String,
+    pub bytes_captured: u64,
+    pub duration_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -145,6 +175,55 @@ pub struct MeetingConfig {
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+}
+
+// === Recording IPC types (slice 11) ===
+
+/// Audio source selection for `recording.start`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioSourcesWire {
+    SystemOnly,
+    MicOnly,
+    SystemAndMic,
+}
+
+fn default_screenshot_interval() -> u64 {
+    500
+}
+
+fn default_screenshot_threshold() -> f32 {
+    0.15
+}
+
+/// Params for `ipc.recording.start`. Starts a live capture session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordingStartParams {
+    pub meeting_id: String,
+    #[serde(default = "default_screenshot_interval")]
+    pub screenshot_interval_ms: u64,
+    #[serde(default = "default_screenshot_threshold")]
+    pub screenshot_threshold: f32,
+}
+
+/// Result of `ipc.recording.start`. Confirms the recording session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordingAccepted {
+    pub recording_id: String,
+}
+
+/// Params for `ipc.recording.stop`. Stops the active recording.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordingStopParams {
+    pub recording_id: String,
+}
+
+/// Result of `ipc.recording.stop`. Returns paths to captured artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordingStopped {
+    pub audio_path: String,
+    pub screenshot_paths: Vec<String>,
+    pub duration_ms: u64,
 }
 
 #[cfg(test)]
@@ -346,5 +425,102 @@ mod tests {
         let back: MeetingSummary =
             serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
         assert_eq!(back, m);
+    }
+
+    // === Recording IPC type tests (slice 11) ===
+
+    #[test]
+    fn recording_start_params_round_trips() {
+        let p = RecordingStartParams {
+            meeting_id: "m1".into(),
+            screenshot_interval_ms: 500,
+            screenshot_threshold: 0.15,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: RecordingStartParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn recording_start_params_accepts_minimal() {
+        let json = r#"{"meeting_id":"m1"}"#;
+        let p: RecordingStartParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.meeting_id, "m1");
+        assert_eq!(p.screenshot_interval_ms, 500); // default
+        assert_eq!(p.screenshot_threshold, 0.15); // default
+    }
+
+    #[test]
+    fn recording_accepted_round_trips() {
+        let r = RecordingAccepted {
+            recording_id: "rec123".into(),
+        };
+        let back =
+            serde_json::from_str::<RecordingAccepted>(&serde_json::to_string(&r).unwrap()).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn recording_stop_params_round_trips() {
+        let p = RecordingStopParams {
+            recording_id: "rec123".into(),
+        };
+        let back = serde_json::from_str::<RecordingStopParams>(&serde_json::to_string(&p).unwrap())
+            .unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn recording_stopped_round_trips() {
+        let r = RecordingStopped {
+            audio_path: "/tmp/audio.wav".into(),
+            screenshot_paths: vec!["/tmp/screenshots/001.jpg".into()],
+            duration_ms: 60_000,
+        };
+        let back =
+            serde_json::from_str::<RecordingStopped>(&serde_json::to_string(&r).unwrap()).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn screenshot_event_round_trips_with_type_tag() {
+        let e = Event::Screenshot(ScreenshotEvent {
+            meeting_id: "m1".into(),
+            timestamp_ms: 12345,
+            path: "/tmp/screenshots/001.jpg".into(),
+        });
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains(r#""type":"screenshot""#));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn recording_progress_event_round_trips_with_type_tag() {
+        let e = Event::RecordingProgress(RecordingProgressEvent {
+            meeting_id: "m1".into(),
+            bytes_captured: 1024,
+            duration_ms: 5000,
+        });
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains(r#""type":"recording.progress""#));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn audio_sources_wire_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&AudioSourcesWire::SystemOnly).unwrap(),
+            r#""system_only""#
+        );
+        assert_eq!(
+            serde_json::to_string(&AudioSourcesWire::MicOnly).unwrap(),
+            r#""mic_only""#
+        );
+        assert_eq!(
+            serde_json::to_string(&AudioSourcesWire::SystemAndMic).unwrap(),
+            r#""system_and_mic""#
+        );
     }
 }

--- a/docs/proto/ipc.md
+++ b/docs/proto/ipc.md
@@ -1,4 +1,4 @@
-# panops IPC protocol — slices 05 + 06
+# panops IPC protocol — slices 05 + 06 + 11
 
 ## Transport
 
@@ -18,6 +18,8 @@
 | `ipc.meeting.get` | `{ id }` | `Meeting` | Full row including `dir_path`, `language`, `ended_at`. |
 | `ipc.meeting.set_language` | `{ id, language }` | `Meeting` | Updates BCP-47 language hint. |
 | `ipc.meeting.delete` | `{ id }` | `()` | Removes registry row (FK-cascades notes), then `rm -rf meetings/<id>/`. Orphan dir on FS-error is logged, not an error. |
+| `ipc.recording.start` | `RecordingStartParams` | `RecordingAccepted` | **Slice 11.** Starts live capture for a meeting. |
+| `ipc.recording.stop` | `{ recording_id }` | `RecordingStopped` | **Slice 11.** Stops capture, returns audio + screenshot paths. |
 
 The `ipc.` namespace + `.` separator are wired via jsonrpsee `#[rpc(server, namespace = "ipc", namespace_separator = ".")]`.
 
@@ -71,6 +73,30 @@ In-progress meetings render `ended_at: null` and `duration_ms: null` on `Meeting
 
 Both fields are optional; an empty `{}` is accepted and applies defaults.
 
+### `RecordingStartParams` (slice 11)
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `meeting_id` | string | required | Existing meeting to attach recording to. |
+| `audio_sources` | `"system_only"` \| `"mic_only"` \| `"system_and_mic"` | `"system_and_mic"` | Audio capture source selection. |
+| `screenshot_interval_ms` | u64 | `500` | Screenshot sampling interval. |
+| `screenshot_threshold` | f32 | `0.15` | Vision FeaturePrint change detection threshold. |
+
+### `RecordingAccepted` (slice 11)
+
+```json
+{ "recording_id": "..." }  // Currently equals meeting_id
+```
+
+### `RecordingStopped` (slice 11)
+
+```json
+{ "audio_path": "...",           // Absolute path to captured audio.wav
+  "screenshot_paths": ["..."],   // Absolute paths to captured JPEGs
+  "duration_ms": 60000           // Recording duration in ms
+}
+```
+
 Param structs intentionally do NOT use `#[serde(deny_unknown_fields)]` — same forward-compat philosophy as `IpcError::Unknown`. New optional fields are non-breaking.
 
 ## Subscriptions
@@ -86,6 +112,8 @@ The subscription is server-push backed by a `tokio::sync::broadcast` channel. A 
 ```json
 { "type": "job.done",  "job_id": "...", "result": { "primary_file": "...", "assets": [...], "meeting_id": "..." } }
 { "type": "job.error", "job_id": "...", "error": { "kind": "input_not_found" | "invalid_input" | "provider_unavailable" | "internal" | "cancelled", "message": "..." } }
+{ "type": "screenshot", "meeting_id": "...", "timestamp_ms": 12345, "path": "..." }  // Slice 11
+{ "type": "recording.progress", "meeting_id": "...", "bytes_captured": 1024, "duration_ms": 5000 }  // Slice 11
 ```
 
 The `Event` enum is internally tagged on `type`. Future event kinds (`asr.partial`, `asr.final`, `screenshot`, `job.progress`) extend this enum. Old clients deserialise unrecognised tags as `Event::Unknown(<original JSON>)`, preserving the subscription so one new tag does not tear down older clients. Implementations that do not use the Rust types directly should mirror this: any envelope whose `type` is not in the known set should be logged and skipped, never treated as a fatal protocol error.
@@ -125,10 +153,11 @@ At the JSON-RPC boundary, errors flowing back as `ErrorObjectOwned` use code `-3
 ## What's NOT shipped (still deferred)
 
 - IPC: `asr.post_pass` / `asr.cancel`, `notes.export`, `llm.probe` / `llm.providers` / `llm.test`, `settings.get` / `settings.set`.
-- Live-capture events: `asr.partial`, `asr.final`, `screenshot`, `job.progress`.
+- Live-capture events: `asr.partial`, `asr.final`, `job.progress` (screen capture writes directly to disk; no streaming events yet).
 - Token auth, WS reconnection, event replay buffer.
 - `CancellationToken` plumbed through `LlmRequest` (the `spawn_blocking` task is uncancellable today).
 - Push events for storage mutations (`meeting.created`, `meeting.deleted`).
+- Real ScreenCaptureKit capture adapter (slice 11 scaffolding: trait + fake + conformance land now; real capture gated on macOS sidecar).
 
 Each deferred item has a tracking issue under `type:debt area:ipc` (or `area:storage`) on the project board.
 


### PR DESCRIPTION
Slice 11 — Live capture (Anchor B), **Rust scaffolding**. Tracking: #137.

## What this ships
- **`Capture` port** (panops-core) + `CaptureError` (no `Serialize`; converts at the protocol boundary) + **`FakeCapture`** + a conformance suite that writes to a temp dir (never mutates `tests/fixtures/`).
- **`MeetingStore` port** (panops-core) for per-meeting `meeting.db` (segment/screenshot/speaker), with both a real **`RusqliteMeetingStore`** (panops-portable) and **`InMemoryMeetingStore`** fake + conformance — satisfies the one-trait + one-real + one-fake rule.
- **IPC**: `recording.start` / `recording.stop` methods (+ `RecordingStart/Stop` wire types with an `audio_sources` field) and `Screenshot` / `RecordingProgress` events (part of #80). `docs/proto/ipc.md` updated.
- **`capture_resolver`**: shared adapter instance with real start→stop session continuity; `FakeCapture` is gated to tests (`PANOPS_TEST_CAPTURE`); real use returns a clear "not implemented" error until the macOS sidecar lands. `recording.start` validates `dir_path` (`validate_meeting_dir`); IO/SQL error details are sanitized off the wire.
- Integration test for `recording.start`→`recording.stop`.

## Deferred (follow-up PR)
The real macOS **ScreenCaptureKit + AVFoundation capture sidecar** (`apps/panops-capture-mac`) and live audio/screenshot capture — needs a macOS spike + manual smoke. This PR lands the port + fake + conformance + IPC wiring only.

## Verification
`cargo fmt --all && cargo build --workspace --locked && cargo test --workspace --locked && cargo clippy --workspace --all-targets --locked -- -D warnings` green; `panops-mac` is `cfg(target_os="macos")`. Copilot + ai-review findings (session continuity, audio_sources, duration underflow, fixture mutation, path validation, wire-error leaks, missing real adapter, test gaps) all addressed.