### PR TITLE
IPC: bound concurrent notes.generate jobs (Semaphore)

### DIFF
--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -125,16 +125,36 @@ impl IpcServer for IpcImpl {
         let events_tx = self.events_tx.clone();
         let job_id_owned = job_id.clone();
 
+        // Backpressure heavy note generation before it reaches tokio's
+        // blocking pool. A permit is held for the whole synchronous
+        // pipeline, so a burst of RPC calls cannot enqueue unbounded
+        // decoded audio / ASR / diarization / LLM work and exhaust RAM.
+        // Calls beyond `MAX_CONCURRENT_NOTES_JOBS` wait here, then still
+        // return the job id immediately after their job is accepted
+        // (results continue to arrive through `events.subscribe`).
+        let notes_job_permit = services
+            .notes_jobs
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "notes.generate semaphore closed");
+                ipc_error_to_obj(IpcError::Internal {
+                    message: "notes.generate internal error".into(),
+                })
+            })?;
+
         // Move the pipeline off any tokio worker thread: rayon (used by
         // `NotesGenerator` for the per-section fan-out) and the blocking
         // ASR/diar adapters mustn't share a runtime worker with the RPC
         // accept loop. `spawn_blocking` drops them on the dedicated
-        // blocking pool. The `notes.generate` RPC returns immediately;
-        // the actual result lands on `events.subscribe` as `JobDone`
-        // or `JobError`.
+        // blocking pool. The `notes.generate` RPC returns immediately
+        // after accepting a bounded job; the actual result lands on
+        // `events.subscribe` as `JobDone` or `JobError`.
         let job_id_for_panic = job_id.clone();
         let events_tx_for_panic = events_tx.clone();
         let join_handle = tokio::task::spawn_blocking(move || {
+            let _notes_job_permit = notes_job_permit;
             let outcome = run_notes_pipeline(&services, &params);
             match outcome {
                 Ok(result) => {
@@ -947,5 +967,214 @@ mod readiness_tests {
             }
             other => panic!("expected Internal, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod notes_generate_concurrency_tests {
+    use super::{IpcImpl, IpcServer};
+    use crate::server::MAX_CONCURRENT_NOTES_JOBS;
+    use panops_core::conformance::fakes::{
+        FakeNotesExporter, InMemoryStorage, KnownTurnsFake, TranscriptFileFake,
+    };
+    use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
+    use panops_core::vad::{SpeechRegion, Vad, VadError};
+    use panops_protocol::{Event, NotesDialect, NotesGenerateParams};
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
+    use tokio::sync::broadcast;
+
+    struct ConcurrencyProbe {
+        in_flight: AtomicUsize,
+        max_seen: AtomicUsize,
+        section_calls_started: AtomicUsize,
+        released: Mutex<bool>,
+        wait_cv: Condvar,
+    }
+
+    impl ConcurrencyProbe {
+        fn new() -> Self {
+            Self {
+                in_flight: AtomicUsize::new(0),
+                max_seen: AtomicUsize::new(0),
+                section_calls_started: AtomicUsize::new(0),
+                released: Mutex::new(false),
+                wait_cv: Condvar::new(),
+            }
+        }
+
+        fn enter_blocking_section_call(&self) {
+            self.section_calls_started.fetch_add(1, Ordering::SeqCst);
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_seen.fetch_max(now, Ordering::SeqCst);
+
+            let mut released = self.released.lock().expect("probe mutex poisoned");
+            while !*released {
+                released = self.wait_cv.wait(released).expect("probe condvar poisoned");
+            }
+
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
+
+        fn release_all(&self) {
+            *self.released.lock().expect("probe mutex poisoned") = true;
+            self.wait_cv.notify_all();
+        }
+
+        async fn wait_for_started(&self, expected: usize) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    if self.section_calls_started.load(Ordering::SeqCst) >= expected {
+                        return;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("timed out waiting for bounded jobs to enter LLM");
+        }
+    }
+
+    struct BlockingSectionLlm {
+        probe: Arc<ConcurrencyProbe>,
+    }
+
+    impl LlmProvider for BlockingSectionLlm {
+        fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            let system = req.system.as_deref().unwrap_or_default();
+            if system.contains("meeting-notes writer") {
+                self.probe.enter_blocking_section_call();
+                return Ok(LlmResponse::Json(serde_json::json!({
+                    "title": "Bounded notes job",
+                    "narrative_md": "The meeting was summarized without exceeding the concurrency bound.",
+                    "key_points": ["Concurrency stayed bounded"],
+                    "action_items": [{"description": "Keep job backpressure in place", "owner": null}]
+                })));
+            }
+
+            if system.contains("meeting-notes editor") {
+                return Ok(LlmResponse::Json(serde_json::json!({
+                    "title": "Bounded notes jobs",
+                    "tags": ["bounded-concurrency"]
+                })));
+            }
+
+            Err(LlmError::Provider(format!(
+                "unexpected prompt system: {system:?}"
+            )))
+        }
+    }
+
+    struct AllSpeechVad;
+
+    impl Vad for AllSpeechVad {
+        fn detect_speech(
+            &self,
+            samples: &[f32],
+            sample_rate: u32,
+        ) -> Result<Vec<SpeechRegion>, VadError> {
+            Ok(vec![SpeechRegion {
+                start_ms: 0,
+                end_ms: (samples.len() as u64 * 1000) / u64::from(sample_rate),
+            }])
+        }
+    }
+
+    fn notes_params(audio_path: &Path) -> NotesGenerateParams {
+        NotesGenerateParams {
+            audio: audio_path.to_string_lossy().into_owned(),
+            dialect: Some(NotesDialect::Basic),
+            llm_provider: None,
+            llm_model: None,
+            no_diarize: Some(true),
+            language: Some("en".into()),
+            meeting_id: None,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn notes_generate_runs_no_more_than_max_concurrent_jobs() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("repo root above crates/panops-engine");
+        let audio_path = repo_root
+            .join("tests")
+            .join("fixtures")
+            .join("audio")
+            .join("multi_speaker_60s.wav");
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let probe = Arc::new(ConcurrencyProbe::new());
+        let services = crate::server::EngineServices::ready(
+            Arc::new(BlockingSectionLlm {
+                probe: probe.clone(),
+            }),
+            Arc::new(InMemoryStorage::new()),
+            data_dir.path().to_path_buf(),
+            Arc::new(TranscriptFileFake::from_text(
+                "The team reviewed bounded job concurrency.",
+                Some("en"),
+            )),
+            Arc::new(KnownTurnsFake),
+            Arc::new(FakeNotesExporter),
+            Arc::new(AllSpeechVad),
+        );
+        let (events_tx, mut events_rx) = broadcast::channel(16);
+        let ipc = Arc::new(IpcImpl {
+            services: Arc::new(services),
+            events_tx,
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+        });
+
+        let total_jobs = MAX_CONCURRENT_NOTES_JOBS + 2;
+        let mut rpc_handles = Vec::with_capacity(total_jobs);
+        for _ in 0..total_jobs {
+            let ipc = ipc.clone();
+            let params = notes_params(&audio_path);
+            rpc_handles.push(tokio::spawn(
+                async move { ipc.notes_generate(params).await },
+            ));
+        }
+
+        probe.wait_for_started(MAX_CONCURRENT_NOTES_JOBS).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            probe.section_calls_started.load(Ordering::SeqCst),
+            MAX_CONCURRENT_NOTES_JOBS,
+            "jobs beyond the semaphore bound should not enter the pipeline while permits are held",
+        );
+        assert_eq!(
+            probe.max_seen.load(Ordering::SeqCst),
+            MAX_CONCURRENT_NOTES_JOBS,
+            "more notes jobs ran concurrently than the configured semaphore bound",
+        );
+
+        probe.release_all();
+
+        for handle in rpc_handles {
+            let accepted = tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .expect("notes.generate RPC task should return")
+                .expect("notes.generate RPC task should not panic")
+                .expect("notes.generate should accept bounded job");
+            assert!(!accepted.job_id.is_empty());
+        }
+
+        let mut done = 0;
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while done < total_jobs {
+                match events_rx.recv().await.expect("events channel open") {
+                    Event::JobDone(_) => done += 1,
+                    Event::JobError(e) => panic!("notes job errored: {:?}", e.error),
+                    Event::Unknown(v) => panic!("unexpected unknown event: {v}"),
+                    Event::Screenshot(_) | Event::RecordingProgress(_) => {}
+                }
+            }
+        })
+        .await
+        .expect("all accepted notes jobs should finish");
     }
 }

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -125,60 +125,67 @@ impl IpcServer for IpcImpl {
         let events_tx = self.events_tx.clone();
         let job_id_owned = job_id.clone();
 
-        // Backpressure heavy note generation before it reaches tokio's
-        // blocking pool. A permit is held for the whole synchronous
-        // pipeline, so a burst of RPC calls cannot enqueue unbounded
-        // decoded audio / ASR / diarization / LLM work and exhaust RAM.
-        // Calls beyond `MAX_CONCURRENT_NOTES_JOBS` wait here, then still
-        // return the job id immediately after their job is accepted
-        // (results continue to arrive through `events.subscribe`).
-        let notes_job_permit = services
-            .notes_jobs
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "notes.generate semaphore closed");
-                ipc_error_to_obj(IpcError::Internal {
-                    message: "notes.generate internal error".into(),
-                })
-            })?;
-
-        // Move the pipeline off any tokio worker thread: rayon (used by
-        // `NotesGenerator` for the per-section fan-out) and the blocking
-        // ASR/diar adapters mustn't share a runtime worker with the RPC
-        // accept loop. `spawn_blocking` drops them on the dedicated
-        // blocking pool. The `notes.generate` RPC returns immediately
-        // after accepting a bounded job; the actual result lands on
+        // Accept the job and return its id immediately. ALL heavy work — the
+        // backpressure wait AND the synchronous pipeline — runs off the RPC
+        // accept path, so the `{job_id}`-then-events contract holds even under
+        // load: the caller never blocks waiting for a permit. Results land on
         // `events.subscribe` as `JobDone` or `JobError`.
-        let job_id_for_panic = job_id.clone();
-        let events_tx_for_panic = events_tx.clone();
-        let join_handle = tokio::task::spawn_blocking(move || {
-            let _notes_job_permit = notes_job_permit;
-            let outcome = run_notes_pipeline(&services, &params);
-            match outcome {
-                Ok(result) => {
-                    let _ = events_tx.send(Event::JobDone(JobDoneEvent {
-                        job_id: job_id_owned,
-                        result,
-                    }));
-                }
-                Err(error) => {
+        tokio::spawn(async move {
+            // Backpressure heavy note generation before it reaches tokio's
+            // blocking pool. A permit is held for the whole synchronous
+            // pipeline, so a burst of jobs cannot enqueue unbounded decoded
+            // audio / ASR / diarization / LLM work and exhaust RAM. Jobs
+            // beyond `MAX_CONCURRENT_NOTES_JOBS` wait here (off the RPC path).
+            let notes_job_permit = match services.notes_jobs.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(e) => {
+                    // `acquire_owned` errors only when the semaphore is
+                    // permanently closed (engine shutdown) — not the normal
+                    // wait-when-full case. The job id was already returned, so
+                    // surface the failure as a `JobError` event, not an RPC error.
+                    tracing::error!(error = %e, "notes.generate semaphore permanently closed");
                     let _ = events_tx.send(Event::JobError(JobErrorEvent {
                         job_id: job_id_owned,
-                        error,
+                        error: IpcError::Internal {
+                            message: "notes.generate internal error".into(),
+                        },
                     }));
+                    return;
                 }
-            }
-        });
+            };
 
-        // Awaiter for the blocking task. Without this, a panic inside
-        // the closure (MockLlm fingerprint mismatch, rayon panic, OOM)
-        // is silently swallowed when the JoinHandle drops, leaving
-        // subscribers waiting forever. We turn a JoinError into a
-        // synthetic `JobError` event with an opaque `Internal` message
-        // so the wire never leaks panic payloads or filesystem paths.
-        tokio::spawn(async move {
+            // Move the pipeline off any tokio worker thread: rayon (used by
+            // `NotesGenerator` for the per-section fan-out) and the blocking
+            // ASR/diar adapters mustn't share a runtime worker with the RPC
+            // accept loop. `spawn_blocking` drops them on the dedicated
+            // blocking pool.
+            let job_id_for_panic = job_id_owned.clone();
+            let events_tx_for_panic = events_tx.clone();
+            let join_handle = tokio::task::spawn_blocking(move || {
+                let _notes_job_permit = notes_job_permit;
+                let outcome = run_notes_pipeline(&services, &params);
+                match outcome {
+                    Ok(result) => {
+                        let _ = events_tx.send(Event::JobDone(JobDoneEvent {
+                            job_id: job_id_owned,
+                            result,
+                        }));
+                    }
+                    Err(error) => {
+                        let _ = events_tx.send(Event::JobError(JobErrorEvent {
+                            job_id: job_id_owned,
+                            error,
+                        }));
+                    }
+                }
+            });
+
+            // Awaiter for the blocking task. Without this, a panic inside
+            // the closure (MockLlm fingerprint mismatch, rayon panic, OOM)
+            // is silently swallowed when the JoinHandle drops, leaving
+            // subscribers waiting forever. We turn a JoinError into a
+            // synthetic `JobError` event with an opaque `Internal` message
+            // so the wire never leaks panic payloads or filesystem paths.
             if let Err(join_err) = join_handle.await {
                 let msg = if join_err.is_panic() {
                     "pipeline panicked".to_string()

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -50,9 +50,10 @@ use crate::server::handlers::{IpcImpl, IpcServer};
 /// diarization state, transcript JSON, and LLM prompt/response payloads, so
 /// keeping this small protects the local Mac from memory exhaustion while
 /// still allowing one foreground job plus one queued/secondary job to make
-/// progress. Additional RPC calls wait for a permit before their blocking
-/// pipeline is spawned, providing backpressure instead of unbounded work.
-pub const MAX_CONCURRENT_NOTES_JOBS: usize = 2;
+/// progress. Additional jobs wait for a permit (off the RPC accept path)
+/// before their blocking pipeline is spawned, providing backpressure instead
+/// of unbounded work.
+pub(super) const MAX_CONCURRENT_NOTES_JOBS: usize = 2;
 
 /// Heavy adapter trio loaded together — bundled so the `OnceLock` swap
 /// is atomic (one set, all three present) and so `notes.generate`'s

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -40,9 +40,19 @@ use panops_core::exporter::NotesExporter;
 use panops_core::llm::LlmProvider;
 use panops_core::storage::Storage;
 use panops_core::vad::Vad;
-use tokio::sync::watch;
+use tokio::sync::{Semaphore, watch};
 
 use crate::server::handlers::{IpcImpl, IpcServer};
+
+/// Maximum number of `notes.generate` pipelines allowed to run at once.
+///
+/// Each notes job can hold a decoded audio buffer, ASR intermediates,
+/// diarization state, transcript JSON, and LLM prompt/response payloads, so
+/// keeping this small protects the local Mac from memory exhaustion while
+/// still allowing one foreground job plus one queued/secondary job to make
+/// progress. Additional RPC calls wait for a permit before their blocking
+/// pipeline is spawned, providing backpressure instead of unbounded work.
+pub const MAX_CONCURRENT_NOTES_JOBS: usize = 2;
 
 /// Heavy adapter trio loaded together — bundled so the `OnceLock` swap
 /// is atomic (one set, all three present) and so `notes.generate`'s
@@ -83,6 +93,7 @@ pub struct EngineServices {
     /// CLI; tests inject a `tempfile::TempDir.path()`.
     pub data_dir: PathBuf,
     pub(super) heavy: Arc<OnceLock<Result<HeavyAdapters, String>>>,
+    pub(super) notes_jobs: Arc<Semaphore>,
 }
 
 impl EngineServices {
@@ -110,6 +121,7 @@ impl EngineServices {
             storage,
             data_dir,
             heavy,
+            notes_jobs: Arc::new(Semaphore::new(MAX_CONCURRENT_NOTES_JOBS)),
         }
     }
 
@@ -134,6 +146,7 @@ impl EngineServices {
             storage,
             data_dir,
             heavy: heavy.clone(),
+            notes_jobs: Arc::new(Semaphore::new(MAX_CONCURRENT_NOTES_JOBS)),
         };
         (services, heavy)
     }
@@ -393,8 +406,8 @@ pub async fn run_serve_in_process(
     // ceiling. When the cap is hit, `try_acquire` returns `None` and
     // the per-request handler responds with HTTP 429 (`too_many_requests`)
     // rather than stalling — keeps a runaway client from exhausting the
-    // accept loop. Revisit alongside the DoS bound on `notes.generate`
-    // (filed as issue #85, severity:high).
+    // accept loop. `notes.generate` has its own job-level semaphore
+    // because each accepted connection can otherwise enqueue heavy work.
     let conn_guard = Arc::new(ConnectionGuard::new(100));
 
     let cleanup_path = path.to_path_buf();

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -122,7 +122,7 @@ impl EngineServices {
             storage,
             data_dir,
             heavy,
-            notes_jobs: Arc::new(Semaphore::new(MAX_CONCURRENT_NOTES_JOBS)),
+            notes_jobs: Self::new_notes_jobs(),
         }
     }
 
@@ -147,9 +147,16 @@ impl EngineServices {
             storage,
             data_dir,
             heavy: heavy.clone(),
-            notes_jobs: Arc::new(Semaphore::new(MAX_CONCURRENT_NOTES_JOBS)),
+            notes_jobs: Self::new_notes_jobs(),
         };
         (services, heavy)
+    }
+
+    /// Single source of truth for the notes-job backpressure semaphore so
+    /// every constructor shares one bound — a new constructor (builder,
+    /// test factory) can't silently drift `MAX_CONCURRENT_NOTES_JOBS`.
+    fn new_notes_jobs() -> Arc<Semaphore> {
+        Arc::new(Semaphore::new(MAX_CONCURRENT_NOTES_JOBS))
     }
 }
 


### PR DESCRIPTION
Closes #85. Adds a bounded `tokio::sync::Semaphore` (MAX_CONCURRENT_NOTES_JOBS) in EngineServices so a burst of `notes.generate` RPCs applies backpressure before hitting the blocking pool, instead of spawning unboundedly (OOM risk). The owned permit moves into the spawn_blocking closure so the slot is held until the heavy pipeline finishes. Test asserts the cap. Gate green (workspace build/test/clippy). Codex-built; reviews pending.