### PR TITLE
Model download: emit periodic progress (bytes/sec, ETA)

### DIFF
--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -229,29 +229,21 @@ fn emit_download_progress(
     let percent = total_bytes.and_then(|total| percent_complete(bytes_downloaded, total));
     let eta_secs = total_bytes.and_then(|total| eta_secs(bytes_downloaded, total, bytes_per_sec));
     let summary = format_download_progress(bytes_downloaded, total_bytes, bytes_per_sec);
-    if complete {
-        tracing::info!(
-            bytes = bytes_downloaded,
-            total_bytes = ?total_bytes,
-            percent = ?percent,
-            bytes_per_sec,
-            rate = %human_rate(bytes_per_sec),
-            eta_secs = ?eta_secs,
-            progress = %summary,
-            "model download progress complete"
-        );
+    let msg = if complete {
+        "model download progress complete"
     } else {
-        tracing::info!(
-            bytes = bytes_downloaded,
-            total_bytes = ?total_bytes,
-            percent = ?percent,
-            bytes_per_sec,
-            rate = %human_rate(bytes_per_sec),
-            eta_secs = ?eta_secs,
-            progress = %summary,
-            "model download progress"
-        );
-    }
+        "model download progress"
+    };
+    tracing::info!(
+        bytes = bytes_downloaded,
+        total_bytes = ?total_bytes,
+        percent = ?percent,
+        bytes_per_sec,
+        rate = %human_rate(bytes_per_sec),
+        eta_secs = ?eta_secs,
+        progress = %summary,
+        "{msg}"
+    );
 }
 
 fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Result<u64, AsrError> {
@@ -287,7 +279,9 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
                 .map_err(|e| AsrError::Model(format!("write {tmp:?}: {e}")))?;
             bytes_written += n as u64;
             let now = Instant::now();
-            let elapsed = now.duration_since(last_progress_at);
+            // saturating: never panic if the monotonic clock appears to go
+            // backwards (VM/container clock adjustments).
+            let elapsed = now.saturating_duration_since(last_progress_at);
             if elapsed >= DOWNLOAD_PROGRESS_INTERVAL {
                 let bytes_since_last = bytes_written - last_progress_bytes;
                 emit_download_progress(
@@ -301,11 +295,14 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
                 last_progress_bytes = bytes_written;
             }
         }
+        // Final line reports the OVERALL AVERAGE rate (cumulative bytes ÷ total
+        // elapsed), the meaningful completion metric — distinct from the periodic
+        // interval rates. saturating to avoid a non-monotonic-clock panic.
         emit_download_progress(
             bytes_written,
             total_bytes,
             bytes_written,
-            download_started_at.elapsed(),
+            Instant::now().saturating_duration_since(download_started_at),
             true,
         );
         file.sync_all()
@@ -485,6 +482,13 @@ mod tests {
         assert_eq!(percent_complete(999, 1000), Some(100));
         assert_eq!(percent_complete(120, 100), Some(100));
         assert_eq!(percent_complete(1, 0), None);
+    }
+
+    #[test]
+    fn bytes_per_second_handles_zero_elapsed_and_normal() {
+        assert_eq!(bytes_per_second(1000, Duration::ZERO), 0);
+        assert_eq!(bytes_per_second(1000, Duration::from_secs(2)), 500);
+        assert_eq!(bytes_per_second(0, Duration::from_secs(5)), 0);
     }
 
     #[test]

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -310,7 +310,9 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
             // can't fill the disk before the post-download checksum catches it.
             let limit = download_size_limit(total_bytes);
             if bytes_written > limit {
-                let _ = fs::remove_file(&tmp);
+                if let Err(e) = fs::remove_file(&tmp) {
+                    tracing::warn!(error = %e, tmp = ?tmp, "failed to remove oversized partial download");
+                }
                 return Err(AsrError::Model(format!(
                     "download exceeded size limit ({bytes_written} > {limit} bytes); aborting"
                 )));
@@ -519,6 +521,14 @@ mod tests {
         assert_eq!(percent_complete(999, 1000), Some(100));
         assert_eq!(percent_complete(120, 100), Some(100));
         assert_eq!(percent_complete(1, 0), None);
+    }
+
+    #[test]
+    fn human_bytes_formats_each_unit_branch() {
+        assert_eq!(human_bytes(500), "500 B");
+        assert_eq!(human_bytes(2048), "2.0 KiB");
+        assert_eq!(human_bytes(1_572_864), "1.5 MiB");
+        assert_eq!(human_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
     }
 
     #[test]

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -146,6 +146,17 @@ const DOWNLOAD_SIZE_GRACE: u64 = 1024 * 1024; // 1 MiB
 /// stream. Comfortably above the largest registered model.
 const MAX_MODEL_DOWNLOAD_BYTES: u64 = 6 * 1024 * 1024 * 1024; // 6 GiB
 
+/// Byte limit for an in-progress download. Always clamped to the hard ceiling,
+/// so an attacker-controlled `Content-Length` (even `u64::MAX`) can't raise it.
+fn download_size_limit(total_bytes: Option<u64>) -> u64 {
+    match total_bytes {
+        Some(t) => t
+            .saturating_add(DOWNLOAD_SIZE_GRACE)
+            .min(MAX_MODEL_DOWNLOAD_BYTES),
+        None => MAX_MODEL_DOWNLOAD_BYTES,
+    }
+}
+
 fn percent_complete(done: u64, total: u64) -> Option<u8> {
     if total == 0 {
         return None;
@@ -265,6 +276,15 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
         return Err(AsrError::Model(format!("download HTTP {}", resp.status())));
     }
     let total_bytes = resp.content_length();
+    // Fail fast on a known-oversized Content-Length (don't stream gigabytes
+    // first); the in-loop guard handles servers that under-report then overrun.
+    if let Some(total) = total_bytes {
+        if total > MAX_MODEL_DOWNLOAD_BYTES {
+            return Err(AsrError::Model(format!(
+                "server Content-Length {total} exceeds max {MAX_MODEL_DOWNLOAD_BYTES} bytes; aborting"
+            )));
+        }
+    }
     let tmp = dest.with_extension("partial");
     let mut bytes_written: u64 = 0;
     {
@@ -288,9 +308,7 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
             // Bound the download: cap at Content-Length + grace, or a hard
             // ceiling when the size is unknown, so a compromised/MITM host
             // can't fill the disk before the post-download checksum catches it.
-            let limit = total_bytes
-                .map(|t| t.saturating_add(DOWNLOAD_SIZE_GRACE))
-                .unwrap_or(MAX_MODEL_DOWNLOAD_BYTES);
+            let limit = download_size_limit(total_bytes);
             if bytes_written > limit {
                 let _ = fs::remove_file(&tmp);
                 return Err(AsrError::Model(format!(
@@ -501,6 +519,21 @@ mod tests {
         assert_eq!(percent_complete(999, 1000), Some(100));
         assert_eq!(percent_complete(120, 100), Some(100));
         assert_eq!(percent_complete(1, 0), None);
+    }
+
+    #[test]
+    fn download_size_limit_always_clamps_to_hard_ceiling() {
+        assert_eq!(download_size_limit(None), MAX_MODEL_DOWNLOAD_BYTES);
+        assert_eq!(download_size_limit(Some(1000)), 1000 + DOWNLOAD_SIZE_GRACE);
+        // Attacker-controlled huge / u64::MAX must NOT raise the limit.
+        assert_eq!(
+            download_size_limit(Some(u64::MAX)),
+            MAX_MODEL_DOWNLOAD_BYTES
+        );
+        assert_eq!(
+            download_size_limit(Some(MAX_MODEL_DOWNLOAD_BYTES * 2)),
+            MAX_MODEL_DOWNLOAD_BYTES
+        );
     }
 
     #[test]

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use directories::ProjectDirs;
 use panops_core::asr::AsrError;
@@ -137,6 +137,123 @@ fn verify_sha256(path: &Path, expected: &str) -> Result<(), AsrError> {
     Ok(())
 }
 
+const DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_secs(2);
+
+fn percent_complete(done: u64, total: u64) -> Option<u8> {
+    if total == 0 {
+        return None;
+    }
+    let pct = ((done.min(total) as f64 / total as f64) * 100.0).round() as u8;
+    Some(pct)
+}
+
+fn bytes_per_second(bytes: u64, elapsed: Duration) -> u64 {
+    if elapsed.is_zero() {
+        return 0;
+    }
+    (bytes as f64 / elapsed.as_secs_f64()).round() as u64
+}
+
+fn eta_secs(done: u64, total: u64, bytes_per_sec: u64) -> Option<u64> {
+    if done >= total {
+        return Some(0);
+    }
+    if total == 0 || bytes_per_sec == 0 {
+        return None;
+    }
+    let remaining = total - done;
+    Some(remaining / bytes_per_sec + u64::from(remaining % bytes_per_sec != 0))
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+
+    let bytes = bytes as f64;
+    if bytes < KIB {
+        format!("{bytes:.0} B")
+    } else if bytes < MIB {
+        format!("{:.1} KiB", bytes / KIB)
+    } else if bytes < GIB {
+        format!("{:.1} MiB", bytes / MIB)
+    } else {
+        format!("{:.1} GiB", bytes / GIB)
+    }
+}
+
+fn human_rate(bytes_per_sec: u64) -> String {
+    format!("{}/s", human_bytes(bytes_per_sec))
+}
+
+fn format_duration_secs(seconds: u64) -> String {
+    let minutes = seconds / 60;
+    let seconds = seconds % 60;
+    if minutes == 0 {
+        format!("{seconds}s")
+    } else {
+        format!("{minutes}m {seconds}s")
+    }
+}
+
+fn format_download_progress(
+    bytes_downloaded: u64,
+    total_bytes: Option<u64>,
+    bytes_per_sec: u64,
+) -> String {
+    let downloaded = human_bytes(bytes_downloaded);
+    let rate = human_rate(bytes_per_sec);
+    match total_bytes {
+        Some(total) => {
+            let total_display = human_bytes(total);
+            let percent = percent_complete(bytes_downloaded, total)
+                .map(|pct| format!("{pct}%"))
+                .unwrap_or_else(|| "unknown".to_string());
+            let eta = eta_secs(bytes_downloaded, total, bytes_per_sec)
+                .map(format_duration_secs)
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("downloaded {downloaded} / {total_display} ({percent}) at {rate}, eta {eta}")
+        }
+        None => format!("downloaded {downloaded} (total unknown) at {rate}"),
+    }
+}
+
+fn emit_download_progress(
+    bytes_downloaded: u64,
+    total_bytes: Option<u64>,
+    bytes_since_last: u64,
+    elapsed_since_last: Duration,
+    complete: bool,
+) {
+    let bytes_per_sec = bytes_per_second(bytes_since_last, elapsed_since_last);
+    let percent = total_bytes.and_then(|total| percent_complete(bytes_downloaded, total));
+    let eta_secs = total_bytes.and_then(|total| eta_secs(bytes_downloaded, total, bytes_per_sec));
+    let summary = format_download_progress(bytes_downloaded, total_bytes, bytes_per_sec);
+    if complete {
+        tracing::info!(
+            bytes = bytes_downloaded,
+            total_bytes = ?total_bytes,
+            percent = ?percent,
+            bytes_per_sec,
+            rate = %human_rate(bytes_per_sec),
+            eta_secs = ?eta_secs,
+            progress = %summary,
+            "model download progress complete"
+        );
+    } else {
+        tracing::info!(
+            bytes = bytes_downloaded,
+            total_bytes = ?total_bytes,
+            percent = ?percent,
+            bytes_per_sec,
+            rate = %human_rate(bytes_per_sec),
+            eta_secs = ?eta_secs,
+            progress = %summary,
+            "model download progress"
+        );
+    }
+}
+
 fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Result<u64, AsrError> {
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
@@ -148,12 +265,16 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
     if !resp.status().is_success() {
         return Err(AsrError::Model(format!("download HTTP {}", resp.status())));
     }
+    let total_bytes = resp.content_length();
     let tmp = dest.with_extension("partial");
     let mut bytes_written: u64 = 0;
     {
         let mut file =
             fs::File::create(&tmp).map_err(|e| AsrError::Model(format!("create {tmp:?}: {e}")))?;
         let mut reader = resp;
+        let download_started_at = Instant::now();
+        let mut last_progress_at = download_started_at;
+        let mut last_progress_bytes = 0_u64;
         let mut buf = [0_u8; 64 * 1024];
         loop {
             let n = reader
@@ -165,7 +286,28 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
             file.write_all(&buf[..n])
                 .map_err(|e| AsrError::Model(format!("write {tmp:?}: {e}")))?;
             bytes_written += n as u64;
+            let now = Instant::now();
+            let elapsed = now.duration_since(last_progress_at);
+            if elapsed >= DOWNLOAD_PROGRESS_INTERVAL {
+                let bytes_since_last = bytes_written - last_progress_bytes;
+                emit_download_progress(
+                    bytes_written,
+                    total_bytes,
+                    bytes_since_last,
+                    elapsed,
+                    false,
+                );
+                last_progress_at = now;
+                last_progress_bytes = bytes_written;
+            }
         }
+        emit_download_progress(
+            bytes_written,
+            total_bytes,
+            bytes_written,
+            download_started_at.elapsed(),
+            true,
+        );
         file.sync_all()
             .map_err(|e| AsrError::Model(format!("fsync {tmp:?}: {e}")))?;
     }
@@ -330,4 +472,44 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
     }
     tracing::info!(bytes = n, dest = ?dest, "vad model download complete");
     Ok(dest.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_complete_rounds_to_nearest_integer() {
+        assert_eq!(percent_complete(1, 3), Some(33));
+        assert_eq!(percent_complete(2, 3), Some(67));
+        assert_eq!(percent_complete(999, 1000), Some(100));
+        assert_eq!(percent_complete(120, 100), Some(100));
+        assert_eq!(percent_complete(1, 0), None);
+    }
+
+    #[test]
+    fn eta_secs_uses_ceiling_remaining_over_rate() {
+        assert_eq!(eta_secs(100, 1000, 100), Some(9));
+        assert_eq!(eta_secs(99, 1000, 100), Some(10));
+        assert_eq!(eta_secs(1000, 1000, 100), Some(0));
+        assert_eq!(eta_secs(100, 1000, 0), None);
+    }
+
+    #[test]
+    fn human_rate_formats_bytes_and_binary_units() {
+        assert_eq!(human_rate(999), "999 B/s");
+        assert_eq!(human_rate(2048), "2.0 KiB/s");
+        assert_eq!(human_rate(1_572_864), "1.5 MiB/s");
+    }
+
+    #[test]
+    fn unknown_size_progress_omits_percent_and_eta() {
+        let progress = format_download_progress(4096, None, 2048);
+
+        assert!(progress.contains("4.0 KiB"));
+        assert!(progress.contains("(total unknown)"));
+        assert!(progress.contains("2.0 KiB/s"));
+        assert!(!progress.contains('%'));
+        assert!(!progress.contains("eta"));
+    }
 }

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -138,6 +138,13 @@ fn verify_sha256(path: &Path, expected: &str) -> Result<(), AsrError> {
 }
 
 const DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_secs(2);
+/// Tolerance over the server's Content-Length before aborting an over-large
+/// download (a compromised/MITM host could otherwise fill the disk before the
+/// post-download checksum runs).
+const DOWNLOAD_SIZE_GRACE: u64 = 1024 * 1024; // 1 MiB
+/// Hard ceiling when the server sends no Content-Length — bounds an unbounded
+/// stream. Comfortably above the largest registered model.
+const MAX_MODEL_DOWNLOAD_BYTES: u64 = 6 * 1024 * 1024 * 1024; // 6 GiB
 
 fn percent_complete(done: u64, total: u64) -> Option<u8> {
     if total == 0 {
@@ -278,6 +285,18 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
             file.write_all(&buf[..n])
                 .map_err(|e| AsrError::Model(format!("write {tmp:?}: {e}")))?;
             bytes_written += n as u64;
+            // Bound the download: cap at Content-Length + grace, or a hard
+            // ceiling when the size is unknown, so a compromised/MITM host
+            // can't fill the disk before the post-download checksum catches it.
+            let limit = total_bytes
+                .map(|t| t.saturating_add(DOWNLOAD_SIZE_GRACE))
+                .unwrap_or(MAX_MODEL_DOWNLOAD_BYTES);
+            if bytes_written > limit {
+                let _ = fs::remove_file(&tmp);
+                return Err(AsrError::Model(format!(
+                    "download exceeded size limit ({bytes_written} > {limit} bytes); aborting"
+                )));
+            }
             let now = Instant::now();
             // saturating: never panic if the monotonic clock appears to go
             // backwards (VM/container clock adjustments).
@@ -482,6 +501,14 @@ mod tests {
         assert_eq!(percent_complete(999, 1000), Some(100));
         assert_eq!(percent_complete(120, 100), Some(100));
         assert_eq!(percent_complete(1, 0), None);
+    }
+
+    #[test]
+    fn format_duration_secs_covers_zero_sub_minute_and_multi_minute() {
+        assert_eq!(format_duration_secs(0), "0s");
+        assert_eq!(format_duration_secs(45), "45s");
+        assert_eq!(format_duration_secs(65), "1m 5s");
+        assert_eq!(format_duration_secs(600), "10m 0s");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes #63. `download()` in `crates/panops-portable/src/model.rs` emitted only a start log and a completion log — so for a ~1.5 GB Whisper model on a slow link the user sees nothing for minutes and can't distinguish a slow download from a hung socket.

## Changes

- `download()` now captures `Response::content_length()` before consuming the body and emits a **throttled** `tracing::info!` progress line roughly every 2s (bytes downloaded, total + percent when known, bytes/sec, ETA), plus a final summary. Existing start/complete logs kept. Benefits all callers (`ensure_model`, `ensure_diar_models`, `ensure_vad_model`) via the shared fn.
- Pure, deterministic helpers for percent / ETA / human-readable rate (+ the unknown-size path) with `#[cfg(test)]` unit tests; time measurement stays in `download()` so the math is testable without network.

## Verification

- `cargo fmt --all` ✅, `cargo build --workspace --locked` ✅, `cargo test -p panops-portable --locked` ✅ (new progress-helper tests pass), `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅.

## Notes

Drafted by an autonomous Codex (`codex exec`) implementer; verified locally. Cold area (`model.rs`) — no overlap with the in-flight slice PRs. Kept draft pending the codex + ai-review gate.