### PR TITLE
test: LlmProvider conformance covers error paths

### DIFF
--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -280,6 +280,50 @@ impl LlmProvider for MockLlm {
     }
 }
 
+/// A `LlmProvider` fake whose backend always fails. Drives the error-path
+/// conformance checks (`conformance::llm::run_error_suite` /
+/// `assert_empty_response`): a live LLM can't be made to fail on command, so
+/// the error contract is validated through this reference failing impl.
+///
+/// `FailingLlm::provider(msg)` models a backend transport/provider failure;
+/// `FailingLlm::empty()` models a backend that returned a blank completion,
+/// which adapters must surface as `LlmError::EmptyResponse` (see
+/// `panops-portable`'s `GenaiLlm`, which maps an empty `first_text()` the same
+/// way). The prompt is ignored.
+pub struct FailingLlm {
+    mode: FailMode,
+}
+
+enum FailMode {
+    Provider(String),
+    Empty,
+}
+
+impl FailingLlm {
+    /// Models a backend transport/provider failure.
+    pub fn provider(message: &str) -> Self {
+        Self {
+            mode: FailMode::Provider(message.to_string()),
+        }
+    }
+
+    /// Models a backend that returned an empty/blank completion.
+    pub fn empty() -> Self {
+        Self {
+            mode: FailMode::Empty,
+        }
+    }
+}
+
+impl LlmProvider for FailingLlm {
+    fn complete(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        match &self.mode {
+            FailMode::Provider(message) => Err(LlmError::Provider(message.clone())),
+            FailMode::Empty => Err(LlmError::EmptyResponse),
+        }
+    }
+}
+
 /// Minimal `NotesExporter` for the conformance harness. Writes a single
 /// `notes.txt` file containing the rendered title and section count under
 /// `dest`. Refuses (with `ExportError::InvalidDest`) when `dest` exists but

--- a/crates/panops-core/src/conformance/llm.rs
+++ b/crates/panops-core/src/conformance/llm.rs
@@ -1,8 +1,13 @@
 //! Conformance harness for `LlmProvider`. Adapter test crates call
 //! `run_suite(&adapter)` after registering the canned prompts the harness
 //! probes for.
+//!
+//! Error-path behavior lives in `run_error_suite` / `assert_empty_response`.
+//! A live LLM can't be made to fail on command, so the error contract is
+//! driven by fakes rigged to fail (`MockLlm::with_error_for`, `FailingLlm`)
+//! rather than the provider-under-test — real adapters run only `run_suite`.
 
-use crate::llm::{LlmProvider, LlmRequest, LlmResponse};
+use crate::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 
 pub fn run_suite<L: LlmProvider>(provider: &L) {
     text_response_round_trip(provider);
@@ -34,5 +39,55 @@ fn json_response_round_trip<L: LlmProvider>(provider: &L) {
     match provider.complete(req).expect("complete failed") {
         LlmResponse::Json(v) => assert!(v.is_object(), "not an object"),
         LlmResponse::Text(_) => panic!("expected json, got text"),
+    }
+}
+
+/// Prompt `run_error_suite` / `assert_empty_response` send to `complete`.
+/// Adapters that rig failures per-prompt (e.g. `MockLlm::with_error_for`)
+/// must arrange the failure for this exact `(system = None, user)` pair;
+/// adapters that fail unconditionally (`FailingLlm`) ignore it.
+pub const ERROR_PROBE_USER: &str = "conformance: force backend failure";
+
+/// Error-path conformance: a provider whose backend fails MUST return
+/// `Err(LlmError)` from `complete` and MUST NOT panic. Drive with any fake
+/// rigged to fail (`FailingLlm`, or `MockLlm::with_error_for(None,
+/// ERROR_PROBE_USER, ...)`). Live adapters can't be forced to fail, so they
+/// run only `run_suite`.
+pub fn run_error_suite<L: LlmProvider>(failing: &L) {
+    backend_failure_returns_err_not_panic(failing);
+}
+
+/// Empty-backend conformance: a provider whose backend returned a blank
+/// completion MUST surface `LlmError::EmptyResponse` (the documented behavior
+/// — see `panops-portable`'s `GenaiLlm`, which maps an empty `first_text()`
+/// the same way). Drive with a fake modelling an empty backend
+/// (`FailingLlm::empty`).
+pub fn assert_empty_response<L: LlmProvider>(empty_provider: &L) {
+    match empty_provider.complete(error_probe_request()) {
+        Err(LlmError::EmptyResponse) => {}
+        other => {
+            panic!("expected Err(LlmError::EmptyResponse) for an empty backend, got {other:?}")
+        }
+    }
+}
+
+fn backend_failure_returns_err_not_panic<L: LlmProvider>(failing: &L) {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        failing.complete(error_probe_request())
+    }));
+    match outcome {
+        Err(_) => panic!("complete panicked instead of returning Err(LlmError)"),
+        Ok(Ok(_)) => panic!("error-suite provider returned Ok; expected Err(LlmError)"),
+        Ok(Err(_)) => {}
+    }
+}
+
+fn error_probe_request() -> LlmRequest {
+    LlmRequest {
+        system: None,
+        user: ERROR_PROBE_USER.into(),
+        schema: None,
+        temperature: 0.0,
+        max_tokens: 16,
     }
 }

--- a/crates/panops-core/tests/conformance_fake_llm.rs
+++ b/crates/panops-core/tests/conformance_fake_llm.rs
@@ -1,8 +1,11 @@
 //! Integration test: validates that `MockLlm` satisfies the `LlmProvider`
-//! conformance harness. Uses only public API + the conformance module.
+//! conformance harness — happy paths plus the error-path contract every
+//! adapter must honor.
 
-use panops_core::conformance::fakes::MockLlm;
-use panops_core::conformance::llm::run_suite;
+use panops_core::conformance::fakes::{FailingLlm, MockLlm};
+use panops_core::conformance::llm::{
+    ERROR_PROBE_USER, assert_empty_response, run_error_suite, run_suite,
+};
 
 #[test]
 fn mock_llm_passes_conformance() {
@@ -14,4 +17,18 @@ fn mock_llm_passes_conformance() {
             panops_core::LlmResponse::Json(serde_json::json!({"ok": true})),
         );
     run_suite(&mock);
+}
+
+#[test]
+fn llm_adapters_honor_error_contract() {
+    // MockLlm is a real adapter (the CI one): its registered-error path must
+    // return Err without panicking.
+    let failing_mock = MockLlm::default().with_error_for(None, ERROR_PROBE_USER, "backend down");
+    run_error_suite(&failing_mock);
+
+    // The reference FailingLlm fake honors the same universal contract...
+    run_error_suite(&FailingLlm::provider("backend down"));
+
+    // ...plus the empty-backend -> EmptyResponse contract MockLlm doesn't model.
+    assert_empty_response(&FailingLlm::empty());
 }


### PR DESCRIPTION
Closes #43. The LlmProvider conformance harness only probed happy paths. Extends it to assert error-path behavior every adapter must honor (returns Err not panic on failure; empty-response handling; Json-vs-Text contract), via a configurable failing fake. claude-built; reviews pending.