### PR TITLE
Slice 14: long-meeting context — chunk over-threshold note sections

### DIFF
--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -17,7 +17,7 @@ use chrono::Utc;
 use rayon::prelude::*;
 
 use crate::Segment;
-use crate::llm::{LlmProvider, LlmResponse};
+use crate::llm::{LlmProvider, LlmRequest, LlmResponse};
 use crate::notes::dialect::MarkdownDialect;
 use crate::notes::error::NotesError;
 use crate::notes::input::NotesInput;
@@ -268,36 +268,31 @@ impl NotesGenerator<'_> {
 
             while index < summaries.len() {
                 let mut batch = Vec::new();
-                let mut batch_estimate = 0usize;
 
                 while index < summaries.len() {
                     let next = summaries[index].clone();
-                    let next_estimate = estimate_chunk_summary_chars(&next);
 
                     if !batch.is_empty() {
-                        let candidate_estimate = batch_estimate.saturating_add(next_estimate);
-                        if candidate_estimate > SECTION_CHUNK_THRESHOLD_CHARS {
-                            break;
-                        }
-
                         let mut candidate_batch = batch.clone();
                         candidate_batch.push(next.clone());
                         let candidate_req =
                             build_merge_section_prompt(&candidate_batch, self.dialect, language);
-                        if candidate_req.user.len() > SECTION_CHUNK_THRESHOLD_CHARS {
+                        if rendered_llm_request_chars(&candidate_req)
+                            > SECTION_CHUNK_THRESHOLD_CHARS
+                        {
                             break;
                         }
                     }
 
                     batch.push(next);
-                    batch_estimate = batch_estimate.saturating_add(next_estimate);
                     index += 1;
                 }
 
                 let merge_req = build_merge_section_prompt(&batch, self.dialect, language);
-                if merge_req.user.len() > SECTION_CHUNK_THRESHOLD_CHARS {
+                let merge_req_chars = rendered_llm_request_chars(&merge_req);
+                if merge_req_chars > SECTION_CHUNK_THRESHOLD_CHARS {
                     tracing::warn!(
-                        input_chars = merge_req.user.len(),
+                        input_chars = merge_req_chars,
                         threshold = SECTION_CHUNK_THRESHOLD_CHARS,
                         "single chunk summary exceeds merge context threshold"
                     );
@@ -370,6 +365,15 @@ impl NotesGenerator<'_> {
             Err(e) => SectionDraft::fallback(time_range_ms, segs, &e.to_string(), self.dialect),
         }
     }
+}
+
+fn rendered_llm_request_chars(req: &LlmRequest) -> usize {
+    req.system.as_deref().map_or(0, str::len)
+        + req.user.len()
+        + req
+            .schema
+            .as_ref()
+            .map_or(0, |schema| schema.to_string().len())
 }
 
 struct SectionDraft {

--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -23,7 +23,9 @@ use crate::notes::error::NotesError;
 use crate::notes::input::NotesInput;
 use crate::notes::ir::{ActionItem, NotesFrontmatter, NotesSection, Screenshot, StructuredNotes};
 use crate::notes::prompts::{
-    SectionSummary, build_frontmatter_prompt, build_section_narrative_prompt,
+    SECTION_CHUNK_TARGET_CHARS, SECTION_CHUNK_THRESHOLD_CHARS, SectionSummary,
+    build_frontmatter_prompt, build_merge_section_prompt, build_section_narrative_prompt,
+    estimate_transcript_chars, split_segments_for_chunking,
 };
 use crate::notes::screenshot_anchoring::anchor_screenshots;
 use crate::notes::topic_segmentation::{TopicSegmentationConfig, segment_topics};
@@ -66,47 +68,7 @@ impl NotesGenerator<'_> {
                     .iter()
                     .map(|i| input.transcript[*i].clone())
                     .collect();
-                let req = build_section_narrative_prompt(&segs, self.dialect, &language);
-                match self.llm.complete(req) {
-                    Ok(LlmResponse::Json(v)) => {
-                        let draft = SectionDraft::from_json(raw.time_range_ms, segs.clone(), v);
-                        // Verifier gate: if the LLM attributed speech to an
-                        // ID not present in the transcript, drop the draft
-                        // and fall back to a deterministic transcript dump.
-                        match verifier::verify_section_attribution(
-                            &draft.narrative_md,
-                            &draft.action_items,
-                            &allowed_speakers,
-                        ) {
-                            verifier::VerifierReport::Ok => draft,
-                            verifier::VerifierReport::DisallowedSpeakers(ids) => {
-                                tracing::warn!(
-                                    section_ms = ?raw.time_range_ms,
-                                    disallowed = ?ids,
-                                    "section narrative referenced speakers not in transcript; using fallback"
-                                );
-                                SectionDraft::fallback(
-                                    raw.time_range_ms,
-                                    segs,
-                                    "verifier: disallowed speaker reference",
-                                    self.dialect,
-                                )
-                            }
-                        }
-                    }
-                    Ok(LlmResponse::Text(_)) => SectionDraft::fallback(
-                        raw.time_range_ms,
-                        segs,
-                        "llm returned text, expected json",
-                        self.dialect,
-                    ),
-                    Err(e) => SectionDraft::fallback(
-                        raw.time_range_ms,
-                        segs,
-                        &e.to_string(),
-                        self.dialect,
-                    ),
-                }
+                self.process_section(raw.time_range_ms, segs, &language, &allowed_speakers)
             })
             .collect();
 
@@ -197,6 +159,146 @@ impl NotesGenerator<'_> {
             language,
             generated_at: Utc::now(),
         })
+    }
+
+    /// Process a single section: either single LLM call (if transcript fits)
+    /// or chunked multi-call with merge (if transcript exceeds threshold).
+    fn process_section(
+        &self,
+        time_range_ms: (u64, u64),
+        segs: Vec<Segment>,
+        language: &str,
+        allowed_speakers: &HashSet<u32>,
+    ) -> SectionDraft {
+        let transcript_chars = estimate_transcript_chars(&segs);
+
+        if transcript_chars <= SECTION_CHUNK_THRESHOLD_CHARS {
+            // Normal case: single LLM call
+            self.process_single_section(time_range_ms, segs, language, allowed_speakers)
+        } else {
+            // Long section: chunk, summarize each, merge
+            tracing::info!(
+                time_range = ?time_range_ms,
+                chars = transcript_chars,
+                threshold = SECTION_CHUNK_THRESHOLD_CHARS,
+                "section exceeds chunk threshold; splitting"
+            );
+            // Split to the lower target size, not the trigger threshold, so
+            // fixed prompt instructions still fit comfortably in the same
+            // approximate context budget. Single segments may exceed this
+            // because we never split mid-segment.
+            let chunks = split_segments_for_chunking(
+                &segs,
+                SECTION_CHUNK_TARGET_CHARS,
+                SECTION_CHUNK_TARGET_CHARS,
+            );
+            let mut chunk_summaries = Vec::with_capacity(chunks.len());
+            for (i, chunk) in chunks.iter().enumerate() {
+                let req = build_section_narrative_prompt(chunk, self.dialect, language);
+                match self.llm.complete(req) {
+                    Ok(LlmResponse::Json(v)) => chunk_summaries.push(v),
+                    Ok(LlmResponse::Text(_)) => {
+                        return SectionDraft::fallback(
+                            time_range_ms,
+                            segs,
+                            &format!("chunk {} LLM returned text, expected json", i + 1),
+                            self.dialect,
+                        );
+                    }
+                    Err(e) => {
+                        return SectionDraft::fallback(
+                            time_range_ms,
+                            segs,
+                            &format!("chunk {} LLM call failed: {e}", i + 1),
+                            self.dialect,
+                        );
+                    }
+                }
+            }
+
+            // Merge chunk summaries into final section
+            let merge_req = build_merge_section_prompt(&chunk_summaries, self.dialect, language);
+            match self.llm.complete(merge_req) {
+                Ok(LlmResponse::Json(v)) => {
+                    let draft = SectionDraft::from_json(time_range_ms, segs.clone(), v);
+                    match verifier::verify_section_attribution(
+                        &draft.narrative_md,
+                        &draft.action_items,
+                        allowed_speakers,
+                    ) {
+                        verifier::VerifierReport::Ok => draft,
+                        verifier::VerifierReport::DisallowedSpeakers(ids) => {
+                            tracing::warn!(
+                                section_ms = ?time_range_ms,
+                                disallowed = ?ids,
+                                "merged section referenced speakers not in transcript; using fallback"
+                            );
+                            SectionDraft::fallback(
+                                time_range_ms,
+                                segs,
+                                "verifier: disallowed speaker reference",
+                                self.dialect,
+                            )
+                        }
+                    }
+                }
+                Ok(LlmResponse::Text(_)) => SectionDraft::fallback(
+                    time_range_ms,
+                    segs,
+                    "merge LLM returned text, expected json",
+                    self.dialect,
+                ),
+                Err(e) => SectionDraft::fallback(
+                    time_range_ms,
+                    segs,
+                    &format!("merge LLM call failed: {e}"),
+                    self.dialect,
+                ),
+            }
+        }
+    }
+
+    /// Single-section LLM call (original path, unchanged).
+    fn process_single_section(
+        &self,
+        time_range_ms: (u64, u64),
+        segs: Vec<Segment>,
+        language: &str,
+        allowed_speakers: &HashSet<u32>,
+    ) -> SectionDraft {
+        let req = build_section_narrative_prompt(&segs, self.dialect, language);
+        match self.llm.complete(req) {
+            Ok(LlmResponse::Json(v)) => {
+                let draft = SectionDraft::from_json(time_range_ms, segs.clone(), v);
+                match verifier::verify_section_attribution(
+                    &draft.narrative_md,
+                    &draft.action_items,
+                    allowed_speakers,
+                ) {
+                    verifier::VerifierReport::Ok => draft,
+                    verifier::VerifierReport::DisallowedSpeakers(ids) => {
+                        tracing::warn!(
+                            section_ms = ?time_range_ms,
+                            disallowed = ?ids,
+                            "section narrative referenced speakers not in transcript; using fallback"
+                        );
+                        SectionDraft::fallback(
+                            time_range_ms,
+                            segs,
+                            "verifier: disallowed speaker reference",
+                            self.dialect,
+                        )
+                    }
+                }
+            }
+            Ok(LlmResponse::Text(_)) => SectionDraft::fallback(
+                time_range_ms,
+                segs,
+                "llm returned text, expected json",
+                self.dialect,
+            ),
+            Err(e) => SectionDraft::fallback(time_range_ms, segs, &e.to_string(), self.dialect),
+        }
     }
 }
 

--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -222,7 +222,7 @@ impl NotesGenerator<'_> {
             // over-context prompt.
             match self.merge_chunk_summaries(chunk_summaries, language) {
                 Ok(v) => {
-                    let draft = SectionDraft::from_json(time_range_ms, segs.clone(), v);
+                    let draft = SectionDraft::from_json(time_range_ms, v);
                     match verifier::verify_section_attribution(
                         &draft.narrative_md,
                         &draft.action_items,
@@ -339,7 +339,7 @@ impl NotesGenerator<'_> {
         let req = build_section_narrative_prompt(&segs, self.dialect, language);
         match self.llm.complete(req) {
             Ok(LlmResponse::Json(v)) => {
-                let draft = SectionDraft::from_json(time_range_ms, segs.clone(), v);
+                let draft = SectionDraft::from_json(time_range_ms, v);
                 match verifier::verify_section_attribution(
                     &draft.narrative_md,
                     &draft.action_items,
@@ -381,7 +381,7 @@ struct SectionDraft {
 }
 
 impl SectionDraft {
-    fn from_json(time_range_ms: (u64, u64), _segs: Vec<Segment>, v: serde_json::Value) -> Self {
+    fn from_json(time_range_ms: (u64, u64), v: serde_json::Value) -> Self {
         let title = v
             .get("title")
             .and_then(|s| s.as_str())

--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -172,26 +172,34 @@ impl NotesGenerator<'_> {
         allowed_speakers: &HashSet<u32>,
     ) -> SectionDraft {
         let transcript_chars = estimate_transcript_chars(&segs);
+        let single_req = build_section_narrative_prompt(&segs, self.dialect, language);
+        let single_req_chars = rendered_llm_request_chars(&single_req);
 
-        if transcript_chars <= SECTION_CHUNK_THRESHOLD_CHARS {
+        if single_req_chars <= SECTION_CHUNK_THRESHOLD_CHARS {
             // Normal case: single LLM call
-            self.process_single_section(time_range_ms, segs, language, allowed_speakers)
+            self.process_single_section(time_range_ms, segs, single_req, allowed_speakers)
         } else {
             // Long section: chunk, summarize each, merge
             tracing::info!(
                 time_range = ?time_range_ms,
-                chars = transcript_chars,
+                transcript_chars,
+                rendered_chars = single_req_chars,
                 threshold = SECTION_CHUNK_THRESHOLD_CHARS,
                 "section exceeds chunk threshold; splitting"
             );
-            // Split to the lower target size, not the trigger threshold, so
-            // fixed prompt instructions still fit comfortably in the same
-            // approximate context budget. Single segments may exceed this
-            // because we never split mid-segment.
-            let chunks = split_segments_for_chunking(
+            // Split toward the lower soft target, while keeping the threshold
+            // as the hard transcript ceiling. Rendered prompt overhead is
+            // checked below because system/schema/dialect text also count.
+            let initial_chunks = split_segments_for_chunking(
                 &segs,
                 SECTION_CHUNK_TARGET_CHARS,
-                SECTION_CHUNK_TARGET_CHARS,
+                SECTION_CHUNK_THRESHOLD_CHARS,
+            );
+            let chunks = split_chunks_to_rendered_budget(
+                initial_chunks,
+                self.dialect,
+                language,
+                SECTION_CHUNK_THRESHOLD_CHARS,
             );
             let mut chunk_summaries = Vec::with_capacity(chunks.len());
             for (i, chunk) in chunks.iter().enumerate() {
@@ -199,18 +207,27 @@ impl NotesGenerator<'_> {
                 match self.llm.complete(req) {
                     Ok(LlmResponse::Json(v)) => chunk_summaries.push(v),
                     Ok(LlmResponse::Text(_)) => {
+                        tracing::warn!(
+                            chunk_index = i + 1,
+                            "chunk summary LLM returned text, expected json"
+                        );
                         return SectionDraft::fallback(
                             time_range_ms,
                             segs,
-                            &format!("chunk {} LLM returned text, expected json", i + 1),
+                            "LLM unavailable",
                             self.dialect,
                         );
                     }
                     Err(e) => {
+                        tracing::warn!(
+                            chunk_index = i + 1,
+                            error = %e,
+                            "chunk summary LLM call failed"
+                        );
                         return SectionDraft::fallback(
                             time_range_ms,
                             segs,
-                            &format!("chunk {} LLM call failed: {e}", i + 1),
+                            "LLM unavailable",
                             self.dialect,
                         );
                     }
@@ -257,6 +274,9 @@ impl NotesGenerator<'_> {
         if summaries.is_empty() {
             return Err("merge LLM call failed: no chunk summaries".to_string());
         }
+        if summaries.len() == 1 {
+            return Ok(summaries.remove(0));
+        }
 
         while summaries.len() > 1 {
             let before_estimate = summaries
@@ -288,6 +308,11 @@ impl NotesGenerator<'_> {
                     index += 1;
                 }
 
+                if batch.len() == 1 {
+                    next_round.push(batch.remove(0));
+                    continue;
+                }
+
                 let merge_req = build_merge_section_prompt(&batch, self.dialect, language);
                 let merge_req_chars = rendered_llm_request_chars(&merge_req);
                 if merge_req_chars > SECTION_CHUNK_THRESHOLD_CHARS {
@@ -301,9 +326,13 @@ impl NotesGenerator<'_> {
                 match self.llm.complete(merge_req) {
                     Ok(LlmResponse::Json(v)) => next_round.push(v),
                     Ok(LlmResponse::Text(_)) => {
-                        return Err("merge LLM returned text, expected json".to_string());
+                        tracing::warn!("merge LLM returned text, expected json");
+                        return Err("LLM unavailable".to_string());
                     }
-                    Err(e) => return Err(format!("merge LLM call failed: {e}")),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "merge LLM call failed");
+                        return Err("LLM unavailable".to_string());
+                    }
                 }
             }
 
@@ -328,10 +357,9 @@ impl NotesGenerator<'_> {
         &self,
         time_range_ms: (u64, u64),
         segs: Vec<Segment>,
-        language: &str,
+        req: LlmRequest,
         allowed_speakers: &HashSet<u32>,
     ) -> SectionDraft {
-        let req = build_section_narrative_prompt(&segs, self.dialect, language);
         match self.llm.complete(req) {
             Ok(LlmResponse::Json(v)) => {
                 let draft = SectionDraft::from_json(time_range_ms, v);
@@ -367,7 +395,50 @@ impl NotesGenerator<'_> {
     }
 }
 
-fn rendered_llm_request_chars(req: &LlmRequest) -> usize {
+fn split_chunks_to_rendered_budget(
+    chunks: Vec<Vec<Segment>>,
+    dialect: MarkdownDialect,
+    language: &str,
+    max_chars: usize,
+) -> Vec<Vec<Segment>> {
+    let mut out = Vec::new();
+    for chunk in chunks {
+        push_rendered_budget_chunk(chunk, dialect, language, max_chars, &mut out);
+    }
+    out
+}
+
+fn push_rendered_budget_chunk(
+    chunk: Vec<Segment>,
+    dialect: MarkdownDialect,
+    language: &str,
+    max_chars: usize,
+    out: &mut Vec<Vec<Segment>>,
+) {
+    let req = build_section_narrative_prompt(&chunk, dialect, language);
+    if chunk.len() <= 1 || rendered_llm_request_chars(&req) <= max_chars {
+        out.push(chunk);
+        return;
+    }
+
+    let mut current = Vec::new();
+    for seg in chunk {
+        current.push(seg);
+        let req = build_section_narrative_prompt(&current, dialect, language);
+        if rendered_llm_request_chars(&req) > max_chars && current.len() > 1 {
+            let overflow = current.pop().expect("current has at least two segments");
+            out.push(current);
+            current = vec![overflow];
+        }
+    }
+
+    if !current.is_empty() {
+        push_rendered_budget_chunk(current, dialect, language, max_chars, out);
+    }
+}
+
+#[doc(hidden)]
+pub fn rendered_llm_request_chars(req: &LlmRequest) -> usize {
     req.system.as_deref().map_or(0, str::len)
         + req.user.len()
         + req

--- a/crates/panops-core/src/notes/pipeline.rs
+++ b/crates/panops-core/src/notes/pipeline.rs
@@ -25,11 +25,12 @@ use crate::notes::ir::{ActionItem, NotesFrontmatter, NotesSection, Screenshot, S
 use crate::notes::prompts::{
     SECTION_CHUNK_TARGET_CHARS, SECTION_CHUNK_THRESHOLD_CHARS, SectionSummary,
     build_frontmatter_prompt, build_merge_section_prompt, build_section_narrative_prompt,
-    estimate_transcript_chars, split_segments_for_chunking,
+    estimate_chunk_summary_chars, estimate_transcript_chars, split_segments_for_chunking,
 };
 use crate::notes::screenshot_anchoring::anchor_screenshots;
 use crate::notes::topic_segmentation::{TopicSegmentationConfig, segment_topics};
 use crate::notes::verifier;
+use serde_json::Value;
 
 pub struct NotesGenerator<'a> {
     pub llm: &'a (dyn LlmProvider + 'a),
@@ -216,10 +217,11 @@ impl NotesGenerator<'_> {
                 }
             }
 
-            // Merge chunk summaries into final section
-            let merge_req = build_merge_section_prompt(&chunk_summaries, self.dialect, language);
-            match self.llm.complete(merge_req) {
-                Ok(LlmResponse::Json(v)) => {
+            // Merge chunk summaries into final section. The merge itself is
+            // bounded so many sub-chunks cannot recreate the original
+            // over-context prompt.
+            match self.merge_chunk_summaries(chunk_summaries, language) {
+                Ok(v) => {
                     let draft = SectionDraft::from_json(time_range_ms, segs.clone(), v);
                     match verifier::verify_section_attribution(
                         &draft.narrative_md,
@@ -242,20 +244,88 @@ impl NotesGenerator<'_> {
                         }
                     }
                 }
-                Ok(LlmResponse::Text(_)) => SectionDraft::fallback(
-                    time_range_ms,
-                    segs,
-                    "merge LLM returned text, expected json",
-                    self.dialect,
-                ),
-                Err(e) => SectionDraft::fallback(
-                    time_range_ms,
-                    segs,
-                    &format!("merge LLM call failed: {e}"),
-                    self.dialect,
-                ),
+                Err(err) => SectionDraft::fallback(time_range_ms, segs, &err, self.dialect),
             }
         }
+    }
+
+    fn merge_chunk_summaries(
+        &self,
+        mut summaries: Vec<Value>,
+        language: &str,
+    ) -> Result<Value, String> {
+        if summaries.is_empty() {
+            return Err("merge LLM call failed: no chunk summaries".to_string());
+        }
+
+        while summaries.len() > 1 {
+            let before_estimate = summaries
+                .iter()
+                .map(estimate_chunk_summary_chars)
+                .sum::<usize>();
+            let mut next_round = Vec::new();
+            let mut index = 0;
+
+            while index < summaries.len() {
+                let mut batch = Vec::new();
+                let mut batch_estimate = 0usize;
+
+                while index < summaries.len() {
+                    let next = summaries[index].clone();
+                    let next_estimate = estimate_chunk_summary_chars(&next);
+
+                    if !batch.is_empty() {
+                        let candidate_estimate = batch_estimate.saturating_add(next_estimate);
+                        if candidate_estimate > SECTION_CHUNK_THRESHOLD_CHARS {
+                            break;
+                        }
+
+                        let mut candidate_batch = batch.clone();
+                        candidate_batch.push(next.clone());
+                        let candidate_req =
+                            build_merge_section_prompt(&candidate_batch, self.dialect, language);
+                        if candidate_req.user.len() > SECTION_CHUNK_THRESHOLD_CHARS {
+                            break;
+                        }
+                    }
+
+                    batch.push(next);
+                    batch_estimate = batch_estimate.saturating_add(next_estimate);
+                    index += 1;
+                }
+
+                let merge_req = build_merge_section_prompt(&batch, self.dialect, language);
+                if merge_req.user.len() > SECTION_CHUNK_THRESHOLD_CHARS {
+                    tracing::warn!(
+                        input_chars = merge_req.user.len(),
+                        threshold = SECTION_CHUNK_THRESHOLD_CHARS,
+                        "single chunk summary exceeds merge context threshold"
+                    );
+                }
+
+                match self.llm.complete(merge_req) {
+                    Ok(LlmResponse::Json(v)) => next_round.push(v),
+                    Ok(LlmResponse::Text(_)) => {
+                        return Err("merge LLM returned text, expected json".to_string());
+                    }
+                    Err(e) => return Err(format!("merge LLM call failed: {e}")),
+                }
+            }
+
+            let after_estimate = next_round
+                .iter()
+                .map(estimate_chunk_summary_chars)
+                .sum::<usize>();
+            if next_round.len() == summaries.len() && after_estimate >= before_estimate {
+                return Err(
+                    "merge LLM call failed: chunk summaries cannot be reduced within context threshold"
+                        .to_string(),
+                );
+            }
+            summaries = next_round;
+        }
+
+        Ok(summaries.remove(0))
     }
 
     /// Single-section LLM call (original path, unchanged).

--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -27,10 +27,10 @@ pub const SECTION_CHUNK_TARGET_CHARS: usize = 4000;
 
 /// Approximate rendered transcript overhead per segment line.
 /// Line format: "[XXXX–YYYYs] speaker_N: TEXT\n".
-pub const SEGMENT_LINE_OVERHEAD: usize = 20;
+const SEGMENT_LINE_OVERHEAD: usize = 20;
 
 /// Minimum silence gap treated as a semantic chunk boundary.
-pub const SPLIT_GAP_THRESHOLD_MS: u64 = 2000;
+const SPLIT_GAP_THRESHOLD_MS: u64 = 2000;
 
 /// Compact summary of a section, fed to the frontmatter prompt.
 #[derive(Debug, Clone)]

--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -140,6 +140,16 @@ pub fn estimate_transcript_chars(segments: &[Segment]) -> usize {
     segments.iter().map(|s| s.text.len() + 20).sum()
 }
 
+/// Estimate the input size contribution of one chunk-summary JSON value.
+///
+/// This intentionally uses serialized JSON length as a cheap, conservative-ish
+/// proxy for the text `build_merge_section_prompt` will render. The rendered
+/// prompt adds labels/instructions around these fields, so callers should still
+/// reserve prompt headroom or verify the final prompt size before sending it.
+pub fn estimate_chunk_summary_chars(summary: &serde_json::Value) -> usize {
+    serde_json::to_string(summary).map_or(0, |s| s.len())
+}
+
 /// Split segments into ordered sub-chunks, each respecting segment boundaries.
 /// Returns non-empty chunks where each chunk's rendered transcript is close to
 /// `target_chars` but never exceeds `max_chars`. The last chunk may be smaller.

--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -25,6 +25,13 @@ pub const SECTION_CHUNK_THRESHOLD_CHARS: usize = 8000;
 /// the merge prompt's overhead when combining sub-summaries.
 pub const SECTION_CHUNK_TARGET_CHARS: usize = 4000;
 
+/// Approximate rendered transcript overhead per segment line.
+/// Line format: "[XXXX–YYYYs] speaker_N: TEXT\n".
+pub const SEGMENT_LINE_OVERHEAD: usize = 20;
+
+/// Minimum silence gap treated as a semantic chunk boundary.
+pub const SPLIT_GAP_THRESHOLD_MS: u64 = 2000;
+
 /// Compact summary of a section, fed to the frontmatter prompt.
 #[derive(Debug, Clone)]
 pub struct SectionSummary {
@@ -135,9 +142,11 @@ fn render_transcript(segments: &[Segment]) -> String {
 /// Estimate the character count of a rendered transcript for a slice of segments.
 /// Used to determine if chunking is needed and to build chunks of target size.
 pub fn estimate_transcript_chars(segments: &[Segment]) -> usize {
-    // Each segment line format: "[XXXX–YYYYs] speaker_N: TEXT\n"
-    // = ~20 chars overhead + text length
-    segments.iter().map(|s| s.text.len() + 20).sum()
+    // Each segment line format: "[XXXX–YYYYs] speaker_N: TEXT\n".
+    segments
+        .iter()
+        .map(|s| s.text.len() + SEGMENT_LINE_OVERHEAD)
+        .sum()
 }
 
 /// Estimate the input size contribution of one chunk-summary JSON value.
@@ -174,7 +183,7 @@ pub fn split_segments_for_chunking(
     let mut current_chars = 0;
 
     for seg in segments {
-        let seg_chars = seg.text.len() + 20;
+        let seg_chars = seg.text.len() + SEGMENT_LINE_OVERHEAD;
 
         // If adding this segment would exceed max_chars AND we already have content,
         // flush the current chunk and start fresh.
@@ -190,7 +199,7 @@ pub fn split_segments_for_chunking(
             let prev = current.last().unwrap();
             let gap = seg.start_ms.saturating_sub(prev.end_ms);
             let speaker_change = seg.speaker_id != prev.speaker_id;
-            if gap > 2000 || speaker_change {
+            if gap > SPLIT_GAP_THRESHOLD_MS || speaker_change {
                 chunks.push(current);
                 current = Vec::new();
                 current_chars = 0;

--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -12,6 +12,19 @@ pub const FRONTMATTER_TEMPERATURE: f32 = 0.3;
 pub const SECTION_NARRATIVE_MAX_TOKENS: u32 = 2048;
 pub const FRONTMATTER_MAX_TOKENS: u32 = 512;
 
+/// Approximate context-window threshold for section chunking.
+/// gemma3:4b has ~4k token context; we reserve headroom for system prompt,
+/// schema, and output tokens. Using chars/4 heuristic (~4 chars/token for
+/// English), 8000 chars ≈ 2000 input tokens, leaving ~2k for output.
+/// Sections exceeding this threshold are split into ordered sub-chunks.
+pub const SECTION_CHUNK_THRESHOLD_CHARS: usize = 8000;
+
+/// Target size for each sub-chunk when splitting a long section.
+/// Chunks are built to this target but may vary slightly due to
+/// segment-boundary constraints. Half the threshold allows room for
+/// the merge prompt's overhead when combining sub-summaries.
+pub const SECTION_CHUNK_TARGET_CHARS: usize = 4000;
+
 /// Compact summary of a section, fed to the frontmatter prompt.
 #[derive(Debug, Clone)]
 pub struct SectionSummary {
@@ -117,6 +130,160 @@ fn render_transcript(segments: &[Segment]) -> String {
         out.push_str(&format!("[{start:>4}–{end:>4}s] {label}: {}\n", seg.text));
     }
     out
+}
+
+/// Estimate the character count of a rendered transcript for a slice of segments.
+/// Used to determine if chunking is needed and to build chunks of target size.
+pub fn estimate_transcript_chars(segments: &[Segment]) -> usize {
+    // Each segment line format: "[XXXX–YYYYs] speaker_N: TEXT\n"
+    // = ~20 chars overhead + text length
+    segments.iter().map(|s| s.text.len() + 20).sum()
+}
+
+/// Split segments into ordered sub-chunks, each respecting segment boundaries.
+/// Returns non-empty chunks where each chunk's rendered transcript is close to
+/// `target_chars` but never exceeds `max_chars`. The last chunk may be smaller.
+/// Guarantees: every segment appears in exactly one chunk, order preserved.
+pub fn split_segments_for_chunking(
+    segments: &[Segment],
+    target_chars: usize,
+    max_chars: usize,
+) -> Vec<Vec<Segment>> {
+    if segments.is_empty() {
+        return Vec::new();
+    }
+
+    let total_chars = estimate_transcript_chars(segments);
+    if total_chars <= max_chars {
+        // No chunking needed
+        return vec![segments.to_vec()];
+    }
+
+    let mut chunks: Vec<Vec<Segment>> = Vec::new();
+    let mut current: Vec<Segment> = Vec::new();
+    let mut current_chars = 0;
+
+    for seg in segments {
+        let seg_chars = seg.text.len() + 20;
+
+        // If adding this segment would exceed max_chars AND we already have content,
+        // flush the current chunk and start fresh.
+        if current_chars + seg_chars > max_chars && !current.is_empty() {
+            chunks.push(current);
+            current = Vec::new();
+            current_chars = 0;
+        }
+
+        // If we're over target and this is a natural boundary (gap or speaker change),
+        // consider flushing. This helps keep chunks semantically coherent.
+        if current_chars >= target_chars && !current.is_empty() {
+            let prev = current.last().unwrap();
+            let gap = seg.start_ms.saturating_sub(prev.end_ms);
+            let speaker_change = seg.speaker_id != prev.speaker_id;
+            if gap > 2000 || speaker_change {
+                chunks.push(current);
+                current = Vec::new();
+                current_chars = 0;
+            }
+        }
+
+        current.push(seg.clone());
+        current_chars += seg_chars;
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    // Ensure no chunk exceeds max_chars (shouldn't happen with logic above,
+    // but verify for safety). If a single segment exceeds max_chars, it stays
+    // alone — we can't split mid-segment.
+    debug_assert!(
+        chunks
+            .iter()
+            .all(|c| estimate_transcript_chars(c) <= max_chars || c.len() == 1),
+        "chunk exceeds max_chars"
+    );
+
+    chunks
+}
+
+/// Prompt for merging multiple sub-chunk summaries into a final section summary.
+/// Takes JSON outputs from chunk-level calls and produces a unified result.
+pub fn build_merge_section_prompt(
+    chunk_summaries: &[serde_json::Value],
+    dialect: MarkdownDialect,
+    language: &str,
+) -> LlmRequest {
+    let mut summaries_text = String::new();
+    for (i, summary) in chunk_summaries.iter().enumerate() {
+        let title = summary
+            .get("title")
+            .and_then(|s| s.as_str())
+            .unwrap_or("Untitled chunk");
+        let narrative = summary
+            .get("narrative_md")
+            .and_then(|s| s.as_str())
+            .unwrap_or("");
+        let key_points = summary
+            .get("key_points")
+            .and_then(|s| s.as_array())
+            .map(|arr| arr.iter().filter_map(|x| x.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
+        let action_items = summary
+            .get("action_items")
+            .and_then(|s| s.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|x| {
+                        let o = x.as_object()?;
+                        let desc = o.get("description")?.as_str()?;
+                        let owner = o.get("owner").and_then(|v| v.as_str());
+                        Some(format!(
+                            "- {} (owner: {})",
+                            desc,
+                            owner.unwrap_or("unassigned")
+                        ))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let _ = writeln!(summaries_text, "Chunk {}:", i + 1);
+        let _ = writeln!(summaries_text, "  Title: {}", title);
+        let _ = writeln!(summaries_text, "  Narrative: {}", narrative);
+        for kp in &key_points {
+            let _ = writeln!(summaries_text, "  Key point: {}", kp);
+        }
+        for ai in &action_items {
+            let _ = writeln!(summaries_text, "  Action: {}", ai);
+        }
+        let _ = writeln!(summaries_text);
+    }
+
+    let cheat = dialect.cheat_sheet();
+    let user = format!(
+        "Sub-chunk summaries (ordered chronologically):\n\n\
+         {summaries_text}\n\
+         Markdown dialect for `narrative_md`:\n\
+         {cheat}\n\
+         Output language: {language}\n\n\
+         Merge these sub-chunks into a single unified section summary.\n\
+         - Combine narratives into flowing prose (no bullet lists).\n\
+         - Deduplicate key_points: keep distinct facts, merge overlapping.\n\
+         - Deduplicate action_items: keep distinct commitments.\n\
+         - Title should represent the unified theme.\n\n\
+         Return JSON matching exactly:\n\
+         {{\n  \"title\": \"string (descriptive, <80 chars)\",\n  \"narrative_md\": \"string (prose only, in the dialect above)\",\n  \"key_points\": [\"string\", ...],\n  \"action_items\": [{{\"description\": \"string\", \"owner\": \"speaker_0\"}}] or [{{\"description\": \"string\", \"owner\": null}}]\n}}"
+    );
+
+    LlmRequest {
+        system: Some(SECTION_NARRATIVE_SYSTEM.to_string()),
+        user,
+        schema: Some(section_narrative_schema()),
+        temperature: SECTION_NARRATIVE_TEMPERATURE,
+        max_tokens: SECTION_NARRATIVE_MAX_TOKENS,
+    }
 }
 
 fn section_narrative_schema() -> serde_json::Value {
@@ -227,5 +394,92 @@ mod tests {
         assert!(p.user.contains("Intro"));
         assert!(p.user.contains("Wrap"));
         assert!(p.user.contains("one"));
+    }
+
+    #[test]
+    fn estimate_transcript_chars_counts_text_plus_overhead() {
+        // Each segment: ~20 chars overhead + text length
+        let segs = vec![
+            seg(0, 5000, Some(0), "hello"),     // 5 chars text
+            seg(5000, 10000, Some(1), "world"), // 5 chars text
+        ];
+        let estimate = estimate_transcript_chars(&segs);
+        assert_eq!(estimate, 50); // 2 * (20 + 5)
+    }
+
+    #[test]
+    fn split_segments_returns_single_chunk_when_below_threshold() {
+        let segs = vec![seg(0, 5000, Some(0), "short")];
+        let chunks = split_segments_for_chunking(&segs, 100, 200);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 1);
+    }
+
+    #[test]
+    fn split_segments_splits_at_segment_boundaries() {
+        // Create segments totaling > max_chars with clear boundaries
+        let segs: Vec<Segment> = (0..10u32)
+            .map(|i| {
+                seg(
+                    u64::from(i) * 5000,
+                    u64::from(i + 1) * 5000,
+                    Some(i % 2),
+                    "word word word word",
+                )
+            })
+            .collect();
+        // Each segment: 20 + 19 = 39 chars, total = 390 chars
+        let chunks = split_segments_for_chunking(&segs, 80, 120);
+        assert!(chunks.len() > 1, "should split into multiple chunks");
+        // Verify no segment is lost
+        let total_segments: usize = chunks.iter().map(|c| c.len()).sum();
+        assert_eq!(total_segments, segs.len());
+        // Verify order preserved
+        let all_texts: Vec<_> = chunks.iter().flatten().map(|s| s.text.as_str()).collect();
+        let expected: Vec<_> = segs.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(all_texts, expected);
+    }
+
+    #[test]
+    fn split_segments_splits_at_speaker_change_after_target() {
+        // Max=50, so total (78 chars) exceeds max. Target=30.
+        // After first segment (39 >= target), speaker change should trigger split.
+        let segs = vec![
+            seg(0, 5000, Some(0), "text text text text"), // 39 chars (20 + 19)
+            seg(5000, 10000, Some(1), "text text text text"), // 39 chars, speaker change
+        ];
+        // Total = 78 chars, max = 50 → chunking required
+        let chunks = split_segments_for_chunking(&segs, 30, 50);
+        // Should split because after first segment we're >= target and speaker changes
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 1);
+        assert_eq!(chunks[1].len(), 1);
+    }
+
+    #[test]
+    fn split_segments_splits_at_gap_after_target() {
+        // Max=50, so total (78 chars) exceeds max. Target=30. Gap of 5s between segments.
+        let segs = vec![
+            seg(0, 5000, Some(0), "text text text text"), // 39 chars
+            seg(10_000, 15_000, Some(0), "text text text text"), // 39 chars, 5s gap
+        ];
+        // Total = 78 chars, max = 50 → chunking required
+        let chunks = split_segments_for_chunking(&segs, 30, 50);
+        // Should split because after first segment we're >= target and gap > 2s
+        assert_eq!(chunks.len(), 2);
+    }
+
+    #[test]
+    fn build_merge_prompt_includes_all_chunk_summaries() {
+        let summaries = vec![
+            serde_json::json!({"title": "Part 1", "narrative_md": "first part", "key_points": ["a"], "action_items": []}),
+            serde_json::json!({"title": "Part 2", "narrative_md": "second part", "key_points": ["b"], "action_items": [{"description": "do it", "owner": null}]}),
+        ];
+        let p = build_merge_section_prompt(&summaries, MarkdownDialect::Basic, "en");
+        assert!(p.user.contains("Part 1"));
+        assert!(p.user.contains("Part 2"));
+        assert!(p.user.contains("first part"));
+        assert!(p.user.contains("second part"));
+        assert!(p.user.contains("do it"));
     }
 }

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -146,6 +146,36 @@ impl LlmProvider for BulkyRecordingLlm {
     }
 }
 
+#[derive(Default)]
+struct MergeFailingLlm {
+    calls: Mutex<Vec<LlmRequest>>,
+}
+
+impl LlmProvider for MergeFailingLlm {
+    fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let response = if req.user.starts_with("Section transcript") {
+            let markers = marker_list(&req.user);
+            LlmResponse::Json(serde_json::json!({
+                "title": markers.first().map_or("Chunk", String::as_str),
+                "narrative_md": markers.join(" "),
+                "key_points": markers,
+                "action_items": []
+            }))
+        } else if req.user.starts_with("Sub-chunk summaries") {
+            LlmResponse::Text("merge failed as text".into())
+        } else if req.user.starts_with("Section summaries") {
+            LlmResponse::Json(serde_json::json!({
+                "title": "Team Meeting",
+                "tags": ["meeting"]
+            }))
+        } else {
+            return Err(LlmError::Provider("unexpected prompt".into()));
+        };
+        self.calls.lock().unwrap().push(req);
+        Ok(response)
+    }
+}
+
 fn marker_list(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     for token in text.split_whitespace() {
@@ -407,6 +437,45 @@ fn long_section_merges_chunk_summaries_in_bounded_rounds() {
         narrative_order.windows(2).all(|pair| pair[0] < pair[1]),
         "merged marker order should remain chronological: {narrative}"
     );
+}
+
+#[test]
+fn long_section_merge_text_response_falls_back_without_aborting() {
+    let mut segments = Vec::new();
+    for i in 0..18u64 {
+        let marker = format!("marker-fallback-{i:02}");
+        let filler = " context".repeat(90);
+        let start_ms = i * 4_000;
+        segments.push(seg(
+            start_ms,
+            start_ms + 1_000,
+            0,
+            &format!("{marker}{filler}"),
+        ));
+    }
+
+    let llm = MergeFailingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 72_000))
+        .expect("generate should not abort when merge falls back");
+
+    assert_eq!(notes.sections.len(), 1);
+    assert_eq!(notes.sections[0].title, "Section");
+    let narrative = &notes.sections[0].narrative_md;
+    assert!(
+        narrative.contains("panops: llm error: merge LLM returned text, expected json"),
+        "fallback should include merge error marker; got: {narrative}"
+    );
+    assert!(
+        narrative.contains("marker-fallback-00"),
+        "fallback should preserve original transcript content; got: {narrative}"
+    );
+    assert_eq!(notes.frontmatter.title, "Team Meeting");
 }
 
 #[test]

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -8,10 +8,10 @@ use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::ir::Screenshot;
-use panops_core::notes::pipeline::NotesGenerator;
+use panops_core::notes::pipeline::{NotesGenerator, rendered_llm_request_chars};
 use panops_core::notes::prompts::{
     SECTION_CHUNK_THRESHOLD_CHARS, SectionSummary, build_frontmatter_prompt,
-    build_section_narrative_prompt,
+    build_section_narrative_prompt, estimate_transcript_chars,
 };
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -187,15 +187,6 @@ fn marker_list(text: &str) -> Vec<String> {
     out
 }
 
-fn rendered_request_chars(req: &LlmRequest) -> usize {
-    req.system.as_deref().map_or(0, str::len)
-        + req.user.len()
-        + req
-            .schema
-            .as_ref()
-            .map_or(0, |schema| schema.to_string().len())
-}
-
 fn notes_input(segments: Vec<Segment>, duration_ms: u64) -> NotesInput {
     NotesInput {
         transcript: segments,
@@ -272,6 +263,112 @@ fn short_section_uses_single_section_llm_call_without_merge() {
 }
 
 #[test]
+fn near_threshold_rendered_section_uses_chunk_path() {
+    let mut segments = Vec::new();
+    let segment_count = 20usize;
+    let mut remaining_estimate = SECTION_CHUNK_THRESHOLD_CHARS - 16;
+
+    for i in 0..segment_count {
+        let marker = format!("marker-rendered-{i:02}");
+        let remaining_segments = segment_count - i;
+        let line_chars = remaining_estimate / remaining_segments;
+        let text_len = line_chars.saturating_sub(20);
+        let filler_len = text_len.saturating_sub(marker.len() + 1);
+        let text = format!("{marker} {}", "x".repeat(filler_len));
+        remaining_estimate = remaining_estimate.saturating_sub(text.len() + 20);
+        let start_ms = i as u64 * 4_000;
+        segments.push(seg(start_ms, start_ms + 1_000, 0, &text));
+    }
+
+    let transcript_chars = estimate_transcript_chars(&segments);
+    let single_req = build_section_narrative_prompt(&segments, MarkdownDialect::Basic, "en");
+    assert!(
+        transcript_chars < SECTION_CHUNK_THRESHOLD_CHARS,
+        "fixture must stay under the transcript-only threshold: {transcript_chars}"
+    );
+    assert!(
+        rendered_llm_request_chars(&single_req) > SECTION_CHUNK_THRESHOLD_CHARS,
+        "fixture must exceed the rendered prompt threshold"
+    );
+
+    let llm = RecordingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 80_000))
+        .expect("generate failed");
+
+    assert_eq!(notes.sections.len(), 1);
+    let calls = llm.calls();
+    let section_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Section transcript"))
+        .collect();
+    let merge_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Sub-chunk summaries"))
+        .collect();
+
+    assert!(
+        section_calls.len() > 1,
+        "rendered prompt overhead should force multiple chunk summaries"
+    );
+    assert_eq!(
+        merge_calls.len(),
+        1,
+        "multiple rendered-budget chunks should merge once"
+    );
+}
+
+#[test]
+fn single_chunk_long_section_skips_merge_call() {
+    let segments = vec![seg(
+        0,
+        60_000,
+        0,
+        &format!("marker-single-chunk {}", "context ".repeat(1_200)),
+    )];
+    let single_req = build_section_narrative_prompt(&segments, MarkdownDialect::Basic, "en");
+    assert!(
+        rendered_llm_request_chars(&single_req) > SECTION_CHUNK_THRESHOLD_CHARS,
+        "fixture must exceed the rendered prompt threshold"
+    );
+
+    let llm = RecordingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 60_000))
+        .expect("generate failed");
+
+    assert_eq!(notes.sections.len(), 1);
+    assert_eq!(notes.sections[0].narrative_md, "marker-single-chunk");
+    let calls = llm.calls();
+    let section_calls = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Section transcript"))
+        .count();
+    let merge_calls = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Sub-chunk summaries"))
+        .count();
+    assert_eq!(
+        section_calls, 1,
+        "single unbreakable chunk is summarized once"
+    );
+    assert_eq!(
+        merge_calls, 0,
+        "one chunk summary should pass through without an LLM merge"
+    );
+}
+
+#[test]
 fn long_section_chunks_summarizes_each_chunk_and_merges_in_order() {
     let mut segments = Vec::new();
     let mut expected_markers = Vec::new();
@@ -326,9 +423,9 @@ fn long_section_chunks_summarizes_each_chunk_and_merges_in_order() {
     }
     for call in &calls {
         assert!(
-            rendered_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
+            rendered_llm_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
             "LLM input exceeded threshold: {} > {}",
-            rendered_request_chars(call),
+            rendered_llm_request_chars(call),
             SECTION_CHUNK_THRESHOLD_CHARS
         );
     }
@@ -414,9 +511,9 @@ fn long_section_merges_chunk_summaries_in_bounded_rounds() {
         call.user.starts_with("Section transcript") || call.user.starts_with("Sub-chunk summaries")
     }) {
         assert!(
-            rendered_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
+            rendered_llm_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
             "LLM input exceeded threshold: {} > {}\n{}",
-            rendered_request_chars(call),
+            rendered_llm_request_chars(call),
             SECTION_CHUNK_THRESHOLD_CHARS,
             call.user
         );
@@ -468,8 +565,13 @@ fn long_section_merge_text_response_falls_back_without_aborting() {
     assert_eq!(notes.sections[0].title, "Section");
     let narrative = &notes.sections[0].narrative_md;
     assert!(
-        narrative.contains("panops: llm error: merge LLM returned text, expected json"),
-        "fallback should include merge error marker; got: {narrative}"
+        narrative.contains("panops: llm error: LLM unavailable"),
+        "fallback should include a generic LLM marker; got: {narrative}"
+    );
+    assert!(
+        !narrative.contains("merge failed as text")
+            && !narrative.contains("merge LLM returned text, expected json"),
+        "fallback should not leak internal LLM details; got: {narrative}"
     );
     assert!(
         narrative.contains("marker-fallback-00"),

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -4,15 +4,17 @@ use chrono::FixedOffset;
 use chrono::TimeZone;
 use panops_core::Segment;
 use panops_core::conformance::fakes::MockLlm;
-use panops_core::llm::LlmResponse;
+use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::ir::Screenshot;
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_core::notes::prompts::{
-    SectionSummary, build_frontmatter_prompt, build_section_narrative_prompt,
+    SECTION_CHUNK_THRESHOLD_CHARS, SectionSummary, build_frontmatter_prompt,
+    build_section_narrative_prompt,
 };
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 fn seg(start: u64, end: u64, speaker: u32, text: &str) -> Segment {
     Segment {
@@ -57,6 +59,78 @@ fn make_mock(segments: &[Segment], duration_ms: u64) -> MockLlm {
         )
 }
 
+#[derive(Default)]
+struct RecordingLlm {
+    calls: Mutex<Vec<LlmRequest>>,
+}
+
+impl RecordingLlm {
+    fn calls(&self) -> Vec<LlmRequest> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl LlmProvider for RecordingLlm {
+    fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let response = if req.user.starts_with("Section transcript") {
+            let markers = marker_list(&req.user);
+            let title = markers
+                .first()
+                .map_or_else(|| "Short Section".to_string(), |m| format!("Chunk {m}"));
+            LlmResponse::Json(serde_json::json!({
+                "title": title,
+                "narrative_md": markers.join(" "),
+                "key_points": markers,
+                "action_items": []
+            }))
+        } else if req.user.starts_with("Sub-chunk summaries") {
+            let markers = marker_list(&req.user);
+            LlmResponse::Json(serde_json::json!({
+                "title": "Long Section",
+                "narrative_md": markers.join(" "),
+                "key_points": markers,
+                "action_items": []
+            }))
+        } else if req.user.starts_with("Section summaries") {
+            LlmResponse::Json(serde_json::json!({
+                "title": "Team Meeting",
+                "tags": ["meeting"]
+            }))
+        } else {
+            return Err(LlmError::Provider("unexpected prompt".into()));
+        };
+        self.calls.lock().unwrap().push(req);
+        Ok(response)
+    }
+}
+
+fn marker_list(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for token in text.split_whitespace() {
+        let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-');
+        if token.starts_with("marker-") && !out.iter().any(|seen| seen == token) {
+            out.push(token.to_string());
+        }
+    }
+    out
+}
+
+fn notes_input(segments: Vec<Segment>, duration_ms: u64) -> NotesInput {
+    NotesInput {
+        transcript: segments,
+        screenshots: vec![],
+        meeting_metadata: MeetingMetadata {
+            started_at: FixedOffset::east_opt(0)
+                .unwrap()
+                .with_ymd_and_hms(2026, 5, 1, 10, 0, 0)
+                .unwrap(),
+            duration_ms,
+            source_path: None,
+            language_hint: Some("en".into()),
+        },
+    }
+}
+
 #[test]
 fn one_section_pipeline_produces_structured_notes() {
     let segments = vec![seg(0, 60_000, 0, "hello and welcome to the meeting")];
@@ -86,6 +160,114 @@ fn one_section_pipeline_produces_structured_notes() {
     assert_eq!(notes.frontmatter.title, "Team Meeting");
     assert_eq!(notes.frontmatter.tags, vec!["meeting", "intro"]);
     assert_eq!(notes.frontmatter.speakers, vec!["speaker_0"]);
+}
+
+#[test]
+fn short_section_uses_single_section_llm_call_without_merge() {
+    let segments = vec![seg(0, 60_000, 0, "marker-short hello and welcome")];
+    let llm = RecordingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 60_000))
+        .expect("generate failed");
+
+    assert_eq!(notes.sections.len(), 1);
+    assert_eq!(notes.sections[0].narrative_md, "marker-short");
+    let calls = llm.calls();
+    let section_calls = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Section transcript"))
+        .count();
+    let merge_calls = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Sub-chunk summaries"))
+        .count();
+    assert_eq!(section_calls, 1, "short sections keep the single-call path");
+    assert_eq!(merge_calls, 0, "short sections must not run a merge pass");
+}
+
+#[test]
+fn long_section_chunks_summarizes_each_chunk_and_merges_in_order() {
+    let mut segments = Vec::new();
+    let mut expected_markers = Vec::new();
+    for i in 0..18u64 {
+        let marker = format!("marker-{i:02}");
+        expected_markers.push(marker.clone());
+        let filler = " context".repeat(90);
+        let start_ms = i * 4_000;
+        segments.push(seg(
+            start_ms,
+            start_ms + 1_000,
+            0,
+            &format!("{marker}{filler}"),
+        ));
+    }
+
+    let llm = RecordingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 72_000))
+        .expect("generate failed");
+
+    assert_eq!(notes.sections.len(), 1);
+    let calls = llm.calls();
+    let section_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Section transcript"))
+        .collect();
+    let merge_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Sub-chunk summaries"))
+        .collect();
+
+    assert!(
+        section_calls.len() > 1,
+        "long section should trigger multiple sub-chunk summaries"
+    );
+    assert_eq!(
+        merge_calls.len(),
+        1,
+        "chunk summaries should be merged once"
+    );
+    for call in &section_calls {
+        assert!(
+            !marker_list(&call.user).is_empty(),
+            "every sub-chunk summary prompt should contain transcript content"
+        );
+    }
+    for call in &calls {
+        assert!(
+            call.user.len() <= SECTION_CHUNK_THRESHOLD_CHARS,
+            "LLM input exceeded threshold: {} > {}",
+            call.user.len(),
+            SECTION_CHUNK_THRESHOLD_CHARS
+        );
+    }
+
+    assert_eq!(notes.sections[0].title, "Long Section");
+    let narrative = &notes.sections[0].narrative_md;
+    for marker in &expected_markers {
+        assert!(
+            narrative.contains(marker),
+            "final merged section should include {marker}; got {narrative}"
+        );
+    }
+    let narrative_order: Vec<_> = expected_markers
+        .iter()
+        .map(|marker| narrative.find(marker).expect("marker should be present"))
+        .collect();
+    assert!(
+        narrative_order.windows(2).all(|pair| pair[0] < pair[1]),
+        "merged marker order should remain chronological: {narrative}"
+    );
 }
 
 #[test]

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -121,7 +121,7 @@ impl LlmProvider for BulkyRecordingLlm {
             let markers = marker_list(&req.user);
             LlmResponse::Json(serde_json::json!({
                 "title": markers.first().map_or("Chunk", String::as_str),
-                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(420)),
+                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(300)),
                 "key_points": markers,
                 "action_items": []
             }))
@@ -129,7 +129,7 @@ impl LlmProvider for BulkyRecordingLlm {
             let markers = marker_list(&req.user);
             LlmResponse::Json(serde_json::json!({
                 "title": "Merged Section",
-                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(420)),
+                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(300)),
                 "key_points": markers,
                 "action_items": []
             }))
@@ -155,6 +155,15 @@ fn marker_list(text: &str) -> Vec<String> {
         }
     }
     out
+}
+
+fn rendered_request_chars(req: &LlmRequest) -> usize {
+    req.system.as_deref().map_or(0, str::len)
+        + req.user.len()
+        + req
+            .schema
+            .as_ref()
+            .map_or(0, |schema| schema.to_string().len())
 }
 
 fn notes_input(segments: Vec<Segment>, duration_ms: u64) -> NotesInput {
@@ -287,9 +296,9 @@ fn long_section_chunks_summarizes_each_chunk_and_merges_in_order() {
     }
     for call in &calls {
         assert!(
-            call.user.len() <= SECTION_CHUNK_THRESHOLD_CHARS,
+            rendered_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
             "LLM input exceeded threshold: {} > {}",
-            call.user.len(),
+            rendered_request_chars(call),
             SECTION_CHUNK_THRESHOLD_CHARS
         );
     }
@@ -375,9 +384,9 @@ fn long_section_merges_chunk_summaries_in_bounded_rounds() {
         call.user.starts_with("Section transcript") || call.user.starts_with("Sub-chunk summaries")
     }) {
         assert!(
-            call.user.len() <= SECTION_CHUNK_THRESHOLD_CHARS,
+            rendered_request_chars(call) <= SECTION_CHUNK_THRESHOLD_CHARS,
             "LLM input exceeded threshold: {} > {}\n{}",
-            call.user.len(),
+            rendered_request_chars(call),
             SECTION_CHUNK_THRESHOLD_CHARS,
             call.user
         );

--- a/crates/panops-core/tests/notes_pipeline.rs
+++ b/crates/panops-core/tests/notes_pipeline.rs
@@ -104,6 +104,48 @@ impl LlmProvider for RecordingLlm {
     }
 }
 
+#[derive(Default)]
+struct BulkyRecordingLlm {
+    calls: Mutex<Vec<LlmRequest>>,
+}
+
+impl BulkyRecordingLlm {
+    fn calls(&self) -> Vec<LlmRequest> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl LlmProvider for BulkyRecordingLlm {
+    fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let response = if req.user.starts_with("Section transcript") {
+            let markers = marker_list(&req.user);
+            LlmResponse::Json(serde_json::json!({
+                "title": markers.first().map_or("Chunk", String::as_str),
+                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(420)),
+                "key_points": markers,
+                "action_items": []
+            }))
+        } else if req.user.starts_with("Sub-chunk summaries") {
+            let markers = marker_list(&req.user);
+            LlmResponse::Json(serde_json::json!({
+                "title": "Merged Section",
+                "narrative_md": format!("{} {}", markers.join(" "), "detail ".repeat(420)),
+                "key_points": markers,
+                "action_items": []
+            }))
+        } else if req.user.starts_with("Section summaries") {
+            LlmResponse::Json(serde_json::json!({
+                "title": "Team Meeting",
+                "tags": ["meeting"]
+            }))
+        } else {
+            return Err(LlmError::Provider("unexpected prompt".into()));
+        };
+        self.calls.lock().unwrap().push(req);
+        Ok(response)
+    }
+}
+
 fn marker_list(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     for token in text.split_whitespace() {
@@ -253,6 +295,94 @@ fn long_section_chunks_summarizes_each_chunk_and_merges_in_order() {
     }
 
     assert_eq!(notes.sections[0].title, "Long Section");
+    let narrative = &notes.sections[0].narrative_md;
+    for marker in &expected_markers {
+        assert!(
+            narrative.contains(marker),
+            "final merged section should include {marker}; got {narrative}"
+        );
+    }
+    let narrative_order: Vec<_> = expected_markers
+        .iter()
+        .map(|marker| narrative.find(marker).expect("marker should be present"))
+        .collect();
+    assert!(
+        narrative_order.windows(2).all(|pair| pair[0] < pair[1]),
+        "merged marker order should remain chronological: {narrative}"
+    );
+}
+
+#[test]
+fn long_section_merges_chunk_summaries_in_bounded_rounds() {
+    let mut segments = Vec::new();
+    let mut expected_markers = Vec::new();
+    for i in 0..12u64 {
+        let marker = format!("marker-bounded-{i:02}");
+        expected_markers.push(marker.clone());
+        let filler = " chunk".repeat(620);
+        let start_ms = i * 4_000;
+        segments.push(seg(
+            start_ms,
+            start_ms + 1_000,
+            0,
+            &format!("{marker}{filler}"),
+        ));
+    }
+
+    let llm = BulkyRecordingLlm::default();
+    let generator = NotesGenerator {
+        llm: &llm,
+        dialect: MarkdownDialect::Basic,
+    };
+
+    let notes = generator
+        .generate(notes_input(segments, 48_000))
+        .expect("generate failed");
+
+    assert_eq!(notes.sections.len(), 1);
+    assert_eq!(notes.sections[0].title, "Merged Section");
+    assert!(
+        !notes.sections[0].narrative_md.contains("panops: llm error"),
+        "iterative merge should produce notes without falling back"
+    );
+
+    let calls = llm.calls();
+    let section_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Section transcript"))
+        .collect();
+    let merge_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.user.starts_with("Sub-chunk summaries"))
+        .collect();
+
+    assert!(
+        section_calls.len() > 1,
+        "fixture should trigger chunk-level summaries"
+    );
+    assert!(
+        merge_calls.len() > 1,
+        "bulky chunk summaries should require multiple bounded merge calls"
+    );
+    assert!(
+        merge_calls
+            .iter()
+            .any(|call| call.user.contains("Title: Merged Section")),
+        "at least one merge call should consume a previous merge result"
+    );
+
+    for call in calls.iter().filter(|call| {
+        call.user.starts_with("Section transcript") || call.user.starts_with("Sub-chunk summaries")
+    }) {
+        assert!(
+            call.user.len() <= SECTION_CHUNK_THRESHOLD_CHARS,
+            "LLM input exceeded threshold: {} > {}\n{}",
+            call.user.len(),
+            SECTION_CHUNK_THRESHOLD_CHARS,
+            call.user
+        );
+    }
+
     let narrative = &notes.sections[0].narrative_md;
     for marker in &expected_markers {
         assert!(


### PR DESCRIPTION
## What

Closes #24. A single notes section whose transcript exceeds the LLM context window blew the default model (`gemma3:4b`). This adds long-section chunking to the notes pipeline.

## Changes

- `crates/panops-core/src/notes/pipeline.rs` — sections over a token-ish threshold are split at segment boundaries (never mid-segment), each sub-chunk summarized via the `LlmProvider`, then merged into one ordered section. Sections under the threshold keep the existing single-call path unchanged. Falls back to the deterministic section path if any chunk/merge LLM call fails.
- `crates/panops-core/src/notes/prompts.rs` — chunk-summary + merge prompt scaffolding.
- `crates/panops-core/tests/notes_pipeline.rs` — long synthetic section test (chunking triggers, every sub-chunk summarized, content preserved, no single LLM input exceeds the threshold) + short-section regression test proving the single-call path is unchanged.

## Verification

- `cargo test -p panops-core --locked` ✅, `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅, `cargo fmt --all` ✅.
- Full `cargo test --workspace --locked` running in CI.

## Notes

Drafted by an autonomous Codex (`codex exec`) implementer, then verified + reviewed locally. Kept in draft pending the full-workspace gate + review.