### PR TITLE
Slice 13: notes quality — humanize speaker labels + NotionEnhanced dialect test

### DIFF
--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -54,7 +54,7 @@ impl NotesExporter for MarkdownExporter {
 fn humanize_speaker_id(raw: &str) -> String {
     if let Some(num) = raw.strip_prefix("speaker_") {
         if let Ok(id) = num.parse::<u32>() {
-            return format!("Speaker {}", id + 1);
+            return format!("Speaker {}", id.saturating_add(1));
         }
     }
     raw.to_string()
@@ -63,32 +63,34 @@ fn humanize_speaker_id(raw: &str) -> String {
 /// Replace all `speaker_N` patterns in text with `Speaker N+1`.
 /// Used for narrative content where speaker references may appear.
 fn humanize_speakers_in_text(text: &str) -> String {
-    // Replace all `speaker_N` patterns. The pattern appears in markdown as:
-    // - `speaker_0` in prose
-    // - `**speaker_0:**` in fallback transcript dumps
-    // Use a simple regex-like replacement since we control the format.
-    let mut result = text.to_string();
-    // Find and replace each speaker_N pattern
-    let mut i = 0;
-    while i < result.len() {
-        if result[i..].starts_with("speaker_") {
-            // Find the end of the number
-            let num_start = i + 8;
-            let num_end = result[num_start..]
-                .find(|c: char| !c.is_ascii_digit())
-                .map(|pos| num_start + pos)
-                .unwrap_or(result.len());
-            if num_start < num_end {
-                if let Ok(id) = result[num_start..num_end].parse::<u32>() {
-                    let replacement = format!("Speaker {}", id + 1);
-                    result.replace_range(i..num_end, &replacement);
-                    i += replacement.len();
-                    continue;
-                }
+    // Replace each `speaker_N` with `Speaker N+1`. `match_indices` on the
+    // ASCII pattern yields only valid UTF-8 char boundaries, so this stays
+    // safe on multi-byte text (e.g. accented Spanish) — the old
+    // byte-increment scan panicked when it sliced mid-character.
+    let mut result = String::with_capacity(text.len());
+    let mut last = 0;
+    for (start, _) in text.match_indices("speaker_") {
+        if start < last {
+            continue; // inside a region already consumed
+        }
+        result.push_str(&text[last..start]);
+        let num_start = start + "speaker_".len();
+        let digits_len = text[num_start..]
+            .bytes()
+            .take_while(u8::is_ascii_digit)
+            .count();
+        if digits_len > 0 {
+            if let Ok(id) = text[num_start..num_start + digits_len].parse::<u32>() {
+                result.push_str(&format!("Speaker {}", id.saturating_add(1)));
+                last = num_start + digits_len;
+                continue;
             }
         }
-        i += 1;
+        // Not a valid `speaker_N`: keep the literal prefix and continue past it.
+        result.push_str("speaker_");
+        last = num_start;
     }
+    result.push_str(&text[last..]);
     result
 }
 

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -49,6 +49,49 @@ impl NotesExporter for MarkdownExporter {
     }
 }
 
+/// Humanize a raw speaker ID string (`speaker_N`) to `Speaker N+1`.
+/// Returns the original string if it doesn't match the `speaker_N` pattern.
+fn humanize_speaker_id(raw: &str) -> String {
+    if let Some(num) = raw.strip_prefix("speaker_") {
+        if let Ok(id) = num.parse::<u32>() {
+            return format!("Speaker {}", id + 1);
+        }
+    }
+    raw.to_string()
+}
+
+/// Replace all `speaker_N` patterns in text with `Speaker N+1`.
+/// Used for narrative content where speaker references may appear.
+fn humanize_speakers_in_text(text: &str) -> String {
+    // Replace all `speaker_N` patterns. The pattern appears in markdown as:
+    // - `speaker_0` in prose
+    // - `**speaker_0:**` in fallback transcript dumps
+    // Use a simple regex-like replacement since we control the format.
+    let mut result = text.to_string();
+    // Find and replace each speaker_N pattern
+    let mut i = 0;
+    while i < result.len() {
+        if result[i..].starts_with("speaker_") {
+            // Find the end of the number
+            let num_start = i + 8;
+            let num_end = result[num_start..]
+                .find(|c: char| !c.is_ascii_digit())
+                .map(|pos| num_start + pos)
+                .unwrap_or(result.len());
+            if num_start < num_end {
+                if let Ok(id) = result[num_start..num_end].parse::<u32>() {
+                    let replacement = format!("Speaker {}", id + 1);
+                    result.replace_range(i..num_end, &replacement);
+                    i += replacement.len();
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    result
+}
+
 fn render_frontmatter(notes: &StructuredNotes) -> String {
     let fm = &notes.frontmatter;
     let mut s = String::from("---\n");
@@ -65,7 +108,8 @@ fn render_frontmatter(notes: &StructuredNotes) -> String {
     } else {
         s.push_str("speakers:\n");
         for sp in &fm.speakers {
-            s.push_str(&format!("  - {}\n", yaml_scalar(sp)));
+            // Humanize speaker IDs at render boundary: speaker_0 → Speaker 1
+            s.push_str(&format!("  - {}\n", yaml_scalar(&humanize_speaker_id(sp))));
         }
     }
     if fm.tags.is_empty() {
@@ -105,20 +149,30 @@ fn render_section(
         format_mmss(sec.time_range_ms.0),
         format_mmss(sec.time_range_ms.1)
     ));
-    s.push_str(sec.narrative_md.trim());
+    // Humanize any speaker_N references in narrative (e.g., fallback transcript dumps)
+    s.push_str(&humanize_speakers_in_text(sec.narrative_md.trim()));
     s.push_str("\n\n");
     if !sec.key_points.is_empty() {
         s.push_str("**Key points:**\n");
         for kp in &sec.key_points {
-            s.push_str(&format!("- {kp}\n"));
+            // Key points shouldn't normally have speaker refs, but humanize if present
+            s.push_str(&format!("- {}\n", humanize_speakers_in_text(kp)));
         }
         s.push('\n');
     }
     if !sec.action_items.is_empty() {
         s.push_str("**Action items:**\n");
         for a in &sec.action_items {
-            let owner = a.owner.as_deref().unwrap_or("owner TBD");
-            s.push_str(&format!("- {} (owner: {owner})\n", a.description));
+            // Humanize owner if it's a speaker_N reference, otherwise use verbatim
+            let owner = a
+                .owner
+                .as_ref()
+                .map(|o| humanize_speaker_id(o))
+                .unwrap_or_else(|| "owner TBD".to_string());
+            s.push_str(&format!(
+                "- {} (owner: {owner})\n",
+                humanize_speakers_in_text(&a.description)
+            ));
         }
         s.push('\n');
     }
@@ -227,7 +281,7 @@ fn yaml_list(items: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::yaml_scalar;
+    use super::{humanize_speaker_id, humanize_speakers_in_text, yaml_scalar};
 
     #[test]
     fn plain_string_is_unquoted() {
@@ -269,5 +323,46 @@ mod tests {
     fn leading_special_char_triggers_double_quoting() {
         assert_eq!(yaml_scalar(":starts-with-colon"), "\":starts-with-colon\"");
         assert_eq!(yaml_scalar("-starts-with-dash"), "\"-starts-with-dash\"");
+    }
+
+    #[test]
+    fn humanize_speaker_id_converts_zero_to_one() {
+        assert_eq!(humanize_speaker_id("speaker_0"), "Speaker 1");
+    }
+
+    #[test]
+    fn humanize_speaker_id_converts_one_to_two() {
+        assert_eq!(humanize_speaker_id("speaker_1"), "Speaker 2");
+    }
+
+    #[test]
+    fn humanize_speaker_id_returns_original_for_non_matching() {
+        assert_eq!(humanize_speaker_id("Alice"), "Alice");
+        assert_eq!(humanize_speaker_id("speaker"), "speaker");
+        assert_eq!(humanize_speaker_id("speaker_"), "speaker_");
+    }
+
+    #[test]
+    fn humanize_speakers_in_text_replaces_multiple_refs() {
+        assert_eq!(
+            humanize_speakers_in_text("speaker_0 said to speaker_1"),
+            "Speaker 1 said to Speaker 2"
+        );
+    }
+
+    #[test]
+    fn humanize_speakers_in_text_handles_markdown_format() {
+        assert_eq!(
+            humanize_speakers_in_text("**speaker_0:** hello"),
+            "**Speaker 1:** hello"
+        );
+    }
+
+    #[test]
+    fn humanize_speakers_in_text_preserves_surrounding_text() {
+        assert_eq!(
+            humanize_speakers_in_text("The discussion between speaker_0 and speaker_2 continued"),
+            "The discussion between Speaker 1 and Speaker 3 continued"
+        );
     }
 }

--- a/crates/panops-portable/tests/conformance_markdown_exporter.rs
+++ b/crates/panops-portable/tests/conformance_markdown_exporter.rs
@@ -321,3 +321,73 @@ fn regenerate_multi_speaker_60s_goldens() {
         .unwrap();
     }
 }
+
+#[test]
+fn speaker_labels_are_humanized_in_frontmatter() {
+    let dir = tempfile::tempdir().unwrap();
+    let exporter = MarkdownExporter;
+    let notes = sample(MarkdownDialect::Basic);
+    let art = exporter.export(&notes, dir.path()).unwrap();
+    let body = fs::read_to_string(&art.primary_file).unwrap();
+    // speaker_0 should be rendered as "Speaker 1"
+    assert!(
+        body.contains("speakers:\n  - Speaker 1"),
+        "expected humanized 'Speaker 1' in frontmatter; got:\n{body}"
+    );
+    // Raw speaker_N must NOT appear in output
+    assert!(
+        !body.contains("speaker_0"),
+        "raw 'speaker_0' must not appear in rendered output; got:\n{body}"
+    );
+}
+
+#[test]
+fn speaker_labels_in_fallback_narrative_are_humanized() {
+    // Simulate a fallback narrative with raw speaker refs (as happens when LLM fails)
+    let dir = tempfile::tempdir().unwrap();
+    let exporter = MarkdownExporter;
+    let mut notes = sample(MarkdownDialect::Basic);
+    notes.frontmatter.speakers = vec!["speaker_0".into(), "speaker_1".into()];
+    // Simulate fallback narrative format
+    notes.sections[0].narrative_md = "**speaker_0:** hello\n\n**speaker_1:** hi".into();
+    let art = exporter.export(&notes, dir.path()).unwrap();
+    let body = fs::read_to_string(&art.primary_file).unwrap();
+    // Both speakers should be humanized
+    assert!(
+        body.contains("**Speaker 1:** hello"),
+        "expected humanized 'Speaker 1' in fallback narrative; got:\n{body}"
+    );
+    assert!(
+        body.contains("**Speaker 2:** hi"),
+        "expected humanized 'Speaker 2' in fallback narrative; got:\n{body}"
+    );
+    // No raw refs should leak
+    assert!(
+        !body.contains("speaker_0") && !body.contains("speaker_1"),
+        "raw speaker_N must not leak; got:\n{body}"
+    );
+}
+
+#[test]
+fn action_item_owner_is_humanized() {
+    let dir = tempfile::tempdir().unwrap();
+    let exporter = MarkdownExporter;
+    let mut notes = sample(MarkdownDialect::Basic);
+    notes.frontmatter.speakers = vec!["speaker_0".into()];
+    notes.sections[0].action_items = vec![ActionItem {
+        description: "do thing".into(),
+        owner: Some("speaker_0".into()),
+        due: None,
+    }];
+    let art = exporter.export(&notes, dir.path()).unwrap();
+    let body = fs::read_to_string(&art.primary_file).unwrap();
+    // owner: speaker_0 should render as "Speaker 1"
+    assert!(
+        body.contains("(owner: Speaker 1)"),
+        "expected humanized 'Speaker 1' as owner; got:\n{body}"
+    );
+    assert!(
+        !body.contains("speaker_0"),
+        "raw 'speaker_0' must not appear; got:\n{body}"
+    );
+}

--- a/crates/panops-portable/tests/conformance_markdown_exporter.rs
+++ b/crates/panops-portable/tests/conformance_markdown_exporter.rs
@@ -391,3 +391,145 @@ fn action_item_owner_is_humanized() {
         "raw 'speaker_0' must not appear; got:\n{body}"
     );
 }
+
+/// FIX 2 (#45) — Verify NotionEnhanced dialect produces its expected structure.
+/// The exporter controls screenshot rendering: NotionEnhanced uses <table>,
+/// Basic uses plain image lines. Test asserts the distinguishing features.
+#[test]
+fn notion_enhanced_screenshots_use_table_layout() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let img1 = src_dir.path().join("shot1.png");
+    let img2 = src_dir.path().join("shot2.png");
+    fs::write(&img1, b"fake-png-1").unwrap();
+    fs::write(&img2, b"fake-png-2").unwrap();
+
+    let mut notes = sample(MarkdownDialect::NotionEnhanced);
+    notes.sections[0].screenshots = vec![
+        Screenshot {
+            ms_since_start: 10_000,
+            path: img1.clone(),
+            caption: Some("First shot".into()),
+        },
+        Screenshot {
+            ms_since_start: 20_000,
+            path: img2.clone(),
+            caption: Some("Second shot".into()),
+        },
+    ];
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    let exporter = MarkdownExporter;
+    exporter.export(&notes, dest_dir.path()).unwrap();
+    let body = fs::read_to_string(dest_dir.path().join("notes.md")).unwrap();
+
+    // NotionEnhanced-specific markers for screenshots
+    assert!(
+        body.contains("<table>"),
+        "NotionEnhanced must wrap screenshots in <table>; got:\n{body}"
+    );
+    assert!(
+        body.contains("<tr>"),
+        "NotionEnhanced screenshots must use <tr>; got:\n{body}"
+    );
+    assert!(
+        body.contains("<td>"),
+        "NotionEnhanced screenshots must use <td>; got:\n{body}"
+    );
+    assert!(
+        body.contains("</table>"),
+        "NotionEnhanced must close <table>; got:\n{body}"
+    );
+    // Dialect header must match
+    assert!(
+        body.contains("dialect: notion-enhanced"),
+        "frontmatter must declare notion-enhanced dialect; got:\n{body}"
+    );
+}
+
+#[test]
+fn basic_screenshots_use_plain_images_not_table() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let img1 = src_dir.path().join("shot1.png");
+    fs::write(&img1, b"fake-png").unwrap();
+
+    let mut notes = sample(MarkdownDialect::Basic);
+    notes.sections[0].screenshots = vec![Screenshot {
+        ms_since_start: 10_000,
+        path: img1.clone(),
+        caption: Some("Caption text".into()),
+    }];
+
+    let dest_dir = tempfile::tempdir().unwrap();
+    let exporter = MarkdownExporter;
+    exporter.export(&notes, dest_dir.path()).unwrap();
+    let body = fs::read_to_string(dest_dir.path().join("notes.md")).unwrap();
+
+    // Basic must NOT use table markup
+    assert!(
+        !body.contains("<table>"),
+        "Basic dialect must NOT use <table>; got:\n{body}"
+    );
+    assert!(
+        !body.contains("<tr>"),
+        "Basic dialect must NOT use <tr>; got:\n{body}"
+    );
+    assert!(
+        !body.contains("<td>"),
+        "Basic dialect must NOT use <td>; got:\n{body}"
+    );
+    // Basic uses plain image syntax with relative path
+    assert!(
+        body.contains("![Caption text](screenshots/"),
+        "Basic must use plain image syntax; got:\n{body}"
+    );
+    // Dialect header must match
+    assert!(
+        body.contains("dialect: basic"),
+        "frontmatter must declare basic dialect; got:\n{body}"
+    );
+}
+
+#[test]
+fn dialects_render_screenshots_differently() {
+    // Comprehensive test: same notes content, different dialects, different screenshot markup
+    let src_dir = tempfile::tempdir().unwrap();
+    let img = src_dir.path().join("frame.png");
+    fs::write(&img, b"png-data").unwrap();
+
+    let mut notes_notion = sample(MarkdownDialect::NotionEnhanced);
+    notes_notion.sections[0].screenshots = vec![Screenshot {
+        ms_since_start: 5_000,
+        path: img.clone(),
+        caption: None,
+    }];
+
+    let mut notes_basic = sample(MarkdownDialect::Basic);
+    notes_basic.sections[0].screenshots = vec![Screenshot {
+        ms_since_start: 5_000,
+        path: img.clone(),
+        caption: None,
+    }];
+
+    let dir_notion = tempfile::tempdir().unwrap();
+    let dir_basic = tempfile::tempdir().unwrap();
+    MarkdownExporter
+        .export(&notes_notion, dir_notion.path())
+        .unwrap();
+    MarkdownExporter
+        .export(&notes_basic, dir_basic.path())
+        .unwrap();
+
+    let notion_body = fs::read_to_string(dir_notion.path().join("notes.md")).unwrap();
+    let basic_body = fs::read_to_string(dir_basic.path().join("notes.md")).unwrap();
+
+    // Structural difference is the table
+    assert!(
+        notion_body.contains("<table>"),
+        "NotionEnhanced: missing <table>"
+    );
+    assert!(!basic_body.contains("<table>"), "Basic: unexpected <table>");
+    assert_ne!(
+        notion_body, basic_body,
+        "dialects must produce different output"
+    );
+}

--- a/tests/fixtures/notes/multi_speaker_60s.expected.basic.md
+++ b/tests/fixtures/notes/multi_speaker_60s.expected.basic.md
@@ -5,8 +5,8 @@ started_at: 2026-05-01T10:00:00+00:00
 duration_ms: 60000
 languages: [en]
 speakers:
-  - speaker_0
-  - speaker_1
+  - Speaker 1
+  - Speaker 2
 tags:
   - budget-review
   - quarterly

--- a/tests/fixtures/notes/multi_speaker_60s.expected.notion.md
+++ b/tests/fixtures/notes/multi_speaker_60s.expected.notion.md
@@ -5,8 +5,8 @@ started_at: 2026-05-01T10:00:00+00:00
 duration_ms: 60000
 languages: [en]
 speakers:
-  - speaker_0
-  - speaker_1
+  - Speaker 1
+  - Speaker 2
 tags:
   - budget-review
   - quarterly


### PR DESCRIPTION
Small notes-quality pass (panops-portable only). Closes #21, #45.

- **#21**: humanize diarization IDs at the render boundary — `speaker_0`→`Speaker 1` in transcript/notes body and the frontmatter `speakers:` list; raw IDs kept internally. Test asserts no raw `speaker_N` leaks into rendered output. (Expected-output fixtures updated to match.)
- **#45**: NotionEnhanced dialect adherence tests — assert the dialect's table-layout screenshot markup vs Basic's plain `![]()`, and that the two dialects render differently.

No engine / Mac-app / capture changes. Verifying via cargo gate.