### PR TITLE
Notes: prompt-regression golden gate (CI catches prompt drift)

### DIFF
--- a/crates/panops-core/tests/prompt_regression.rs
+++ b/crates/panops-core/tests/prompt_regression.rs
@@ -141,7 +141,7 @@ fn check_or_regenerate_golden(
 
 #[test]
 fn section_narrative_prompt_goldens() {
-    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").as_deref() == Ok("1");
     let goldens_dir = workspace_root().join("tests/fixtures/prompts");
     std::fs::create_dir_all(&goldens_dir).unwrap();
 
@@ -162,7 +162,7 @@ fn section_narrative_prompt_goldens() {
 
 #[test]
 fn frontmatter_prompt_golden() {
-    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").as_deref() == Ok("1");
     let goldens_dir = workspace_root().join("tests/fixtures/prompts");
     std::fs::create_dir_all(&goldens_dir).unwrap();
 
@@ -176,7 +176,7 @@ fn frontmatter_prompt_golden() {
 
 #[test]
 fn merge_section_prompt_goldens() {
-    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").as_deref() == Ok("1");
     let goldens_dir = workspace_root().join("tests/fixtures/prompts");
     std::fs::create_dir_all(&goldens_dir).unwrap();
 

--- a/crates/panops-core/tests/prompt_regression.rs
+++ b/crates/panops-core/tests/prompt_regression.rs
@@ -1,0 +1,196 @@
+//! Golden-snapshot regression tests for the notes pipeline's LLM prompts.
+//!
+//! CI exercises the notes pipeline only via `MockLlm`, which returns canned
+//! responses regardless of prompt content. This test catches regressions in
+//! the rendered prompt text (system, user, schema) by comparing against
+//! committed golden files.
+//!
+//! Run with `PANOPS_REGEN_PROMPT_GOLDENS=1` to regenerate goldens after
+//! intentional prompt changes.
+
+use panops_core::Segment;
+use panops_core::notes::dialect::MarkdownDialect;
+use panops_core::notes::prompts::{
+    SectionSummary, build_frontmatter_prompt, build_merge_section_prompt,
+    build_section_narrative_prompt,
+};
+
+/// Fixed sample transcript for deterministic golden generation.
+/// Two segments, one with speaker_0, one with speaker_1.
+fn sample_segments() -> Vec<Segment> {
+    vec![
+        Segment {
+            start_ms: 0,
+            end_ms: 5000,
+            text: "Hello, let's discuss the quarterly review.".into(),
+            language_detected: Some("en".into()),
+            confidence: 1.0,
+            is_partial: false,
+            speaker_id: Some(0),
+        },
+        Segment {
+            start_ms: 5000,
+            end_ms: 12_000,
+            text: "Thanks. I'll cover the budget items first.".into(),
+            language_detected: Some("en".into()),
+            confidence: 1.0,
+            is_partial: false,
+            speaker_id: Some(1),
+        },
+    ]
+}
+
+/// Fixed sample summaries for frontmatter and merge prompts.
+fn sample_summaries() -> Vec<SectionSummary> {
+    vec![SectionSummary {
+        title: "Quarterly budget review kickoff".into(),
+        key_points: vec![
+            "Budget scoped to next quarter".into(),
+            "Review sequence: marketing, engineering".into(),
+        ],
+    }]
+}
+
+/// Fixed sample chunk summaries for merge prompt.
+fn sample_chunk_summaries() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::json!({
+            "title": "Part 1: Introduction",
+            "narrative_md": "The meeting opened with a welcome and agenda overview.",
+            "key_points": ["Budget review scoped to Q2"],
+            "action_items": []
+        }),
+        serde_json::json!({
+            "title": "Part 2: Budget discussion",
+            "narrative_md": "The team reviewed the marketing and engineering budgets.",
+            "key_points": ["Marketing budget approved", "Engineering deferred"],
+            "action_items": [{"description": "Finalize engineering budget", "owner": null}]
+        }),
+    ]
+}
+
+/// Find workspace root for golden file paths.
+fn workspace_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|p| p.join("Cargo.toml").exists() && p.join("crates").exists())
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Serialize a prompt (system + user + schema) to a stable string.
+/// Format: three sections separated by `---` fences.
+fn serialize_prompt(
+    system: Option<&str>,
+    user: &str,
+    schema: Option<&serde_json::Value>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("=== SYSTEM ===\n");
+    if let Some(s) = system {
+        out.push_str(s);
+        out.push('\n');
+    } else {
+        out.push_str("(none)\n");
+    }
+    out.push_str("\n=== USER ===\n");
+    out.push_str(user);
+    out.push('\n');
+    out.push_str("\n=== SCHEMA ===\n");
+    if let Some(s) = schema {
+        out.push_str(&serde_json::to_string_pretty(s).unwrap());
+        out.push('\n');
+    } else {
+        out.push_str("(none)\n");
+    }
+    out
+}
+
+/// Check/generate golden for a single prompt. Returns true if mismatch detected.
+fn check_or_regenerate_golden(
+    name: &str,
+    actual: &str,
+    goldens_dir: &std::path::Path,
+    regen: bool,
+) -> bool {
+    let golden_path = goldens_dir.join(format!("{name}.golden.txt"));
+    if regen {
+        std::fs::write(&golden_path, actual).unwrap();
+        eprintln!("regenerated: {}", golden_path.display());
+        return false;
+    }
+    if !golden_path.exists() {
+        panic!(
+            "golden file missing: {}\nRun with PANOPS_REGEN_PROMPT_GOLDENS=1 to generate",
+            golden_path.display()
+        );
+    }
+    let expected = std::fs::read_to_string(&golden_path).unwrap();
+    if actual != expected {
+        eprintln!(
+            "prompt drift detected for '{}'\n\
+             --- expected (golden)\n{}\n\
+             --- actual (current)\n{}\n\
+             Run with PANOPS_REGEN_PROMPT_GOLDENS=1 to re-bless",
+            name, expected, actual
+        );
+        return true;
+    }
+    false
+}
+
+#[test]
+fn section_narrative_prompt_goldens() {
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let goldens_dir = workspace_root().join("tests/fixtures/prompts");
+    std::fs::create_dir_all(&goldens_dir).unwrap();
+
+    let segments = sample_segments();
+    let mut mismatches = 0;
+
+    for dialect in [MarkdownDialect::NotionEnhanced, MarkdownDialect::Basic] {
+        let req = build_section_narrative_prompt(&segments, dialect, "en");
+        let name = format!("section_narrative_{}", dialect.as_str());
+        let serialized = serialize_prompt(req.system.as_deref(), &req.user, req.schema.as_ref());
+        if check_or_regenerate_golden(&name, &serialized, &goldens_dir, regen) {
+            mismatches += 1;
+        }
+    }
+
+    assert_eq!(mismatches, 0, "prompt regression detected");
+}
+
+#[test]
+fn frontmatter_prompt_golden() {
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let goldens_dir = workspace_root().join("tests/fixtures/prompts");
+    std::fs::create_dir_all(&goldens_dir).unwrap();
+
+    let summaries = sample_summaries();
+    let req = build_frontmatter_prompt(&summaries, "en", 60_000);
+    let serialized = serialize_prompt(req.system.as_deref(), &req.user, req.schema.as_ref());
+
+    let mismatch = check_or_regenerate_golden("frontmatter", &serialized, &goldens_dir, regen);
+    assert!(!mismatch, "prompt regression detected");
+}
+
+#[test]
+fn merge_section_prompt_goldens() {
+    let regen = std::env::var("PANOPS_REGEN_PROMPT_GOLDENS").is_ok();
+    let goldens_dir = workspace_root().join("tests/fixtures/prompts");
+    std::fs::create_dir_all(&goldens_dir).unwrap();
+
+    let chunk_summaries = sample_chunk_summaries();
+    let mut mismatches = 0;
+
+    for dialect in [MarkdownDialect::NotionEnhanced, MarkdownDialect::Basic] {
+        let req = build_merge_section_prompt(&chunk_summaries, dialect, "en");
+        let name = format!("merge_section_{}", dialect.as_str());
+        let serialized = serialize_prompt(req.system.as_deref(), &req.user, req.schema.as_ref());
+        if check_or_regenerate_golden(&name, &serialized, &goldens_dir, regen) {
+            mismatches += 1;
+        }
+    }
+
+    assert_eq!(mismatches, 0, "prompt regression detected");
+}

--- a/tests/fixtures/prompts/frontmatter.golden.txt
+++ b/tests/fixtures/prompts/frontmatter.golden.txt
@@ -1,0 +1,42 @@
+=== SYSTEM ===
+You are an expert meeting-notes editor. You receive a list of section titles
+and key points and produce a meeting title and tag list. Title is concise
+(<=80 chars), descriptive, neutral. Tags are lowercase kebab-case, max 10,
+factual (no marketing). You return a single JSON object with the schema you
+are given.
+
+=== USER ===
+Section summaries:
+
+Section 1: Quarterly budget review kickoff
+  - Budget scoped to next quarter
+  - Review sequence: marketing, engineering
+
+Meeting language: en
+Meeting duration: 60000 ms
+
+Return JSON matching exactly:
+{
+  "title": "string (<=80 chars, descriptive)",
+  "tags": ["lowercase-kebab-case", ...] (max 10)
+}
+
+=== SCHEMA ===
+{
+  "properties": {
+    "tags": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title",
+    "tags"
+  ],
+  "type": "object"
+}

--- a/tests/fixtures/prompts/merge_section_basic.golden.txt
+++ b/tests/fixtures/prompts/merge_section_basic.golden.txt
@@ -1,0 +1,96 @@
+=== SYSTEM ===
+You are an expert meeting-notes writer. You receive a diarized transcript
+section and produce a structured narrative summary. You write in clear,
+neutral prose. You NEVER attribute a quote or statement to a specific speaker
+unless that segment carries a confirmed speaker_id from diarization. When
+attribution is ambiguous, write in passive voice ("the team discussed", "a
+concern was raised", "it was proposed that"). You return a single JSON object
+with the schema you are given.
+
+=== USER ===
+Sub-chunk summaries (ordered chronologically):
+
+Chunk 1:
+  Title: Part 1: Introduction
+  Narrative: The meeting opened with a welcome and agenda overview.
+  Key point: Budget review scoped to Q2
+
+Chunk 2:
+  Title: Part 2: Budget discussion
+  Narrative: The team reviewed the marketing and engineering budgets.
+  Key point: Marketing budget approved
+  Key point: Engineering deferred
+  Action: - Finalize engineering budget (owner: unassigned)
+
+
+Markdown dialect for `narrative_md`:
+You are emitting strict CommonMark. Allowed constructs:
+- Headings (#, ##, ###).
+- Unordered lists (-) and ordered lists (1.).
+- Pipe tables.
+- Fenced code blocks with language tags.
+- Blockquotes (>).
+- Links and image embeds.
+NEVER emit HTML tags, callouts, color attributes, or Notion-specific extensions.
+This is for Obsidian / GitHub / vanilla CommonMark viewers.
+
+Output language: en
+
+Merge these sub-chunks into a single unified section summary.
+- Combine narratives into flowing prose (no bullet lists).
+- Deduplicate key_points: keep distinct facts, merge overlapping.
+- Deduplicate action_items: keep distinct commitments.
+- Title should represent the unified theme.
+
+Return JSON matching exactly:
+{
+  "title": "string (descriptive, <80 chars)",
+  "narrative_md": "string (prose only, in the dialect above)",
+  "key_points": ["string", ...],
+  "action_items": [{"description": "string", "owner": "speaker_0"}] or [{"description": "string", "owner": null}]
+}
+
+=== SCHEMA ===
+{
+  "properties": {
+    "action_items": {
+      "items": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "key_points": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "narrative_md": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title",
+    "narrative_md",
+    "key_points",
+    "action_items"
+  ],
+  "type": "object"
+}

--- a/tests/fixtures/prompts/merge_section_notion-enhanced.golden.txt
+++ b/tests/fixtures/prompts/merge_section_notion-enhanced.golden.txt
@@ -1,0 +1,95 @@
+=== SYSTEM ===
+You are an expert meeting-notes writer. You receive a diarized transcript
+section and produce a structured narrative summary. You write in clear,
+neutral prose. You NEVER attribute a quote or statement to a specific speaker
+unless that segment carries a confirmed speaker_id from diarization. When
+attribution is ambiguous, write in passive voice ("the team discussed", "a
+concern was raised", "it was proposed that"). You return a single JSON object
+with the schema you are given.
+
+=== USER ===
+Sub-chunk summaries (ordered chronologically):
+
+Chunk 1:
+  Title: Part 1: Introduction
+  Narrative: The meeting opened with a welcome and agenda overview.
+  Key point: Budget review scoped to Q2
+
+Chunk 2:
+  Title: Part 2: Budget discussion
+  Narrative: The team reviewed the marketing and engineering budgets.
+  Key point: Marketing budget approved
+  Key point: Engineering deferred
+  Action: - Finalize engineering budget (owner: unassigned)
+
+
+Markdown dialect for `narrative_md`:
+You are emitting Notion-flavored markdown. Allowed constructs:
+- CommonMark: headings (#, ##, ###), lists (-, 1.), tables, fenced code blocks, blockquotes, links, images.
+- <callout icon="🎯">…</callout> for highlighted notes.
+- <details><summary>Title</summary>…</details> for collapsible blocks.
+- <table>…</table> with explicit <tr>/<td> for rich tables.
+- {color="red"} after a paragraph or heading for block colors.
+- Inline mentions: @user, @date.
+NEVER emit raw HTML beyond the listed tags. NEVER nest callouts.
+
+Output language: en
+
+Merge these sub-chunks into a single unified section summary.
+- Combine narratives into flowing prose (no bullet lists).
+- Deduplicate key_points: keep distinct facts, merge overlapping.
+- Deduplicate action_items: keep distinct commitments.
+- Title should represent the unified theme.
+
+Return JSON matching exactly:
+{
+  "title": "string (descriptive, <80 chars)",
+  "narrative_md": "string (prose only, in the dialect above)",
+  "key_points": ["string", ...],
+  "action_items": [{"description": "string", "owner": "speaker_0"}] or [{"description": "string", "owner": null}]
+}
+
+=== SCHEMA ===
+{
+  "properties": {
+    "action_items": {
+      "items": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "key_points": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "narrative_md": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title",
+    "narrative_md",
+    "key_points",
+    "action_items"
+  ],
+  "type": "object"
+}

--- a/tests/fixtures/prompts/section_narrative_basic.golden.txt
+++ b/tests/fixtures/prompts/section_narrative_basic.golden.txt
@@ -1,0 +1,98 @@
+=== SYSTEM ===
+You are an expert meeting-notes writer. You receive a diarized transcript
+section and produce a structured narrative summary. You write in clear,
+neutral prose. You NEVER attribute a quote or statement to a specific speaker
+unless that segment carries a confirmed speaker_id from diarization. When
+attribution is ambiguous, write in passive voice ("the team discussed", "a
+concern was raised", "it was proposed that"). You return a single JSON object
+with the schema you are given.
+
+=== USER ===
+Section transcript (diarized; speaker_X is a stable label per voice):
+
+[   0–   5s] speaker_0: Hello, let's discuss the quarterly review.
+[   5–  12s] speaker_1: Thanks. I'll cover the budget items first.
+
+Markdown dialect for `narrative_md`:
+You are emitting strict CommonMark. Allowed constructs:
+- Headings (#, ##, ###).
+- Unordered lists (-) and ordered lists (1.).
+- Pipe tables.
+- Fenced code blocks with language tags.
+- Blockquotes (>).
+- Links and image embeds.
+NEVER emit HTML tags, callouts, color attributes, or Notion-specific extensions.
+This is for Obsidian / GitHub / vanilla CommonMark viewers.
+
+Output language: en
+
+Speaker attribution rule (STRICT): never attribute a quote to a speaker_id
+that does not appear in the transcript. When in doubt, use passive voice.
+
+Non-duplication rule (STRICT): `narrative_md`, `key_points`, and `action_items`
+must NOT restate the same facts in different shapes. They are three
+distinct views of the section:
+- `narrative_md`: connective prose — context, who arrived/left, how the
+conversation moved, transitions between topics, mood/tone where it
+matters. NO bullet lists. NO embedded "Key points:" or "Action items:"
+sections. Do NOT restate the bullets in prose form.
+- `key_points`: durable takeaways the reader scans for later — facts,
+numbers, decisions, named outcomes. Punchy and self-contained. Each
+bullet is a fact that does NOT appear (in any paraphrase) in
+`narrative_md`.
+- `action_items`: explicit commitments — "who will do what by when".
+A commitment that is also a key takeaway belongs HERE, not in
+`key_points`. Owner is a speaker_id (or null when unassigned).
+
+Return JSON matching exactly:
+{
+  "title": "string (descriptive, <80 chars)",
+  "narrative_md": "string (prose only — no bullets — in the dialect above; up to 400 words, scaled to section length)",
+  "key_points": ["string", ...] (0–6 short bullets, each a fact NOT in narrative_md),
+  "action_items": [{"description": "string", "owner": "speaker_0"}] or [{"description": "string", "owner": null}]
+}
+
+=== SCHEMA ===
+{
+  "properties": {
+    "action_items": {
+      "items": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "key_points": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "narrative_md": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title",
+    "narrative_md",
+    "key_points",
+    "action_items"
+  ],
+  "type": "object"
+}

--- a/tests/fixtures/prompts/section_narrative_notion-enhanced.golden.txt
+++ b/tests/fixtures/prompts/section_narrative_notion-enhanced.golden.txt
@@ -1,0 +1,97 @@
+=== SYSTEM ===
+You are an expert meeting-notes writer. You receive a diarized transcript
+section and produce a structured narrative summary. You write in clear,
+neutral prose. You NEVER attribute a quote or statement to a specific speaker
+unless that segment carries a confirmed speaker_id from diarization. When
+attribution is ambiguous, write in passive voice ("the team discussed", "a
+concern was raised", "it was proposed that"). You return a single JSON object
+with the schema you are given.
+
+=== USER ===
+Section transcript (diarized; speaker_X is a stable label per voice):
+
+[   0–   5s] speaker_0: Hello, let's discuss the quarterly review.
+[   5–  12s] speaker_1: Thanks. I'll cover the budget items first.
+
+Markdown dialect for `narrative_md`:
+You are emitting Notion-flavored markdown. Allowed constructs:
+- CommonMark: headings (#, ##, ###), lists (-, 1.), tables, fenced code blocks, blockquotes, links, images.
+- <callout icon="🎯">…</callout> for highlighted notes.
+- <details><summary>Title</summary>…</details> for collapsible blocks.
+- <table>…</table> with explicit <tr>/<td> for rich tables.
+- {color="red"} after a paragraph or heading for block colors.
+- Inline mentions: @user, @date.
+NEVER emit raw HTML beyond the listed tags. NEVER nest callouts.
+
+Output language: en
+
+Speaker attribution rule (STRICT): never attribute a quote to a speaker_id
+that does not appear in the transcript. When in doubt, use passive voice.
+
+Non-duplication rule (STRICT): `narrative_md`, `key_points`, and `action_items`
+must NOT restate the same facts in different shapes. They are three
+distinct views of the section:
+- `narrative_md`: connective prose — context, who arrived/left, how the
+conversation moved, transitions between topics, mood/tone where it
+matters. NO bullet lists. NO embedded "Key points:" or "Action items:"
+sections. Do NOT restate the bullets in prose form.
+- `key_points`: durable takeaways the reader scans for later — facts,
+numbers, decisions, named outcomes. Punchy and self-contained. Each
+bullet is a fact that does NOT appear (in any paraphrase) in
+`narrative_md`.
+- `action_items`: explicit commitments — "who will do what by when".
+A commitment that is also a key takeaway belongs HERE, not in
+`key_points`. Owner is a speaker_id (or null when unassigned).
+
+Return JSON matching exactly:
+{
+  "title": "string (descriptive, <80 chars)",
+  "narrative_md": "string (prose only — no bullets — in the dialect above; up to 400 words, scaled to section length)",
+  "key_points": ["string", ...] (0–6 short bullets, each a fact NOT in narrative_md),
+  "action_items": [{"description": "string", "owner": "speaker_0"}] or [{"description": "string", "owner": null}]
+}
+
+=== SCHEMA ===
+{
+  "properties": {
+    "action_items": {
+      "items": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "key_points": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "narrative_md": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "title",
+    "narrative_md",
+    "key_points",
+    "action_items"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## What

Closes #22. CI exercises the notes pipeline only via `MockLlm`, which returns canned responses regardless of prompt **content** — so a regression in the rendered LLM prompts (instructions, schema, dialect text) was caught by nothing.

## Changes

- `crates/panops-core/tests/prompt_regression.rs` — 3 tests that build `build_section_narrative_prompt`, `build_frontmatter_prompt`, `build_merge_section_prompt` with fixed deterministic inputs and snapshot the full rendered prompt (system + user + serialized schema) to committed goldens.
- `tests/fixtures/prompts/*.golden.txt` — 5 goldens (section_narrative × 2 dialects, merge_section × 2 dialects, frontmatter).
- Any prompt drift now fails CI; regeneration is opt-in via `PANOPS_REGEN_PROMPT_GOLDENS=1` (mirrors the existing notes-goldens pattern).

## Verification
`cargo fmt --all` ✅, `cargo build --workspace --locked` ✅, `cargo test -p panops-core --locked` ✅, `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅.

Drafted by an autonomous claudea implementer; verified locally. Cold area (panops-core notes tests) — non-conflicting with the in-flight slice PRs.