### PR TITLE
ASR: cache sha256 verification for the large model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ dependencies = [
  "panops-core",
  "reqwest 0.12.28",
  "rusqlite",
+ "serde",
  "serde_json",
  "sha2",
  "sherpa-rs",

--- a/crates/panops-portable/Cargo.toml
+++ b/crates/panops-portable/Cargo.toml
@@ -20,6 +20,7 @@ tar = "0.4"
 bzip2 = "0.6"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 genai = "=0.5.3"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 tracing = "0.1"

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -143,7 +143,14 @@ fn verification_cache_valid(model_path: &Path, expected_sha256: &str) -> bool {
     let current_size = metadata.len();
     let (current_mtime_secs, current_mtime_nanos) = mtime_parts(current_mtime);
 
-    // Size and mtime must match.
+    // Trust file metadata (size + mtime) as a proxy for "unchanged since we
+    // last verified its sha256". This is a STARTUP-PERF optimization, not a
+    // security boundary: the multi-GB model is re-hashed on first acquisition
+    // (download integrity is fully verified there), and the model dir is the
+    // user's own local Application Support dir. A local actor who replaces the
+    // file preserving both size AND mtime would bypass re-verification — that's
+    // out of scope (same local-operator-trust posture as the sidecar-bin path).
+    // Any size/mtime change (the normal case for a real replacement) re-verifies.
     if marker.size != current_size {
         return false;
     }

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -119,19 +119,32 @@ fn write_verification_marker(marker_path: &Path, sha256: &str, size: u64, mtime:
 /// source for the post-verify marker write so the four `ensure_*` paths
 /// (cache-miss verify + post-download verify, for model and vad) don't
 /// duplicate the metadata read.
-fn mark_verified(file_path: &Path, sha256: &str) -> Result<(), AsrError> {
-    let metadata = fs::metadata(file_path)
-        .map_err(|e| AsrError::Model(format!("metadata {file_path:?}: {e}")))?;
-    let mtime = metadata
-        .modified()
-        .map_err(|e| AsrError::Model(format!("mtime {file_path:?}: {e}")))?;
+///
+/// Best-effort: the marker is purely a startup-perf cache, so a transient
+/// failure to stat the file (e.g. it was unlinked right after verify) is
+/// logged and ignored rather than failing model setup — the next run just
+/// re-verifies. Paths stay in the local log, never in a returned error.
+fn mark_verified(file_path: &Path, sha256: &str) {
+    let metadata = match fs::metadata(file_path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(path = ?file_path, error = %e, "skip verification marker (metadata)");
+            return;
+        }
+    };
+    let mtime = match metadata.modified() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(path = ?file_path, error = %e, "skip verification marker (mtime)");
+            return;
+        }
+    };
     write_verification_marker(
         &verification_marker_path(file_path),
         sha256,
         metadata.len(),
         mtime,
     );
-    Ok(())
 }
 
 /// Check if the verification cache is valid for a given model file.
@@ -497,7 +510,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
             } else {
                 verify_sha256(dest, info.sha256)?;
                 // Write marker after successful verify.
-                mark_verified(dest, info.sha256)?;
+                mark_verified(dest, info.sha256);
             }
         }
         return Ok(dest.to_path_buf());
@@ -517,7 +530,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         return Err(e);
     }
     // Write marker after successful download + verify.
-    mark_verified(dest, info.sha256)?;
+    mark_verified(dest, info.sha256);
     tracing::info!(bytes = n, dest = ?dest, "model download complete");
     Ok(dest.to_path_buf())
 }
@@ -629,7 +642,7 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
             } else {
                 verify_sha256(dest, info.sha256)?;
                 // Write marker after successful verify.
-                mark_verified(dest, info.sha256)?;
+                mark_verified(dest, info.sha256);
             }
         }
         return Ok(dest.to_path_buf());
@@ -647,7 +660,7 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
         return Err(e);
     }
     // Write marker after successful download + verify.
-    mark_verified(dest, info.sha256)?;
+    mark_verified(dest, info.sha256);
     tracing::info!(bytes = n, dest = ?dest, "vad model download complete");
     Ok(dest.to_path_buf())
 }

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -72,9 +72,11 @@ struct VerificationMarker {
     sha256: String,
     /// File size in bytes at verification time.
     size: u64,
-    /// File modification time as Unix timestamp (seconds since epoch).
-    /// Using duration_since UNIX_EPOCH for portability.
+    /// File modification time seconds component since Unix epoch.
+    /// Stored with nanoseconds below so same-second rewrites re-verify.
     mtime_secs: u64,
+    /// File modification time nanoseconds component within `mtime_secs`.
+    mtime_nanos: u32,
 }
 
 /// Returns the path to the verification marker file for a given model path.
@@ -91,16 +93,21 @@ fn read_verification_marker(marker_path: &Path) -> Option<VerificationMarker> {
     serde_json::from_str(&contents).ok()
 }
 
+fn mtime_parts(mtime: SystemTime) -> (u64, u32) {
+    let duration = mtime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    (duration.as_secs(), duration.subsec_nanos())
+}
+
 /// Write the verification marker after a successful sha256 verify.
 fn write_verification_marker(marker_path: &Path, sha256: &str, size: u64, mtime: SystemTime) {
-    let mtime_secs = mtime
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let (mtime_secs, mtime_nanos) = mtime_parts(mtime);
     let marker = VerificationMarker {
         sha256: sha256.to_string(),
         size,
         mtime_secs,
+        mtime_nanos,
     };
     let contents = serde_json::to_string(&marker).unwrap_or_default();
     // Ignore write errors — marker is optional; next run will re-verify.
@@ -134,16 +141,16 @@ fn verification_cache_valid(model_path: &Path, expected_sha256: &str) -> bool {
         return false;
     };
     let current_size = metadata.len();
-    let current_mtime_secs = current_mtime
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let (current_mtime_secs, current_mtime_nanos) = mtime_parts(current_mtime);
 
     // Size and mtime must match.
     if marker.size != current_size {
         return false;
     }
     if marker.mtime_secs != current_mtime_secs {
+        return false;
+    }
+    if marker.mtime_nanos != current_mtime_nanos {
         return false;
     }
 
@@ -662,6 +669,45 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn set_file_mtime(path: &Path, secs: std::ffi::c_long, nanos: std::ffi::c_long) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        #[repr(C)]
+        struct Timespec {
+            tv_sec: std::ffi::c_long,
+            tv_nsec: std::ffi::c_long,
+        }
+
+        unsafe extern "C" {
+            fn utimensat(
+                dirfd: std::ffi::c_int,
+                pathname: *const std::ffi::c_char,
+                times: *const Timespec,
+                flags: std::ffi::c_int,
+            ) -> std::ffi::c_int;
+        }
+
+        const AT_FDCWD: std::ffi::c_int = -100;
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let times = [
+            Timespec {
+                tv_sec: secs,
+                tv_nsec: nanos,
+            },
+            Timespec {
+                tv_sec: secs,
+                tv_nsec: nanos,
+            },
+        ];
+
+        // SAFETY: `path` is a valid, NUL-terminated CString and `times` points to
+        // two initialized POSIX timespec values for atime and mtime.
+        let result = unsafe { utimensat(AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) };
+        assert_eq!(result, 0, "utimensat should set file mtime");
+    }
+
     #[test]
     fn percent_complete_rounds_to_nearest_integer() {
         assert_eq!(percent_complete(1, 3), Some(33));
@@ -758,7 +804,7 @@ mod tests {
         let marker_path = dir.path().join("model.verified");
         let sha256 = "abc123";
         let size = 1024_u64;
-        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+        let mtime = SystemTime::UNIX_EPOCH + Duration::new(12345, 678);
 
         write_verification_marker(&marker_path, sha256, size, mtime);
 
@@ -766,6 +812,7 @@ mod tests {
         assert_eq!(marker.sha256, sha256);
         assert_eq!(marker.size, size);
         assert_eq!(marker.mtime_secs, 12345);
+        assert_eq!(marker.mtime_nanos, 678);
     }
 
     #[test]
@@ -858,5 +905,45 @@ mod tests {
 
         // Cache should be invalid (mtime mismatch).
         assert!(!verification_cache_valid(&model_path, &sha256));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verification_cache_invalidates_same_size_rewrite_with_subsecond_mtime_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        let original = b"original bytes";
+        let replacement = b"changed! bytes";
+        assert_eq!(original.len(), replacement.len());
+
+        fs::write(&model_path, original).unwrap();
+        set_file_mtime(&model_path, 1_700_000_000, 100);
+        let metadata = fs::metadata(&model_path).unwrap();
+        let original_mtime = metadata.modified().unwrap();
+        let original_sha256 = format!("{:x}", Sha256::digest(original));
+        write_verification_marker(
+            &marker_path,
+            &original_sha256,
+            metadata.len(),
+            original_mtime,
+        );
+
+        fs::write(&model_path, replacement).unwrap();
+        set_file_mtime(&model_path, 1_700_000_000, 200);
+        let rewritten_metadata = fs::metadata(&model_path).unwrap();
+        let rewritten_mtime = rewritten_metadata.modified().unwrap();
+
+        assert_eq!(metadata.len(), rewritten_metadata.len());
+        assert_eq!(
+            mtime_parts(original_mtime).0,
+            mtime_parts(rewritten_mtime).0
+        );
+        assert_ne!(
+            mtime_parts(original_mtime).1,
+            mtime_parts(rewritten_mtime).1
+        );
+        assert!(!verification_cache_valid(&model_path, &original_sha256));
     }
 }

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -1,10 +1,11 @@
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use directories::ProjectDirs;
 use panops_core::asr::AsrError;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 pub struct ModelInfo {
@@ -61,6 +62,93 @@ pub const VAD_MODELS: &[ModelInfo] = &[ModelInfo {
 pub const DEFAULT_MODEL_NAME: &str = "ggml-large-v3-turbo-q5_0";
 
 pub const DEFAULT_VAD_MODEL_NAME: &str = "ggml-silero-v6.2.0";
+
+/// Marker file for caching successful sha256 verifications.
+/// Written after a successful verify; read on subsequent calls to skip re-hashing
+/// if the file hasn't changed (size + mtime match).
+#[derive(Serialize, Deserialize)]
+struct VerificationMarker {
+    /// The expected sha256 hash that was verified.
+    sha256: String,
+    /// File size in bytes at verification time.
+    size: u64,
+    /// File modification time as Unix timestamp (seconds since epoch).
+    /// Using duration_since UNIX_EPOCH for portability.
+    mtime_secs: u64,
+}
+
+/// Returns the path to the verification marker file for a given model path.
+/// Marker is a sidecar file: `<model_path>.verified`.
+fn verification_marker_path(model_path: &Path) -> PathBuf {
+    let mut marker = model_path.as_os_str().to_os_string();
+    marker.push(".verified");
+    PathBuf::from(marker)
+}
+
+/// Read the verification marker if it exists and is valid JSON.
+fn read_verification_marker(marker_path: &Path) -> Option<VerificationMarker> {
+    let contents = fs::read_to_string(marker_path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Write the verification marker after a successful sha256 verify.
+fn write_verification_marker(marker_path: &Path, sha256: &str, size: u64, mtime: SystemTime) {
+    let mtime_secs = mtime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let marker = VerificationMarker {
+        sha256: sha256.to_string(),
+        size,
+        mtime_secs,
+    };
+    let contents = serde_json::to_string(&marker).unwrap_or_default();
+    // Ignore write errors — marker is optional; next run will re-verify.
+    let _ = fs::write(marker_path, contents);
+}
+
+/// Check if the verification cache is valid for a given model file.
+/// Returns true if:
+/// - Marker file exists
+/// - Marker's sha256 matches the expected hash
+/// - Marker's size matches current file size
+/// - Marker's mtime matches current file mtime
+///
+/// If any check fails, returns false (caller should re-verify).
+fn verification_cache_valid(model_path: &Path, expected_sha256: &str) -> bool {
+    let marker_path = verification_marker_path(model_path);
+    let Some(marker) = read_verification_marker(&marker_path) else {
+        return false;
+    };
+
+    // Hash must match what we're verifying against.
+    if marker.sha256 != expected_sha256 {
+        return false;
+    }
+
+    // Get current file metadata.
+    let Some(metadata) = fs::metadata(model_path).ok() else {
+        return false;
+    };
+    let Some(current_mtime) = metadata.modified().ok() else {
+        return false;
+    };
+    let current_size = metadata.len();
+    let current_mtime_secs = current_mtime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // Size and mtime must match.
+    if marker.size != current_size {
+        return false;
+    }
+    if marker.mtime_secs != current_mtime_secs {
+        return false;
+    }
+
+    true
+}
 
 fn data_dir() -> Result<PathBuf, AsrError> {
     let dirs = ProjectDirs::from("dev", "panops", "panops")
@@ -361,14 +449,32 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
 ///   (the user explicitly chose this path, possibly pointing at a different
 ///   registered model than `name`).
 /// - If `PANOPS_SKIP_MODEL_CHECKSUM` env is set: skip checksum.
-/// - Otherwise: verify against the registered hash.
+/// - Otherwise: verify against the registered hash (with caching — skips re-hash
+///   if a valid `.verified` marker exists).
 pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
     let info = lookup_model(name)?;
     if dest.exists() {
         let user_override = std::env::var("PANOPS_MODEL").is_ok();
         let skip_checksum = std::env::var("PANOPS_SKIP_MODEL_CHECKSUM").is_ok();
         if !user_override && !skip_checksum {
-            verify_sha256(dest, info.sha256)?;
+            // Check verification cache before hashing.
+            if verification_cache_valid(dest, info.sha256) {
+                tracing::debug!(dest = ?dest, "skipping sha256 verify (cached)");
+            } else {
+                verify_sha256(dest, info.sha256)?;
+                // Write marker after successful verify.
+                let metadata = fs::metadata(dest)
+                    .map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
+                let mtime = metadata
+                    .modified()
+                    .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
+                write_verification_marker(
+                    &verification_marker_path(dest),
+                    info.sha256,
+                    metadata.len(),
+                    mtime,
+                );
+            }
         }
         return Ok(dest.to_path_buf());
     }
@@ -386,6 +492,18 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         let _ = fs::remove_file(dest);
         return Err(e);
     }
+    // Write marker after successful download + verify.
+    let metadata =
+        fs::metadata(dest).map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
+    let mtime = metadata
+        .modified()
+        .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
+    write_verification_marker(
+        &verification_marker_path(dest),
+        info.sha256,
+        metadata.len(),
+        mtime,
+    );
     tracing::info!(bytes = n, dest = ?dest, "model download complete");
     Ok(dest.to_path_buf())
 }
@@ -483,14 +601,32 @@ pub fn ensure_diar_models() -> Result<(PathBuf, PathBuf), AsrError> {
 /// Behavior on existing files:
 /// - If `PANOPS_VAD_MODEL` env is set: trust the user-provided file, skip checksum.
 /// - If `PANOPS_SKIP_MODEL_CHECKSUM` env is set: skip checksum.
-/// - Otherwise: verify against the registered hash.
+/// - Otherwise: verify against the registered hash (with caching — skips re-hash
+///   if a valid `.verified` marker exists).
 pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
     let info = &VAD_MODELS[0];
     if dest.exists() {
         let user_override = std::env::var("PANOPS_VAD_MODEL").is_ok();
         let skip_checksum = std::env::var("PANOPS_SKIP_MODEL_CHECKSUM").is_ok();
         if !user_override && !skip_checksum {
-            verify_sha256(dest, info.sha256)?;
+            // Check verification cache before hashing.
+            if verification_cache_valid(dest, info.sha256) {
+                tracing::debug!(dest = ?dest, "skipping sha256 verify (cached)");
+            } else {
+                verify_sha256(dest, info.sha256)?;
+                // Write marker after successful verify.
+                let metadata = fs::metadata(dest)
+                    .map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
+                let mtime = metadata
+                    .modified()
+                    .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
+                write_verification_marker(
+                    &verification_marker_path(dest),
+                    info.sha256,
+                    metadata.len(),
+                    mtime,
+                );
+            }
         }
         return Ok(dest.to_path_buf());
     }
@@ -506,6 +642,18 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
         let _ = fs::remove_file(dest);
         return Err(e);
     }
+    // Write marker after successful download + verify.
+    let metadata =
+        fs::metadata(dest).map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
+    let mtime = metadata
+        .modified()
+        .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
+    write_verification_marker(
+        &verification_marker_path(dest),
+        info.sha256,
+        metadata.len(),
+        mtime,
+    );
     tracing::info!(bytes = n, dest = ?dest, "vad model download complete");
     Ok(dest.to_path_buf())
 }
@@ -585,5 +733,130 @@ mod tests {
         assert!(progress.contains("2.0 KiB/s"));
         assert!(!progress.contains('%'));
         assert!(!progress.contains("eta"));
+    }
+
+    #[test]
+    fn verification_marker_path_is_sidecar() {
+        let model_path = PathBuf::from("/models/ggml-large-v3-turbo-q5_0.bin");
+        let marker_path = verification_marker_path(&model_path);
+        assert_eq!(
+            marker_path.to_str().unwrap(),
+            "/models/ggml-large-v3-turbo-q5_0.bin.verified"
+        );
+
+        let already_verified_model_path = PathBuf::from("/models/model.verified");
+        let marker_path = verification_marker_path(&already_verified_model_path);
+        assert_eq!(
+            marker_path.to_str().unwrap(),
+            "/models/model.verified.verified"
+        );
+    }
+
+    #[test]
+    fn write_and_read_verification_marker_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("model.verified");
+        let sha256 = "abc123";
+        let size = 1024_u64;
+        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(12345);
+
+        write_verification_marker(&marker_path, sha256, size, mtime);
+
+        let marker = read_verification_marker(&marker_path).expect("marker should exist");
+        assert_eq!(marker.sha256, sha256);
+        assert_eq!(marker.size, size);
+        assert_eq!(marker.mtime_secs, 12345);
+    }
+
+    #[test]
+    fn verification_cache_valid_returns_true_when_marker_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        // Write a model file.
+        let content = b"test model content";
+        fs::write(&model_path, content).unwrap();
+        let metadata = fs::metadata(&model_path).unwrap();
+        let mtime = metadata.modified().unwrap();
+        let expected_sha256 = format!("{:x}", Sha256::digest(content));
+
+        // Write marker with correct values.
+        write_verification_marker(&marker_path, &expected_sha256, metadata.len(), mtime);
+
+        // Cache should be valid.
+        assert!(verification_cache_valid(&model_path, &expected_sha256));
+    }
+
+    #[test]
+    fn verification_cache_invalid_when_marker_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+
+        // Write a model file but no marker.
+        fs::write(&model_path, b"test").unwrap();
+
+        // Cache should be invalid (no marker).
+        assert!(!verification_cache_valid(&model_path, "any-hash"));
+    }
+
+    #[test]
+    fn verification_cache_invalid_when_sha256_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        // Write a model file.
+        let content = b"test model content";
+        fs::write(&model_path, content).unwrap();
+        let metadata = fs::metadata(&model_path).unwrap();
+        let mtime = metadata.modified().unwrap();
+
+        // Write marker with wrong hash.
+        write_verification_marker(&marker_path, "wrong-hash", metadata.len(), mtime);
+
+        // Cache should be invalid (hash mismatch).
+        let actual_sha256 = format!("{:x}", Sha256::digest(content));
+        assert!(!verification_cache_valid(&model_path, &actual_sha256));
+    }
+
+    #[test]
+    fn verification_cache_invalid_when_size_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        // Write a model file.
+        let content = b"test model content";
+        fs::write(&model_path, content).unwrap();
+        let metadata = fs::metadata(&model_path).unwrap();
+        let mtime = metadata.modified().unwrap();
+        let sha256 = format!("{:x}", Sha256::digest(content));
+
+        // Write marker with wrong size (model file changed).
+        write_verification_marker(&marker_path, &sha256, 1, mtime);
+
+        // Cache should be invalid (size mismatch).
+        assert!(!verification_cache_valid(&model_path, &sha256));
+    }
+
+    #[test]
+    fn verification_cache_invalid_when_mtime_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        // Write a model file.
+        let content = b"test model content";
+        fs::write(&model_path, content).unwrap();
+        let metadata = fs::metadata(&model_path).unwrap();
+        let sha256 = format!("{:x}", Sha256::digest(content));
+
+        // Write marker with old mtime (file touched/modified after marker).
+        let old_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        write_verification_marker(&marker_path, &sha256, metadata.len(), old_mtime);
+
+        // Cache should be invalid (mtime mismatch).
+        assert!(!verification_cache_valid(&model_path, &sha256));
     }
 }

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -67,6 +67,7 @@ pub const DEFAULT_VAD_MODEL_NAME: &str = "ggml-silero-v6.2.0";
 /// Written after a successful verify; read on subsequent calls to skip re-hashing
 /// if the file hasn't changed (size + mtime match).
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct VerificationMarker {
     /// The expected sha256 hash that was verified.
     sha256: String,

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -114,6 +114,26 @@ fn write_verification_marker(marker_path: &Path, sha256: &str, size: u64, mtime:
     let _ = fs::write(marker_path, contents);
 }
 
+/// Record a successful sha256 verification of `file_path` by writing its
+/// `.verified` marker (capturing the file's current size + mtime). Single
+/// source for the post-verify marker write so the four `ensure_*` paths
+/// (cache-miss verify + post-download verify, for model and vad) don't
+/// duplicate the metadata read.
+fn mark_verified(file_path: &Path, sha256: &str) -> Result<(), AsrError> {
+    let metadata = fs::metadata(file_path)
+        .map_err(|e| AsrError::Model(format!("metadata {file_path:?}: {e}")))?;
+    let mtime = metadata
+        .modified()
+        .map_err(|e| AsrError::Model(format!("mtime {file_path:?}: {e}")))?;
+    write_verification_marker(
+        &verification_marker_path(file_path),
+        sha256,
+        metadata.len(),
+        mtime,
+    );
+    Ok(())
+}
+
 /// Check if the verification cache is valid for a given model file.
 /// Returns true if:
 /// - Marker file exists
@@ -477,17 +497,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
             } else {
                 verify_sha256(dest, info.sha256)?;
                 // Write marker after successful verify.
-                let metadata = fs::metadata(dest)
-                    .map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
-                let mtime = metadata
-                    .modified()
-                    .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
-                write_verification_marker(
-                    &verification_marker_path(dest),
-                    info.sha256,
-                    metadata.len(),
-                    mtime,
-                );
+                mark_verified(dest, info.sha256)?;
             }
         }
         return Ok(dest.to_path_buf());
@@ -507,17 +517,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         return Err(e);
     }
     // Write marker after successful download + verify.
-    let metadata =
-        fs::metadata(dest).map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
-    let mtime = metadata
-        .modified()
-        .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
-    write_verification_marker(
-        &verification_marker_path(dest),
-        info.sha256,
-        metadata.len(),
-        mtime,
-    );
+    mark_verified(dest, info.sha256)?;
     tracing::info!(bytes = n, dest = ?dest, "model download complete");
     Ok(dest.to_path_buf())
 }
@@ -629,17 +629,7 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
             } else {
                 verify_sha256(dest, info.sha256)?;
                 // Write marker after successful verify.
-                let metadata = fs::metadata(dest)
-                    .map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
-                let mtime = metadata
-                    .modified()
-                    .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
-                write_verification_marker(
-                    &verification_marker_path(dest),
-                    info.sha256,
-                    metadata.len(),
-                    mtime,
-                );
+                mark_verified(dest, info.sha256)?;
             }
         }
         return Ok(dest.to_path_buf());
@@ -657,17 +647,7 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
         return Err(e);
     }
     // Write marker after successful download + verify.
-    let metadata =
-        fs::metadata(dest).map_err(|e| AsrError::Model(format!("metadata {dest:?}: {e}")))?;
-    let mtime = metadata
-        .modified()
-        .map_err(|e| AsrError::Model(format!("mtime {dest:?}: {e}")))?;
-    write_verification_marker(
-        &verification_marker_path(dest),
-        info.sha256,
-        metadata.len(),
-        mtime,
-    );
+    mark_verified(dest, info.sha256)?;
     tracing::info!(bytes = n, dest = ?dest, "vad model download complete");
     Ok(dest.to_path_buf())
 }
@@ -852,6 +832,24 @@ mod tests {
 
         // Cache should be invalid (no marker).
         assert!(!verification_cache_valid(&model_path, "any-hash"));
+    }
+
+    #[test]
+    fn verification_cache_invalid_when_marker_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("model.bin");
+        let marker_path = verification_marker_path(&model_path);
+
+        let content = b"test model content";
+        fs::write(&model_path, content).unwrap();
+
+        // A truncated/corrupt marker must not be trusted — it should parse to
+        // None and fall through to a real re-verify, not silently validate.
+        fs::write(&marker_path, b"{not valid json").unwrap();
+
+        assert!(read_verification_marker(&marker_path).is_none());
+        let sha256 = format!("{:x}", Sha256::digest(content));
+        assert!(!verification_cache_valid(&model_path, &sha256));
     }
 
     #[test]


### PR DESCRIPTION
Closes #12. Avoids re-hashing the multi-GB default model on every startup: after a successful verify, writes a sidecar marker (hash + size + mtime); subsequent ensure_model calls skip re-hashing when the marker matches, re-verify on mismatch. Honors PANOPS_MODEL / PANOPS_SKIP_MODEL_CHECKSUM. Tests included. claudea-built; reviews pending.