### PR TITLE
Slice 15: FoundationModels LLM sidecar

### DIFF
--- a/apps/panops-llm-mac/Package.swift
+++ b/apps/panops-llm-mac/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "PanopsLlmMac",
+    platforms: [.macOS(.v26)],
+    products: [
+        .executable(name: "panops-llm-mac", targets: ["PanopsLlmMac"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "PanopsLlmMac",
+            path: "Sources/PanopsLlmMac"
+        ),
+        .testTarget(
+            name: "PanopsLlmMacTests",
+            dependencies: ["PanopsLlmMac"],
+            path: "Tests/PanopsLlmMacTests"
+        ),
+    ]
+)

--- a/apps/panops-llm-mac/Package.swift
+++ b/apps/panops-llm-mac/Package.swift
@@ -12,10 +12,15 @@ let package = Package(
             name: "PanopsLlmMac",
             path: "Sources/PanopsLlmMac"
         ),
+        .target(
+            name: "PanopsLlmMacTestsBootstrap",
+            path: "Sources/PanopsLlmMacTestsBootstrap"
+        ),
         .testTarget(
             name: "PanopsLlmMacTests",
-            dependencies: ["PanopsLlmMac"],
-            path: "Tests/PanopsLlmMacTests"
+            dependencies: ["PanopsLlmMac", "PanopsLlmMacTestsBootstrap"],
+            path: "Tests/PanopsLlmMacTests",
+            linkerSettings: [.unsafeFlags(["-Xlinker", "-all_load"])]
         ),
     ]
 )

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/Codecs.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/Codecs.swift
@@ -1,0 +1,335 @@
+import Foundation
+import FoundationModels
+
+/// JSON value carrier used for both raw JSON-RPC params and structured
+/// FoundationModels output. It intentionally avoids `Any` so codecs remain
+/// deterministic and testable without involving a live model.
+enum JSONValue: Codable, Equatable, Sendable {
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() {
+            self = .null
+        } else if let v = try? c.decode(Bool.self) {
+            self = .bool(v)
+        } else if let v = try? c.decode(Int.self) {
+            self = .int(v)
+        } else if let v = try? c.decode(Double.self) {
+            self = .double(v)
+        } else if let v = try? c.decode(String.self) {
+            self = .string(v)
+        } else if let v = try? c.decode([JSONValue].self) {
+            self = .array(v)
+        } else if let v = try? c.decode([String: JSONValue].self) {
+            self = .object(v)
+        } else {
+            throw DecodingError.dataCorruptedError(in: c, debugDescription: "unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .object(let v): try c.encode(v)
+        case .array(let v): try c.encode(v)
+        case .string(let v): try c.encode(v)
+        case .int(let v): try c.encode(v)
+        case .double(let v): try c.encode(v)
+        case .bool(let v): try c.encode(v)
+        case .null: try c.encodeNil()
+        }
+    }
+
+    var objectValue: [String: JSONValue]? {
+        if case .object(let v) = self { return v }
+        return nil
+    }
+
+    var arrayValue: [JSONValue]? {
+        if case .array(let v) = self { return v }
+        return nil
+    }
+
+    var stringValue: String? {
+        if case .string(let v) = self { return v }
+        return nil
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from value: JSONValue) throws -> T {
+        try JSONDecoder().decode(T.self, from: JSONEncoder().encode(value))
+    }
+
+    static func fromEncodable<T: Encodable>(_ value: T) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(value))
+    }
+}
+
+enum CodecError: Error, CustomStringConvertible, Equatable {
+    case invalidSchema(String)
+    case unsupportedSchema(String)
+    case invalidGeneratedJSON(String)
+
+    var description: String {
+        switch self {
+        case .invalidSchema(let message): "invalid schema: \(message)"
+        case .unsupportedSchema(let message): "unsupported schema: \(message)"
+        case .invalidGeneratedJSON(let message): "invalid generated JSON: \(message)"
+        }
+    }
+}
+
+struct JsonRpcRequest: Decodable, Sendable {
+    let jsonrpc: String
+    let id: JSONValue?
+    let method: String
+    let params: JSONValue?
+}
+
+struct JsonRpcResponse: Encodable {
+    let jsonrpc: String
+    let id: JSONValue?
+    let result: JSONValue?
+    let error: JsonRpcError?
+
+    init(id: JSONValue?, result: JSONValue? = nil, error: JsonRpcError? = nil) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.result = result
+        self.error = error
+    }
+
+    enum CodingKeys: String, CodingKey { case jsonrpc, id, result, error }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(jsonrpc, forKey: .jsonrpc)
+        if let id { try c.encode(id, forKey: .id) } else { try c.encodeNil(forKey: .id) }
+        try c.encodeIfPresent(result, forKey: .result)
+        try c.encodeIfPresent(error, forKey: .error)
+    }
+}
+
+struct JsonRpcError: Encodable {
+    let code: Int
+    let message: String
+}
+
+struct ProbeResult: Codable, Equatable, Sendable {
+    let available: Bool
+    let reason: String?
+}
+
+struct CompleteParams: Decodable, Equatable, Sendable {
+    let system: String?
+    let user: String
+    let schema: JSONValue?
+    let temperature: Double
+    let maxTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case system, user, schema, temperature
+        case maxTokens = "max_tokens"
+    }
+}
+
+struct CompleteResult: Codable, Equatable, Sendable {
+    let json: JSONValue?
+    let text: String?
+
+    init(json: JSONValue) {
+        self.json = json
+        self.text = nil
+    }
+
+    init(text: String) {
+        self.json = nil
+        self.text = text
+    }
+}
+
+@available(macOS 26.0, *)
+enum FoundationModelCodecs {
+    static func generationSchema(from schema: JSONValue, rootName: String = "PanopsLlmResponse") throws -> GenerationSchema {
+        let root = try dynamicGenerationSchema(from: schema, name: sanitizedTypeName(rootName))
+        return try GenerationSchema(root: root, dependencies: [])
+    }
+
+    static func jsonValue(from content: GeneratedContent) throws -> JSONValue {
+        guard let data = content.jsonString.data(using: .utf8) else {
+            throw CodecError.invalidGeneratedJSON("GeneratedContent.jsonString was not UTF-8")
+        }
+        do {
+            return try JSONDecoder().decode(JSONValue.self, from: data)
+        } catch {
+            throw CodecError.invalidGeneratedJSON(error.localizedDescription)
+        }
+    }
+
+    private static func dynamicGenerationSchema(from raw: JSONValue, name: String) throws -> DynamicGenerationSchema {
+        guard let schema = raw.objectValue else {
+            throw CodecError.invalidSchema("schema root for \(name) must be an object")
+        }
+
+        if let enumValues = schema["enum"]?.arrayValue {
+            let choices = try enumValues.map { value -> String in
+                guard let s = value.stringValue else {
+                    throw CodecError.unsupportedSchema("enum for \(name) must contain only strings")
+                }
+                return s
+            }
+            guard !choices.isEmpty else {
+                throw CodecError.invalidSchema("enum for \(name) must not be empty")
+            }
+            return DynamicGenerationSchema(name: name, anyOf: choices)
+        }
+
+        if let anyOf = schema["anyOf"]?.arrayValue ?? schema["oneOf"]?.arrayValue {
+            let nonNull = anyOf.filter { !isNullSchema($0) }
+            guard !nonNull.isEmpty else { return try nullSchema(name: name) }
+            if nonNull.count == 1 {
+                return try dynamicGenerationSchema(from: nonNull[0], name: name)
+            }
+            let choices = try nonNull.enumerated().map { index, choice in
+                try dynamicGenerationSchema(from: choice, name: "\(name)Choice\(index + 1)")
+            }
+            return DynamicGenerationSchema(name: name, anyOf: choices)
+        }
+
+        let types = try typeNames(in: schema, name: name)
+        let nonNullTypes = types.filter { $0 != "null" }
+        if nonNullTypes.isEmpty { return try nullSchema(name: name) }
+        if nonNullTypes.count > 1 {
+            let choices = try nonNullTypes.map { typeName in
+                var narrowed = schema
+                narrowed["type"] = .string(typeName)
+                return try dynamicGenerationSchema(from: .object(narrowed), name: "\(name)\(sanitizedTypeName(typeName))")
+            }
+            return DynamicGenerationSchema(name: name, anyOf: choices)
+        }
+
+        switch nonNullTypes[0] {
+        case "object":
+            let properties = schema["properties"]?.objectValue ?? [:]
+            let required = Set((schema["required"]?.arrayValue ?? []).compactMap(\.stringValue))
+            let dynamicProperties = try properties.keys.sorted().map { propertyName in
+                guard let propertySchema = properties[propertyName] else {
+                    throw CodecError.invalidSchema("missing schema for property \(propertyName)")
+                }
+                let stripped = stripNullable(propertySchema)
+                return DynamicGenerationSchema.Property(
+                    name: propertyName,
+                    description: description(in: stripped),
+                    schema: try dynamicGenerationSchema(
+                        from: stripped,
+                        name: sanitizedTypeName("\(name)_\(propertyName)")
+                    ),
+                    isOptional: !required.contains(propertyName)
+                )
+            }
+            return DynamicGenerationSchema(
+                name: name,
+                description: description(in: raw),
+                properties: dynamicProperties
+            )
+        case "array":
+            guard let items = schema["items"] else {
+                throw CodecError.invalidSchema("array schema \(name) is missing items")
+            }
+            return DynamicGenerationSchema(
+                arrayOf: try dynamicGenerationSchema(from: stripNullable(items), name: "\(name)Item"),
+                minimumElements: intValue(schema["minItems"]),
+                maximumElements: intValue(schema["maxItems"])
+            )
+        case "string":
+            return DynamicGenerationSchema(type: String.self)
+        case "integer":
+            return DynamicGenerationSchema(type: Int.self)
+        case "number":
+            return DynamicGenerationSchema(type: Double.self)
+        case "boolean":
+            return DynamicGenerationSchema(type: Bool.self)
+        default:
+            throw CodecError.unsupportedSchema("type \(nonNullTypes[0]) for \(name)")
+        }
+    }
+
+    private static func typeNames(in schema: [String: JSONValue], name: String) throws -> [String] {
+        guard let typeValue = schema["type"] else {
+            if schema["properties"] != nil { return ["object"] }
+            if schema["items"] != nil { return ["array"] }
+            if schema["enum"] != nil { return ["string"] }
+            throw CodecError.invalidSchema("schema \(name) is missing type")
+        }
+        if let s = typeValue.stringValue { return [s] }
+        if let a = typeValue.arrayValue {
+            let names = a.compactMap(\.stringValue)
+            guard names.count == a.count else {
+                throw CodecError.invalidSchema("type array for \(name) must contain only strings")
+            }
+            return names
+        }
+        throw CodecError.invalidSchema("type for \(name) must be a string or string array")
+    }
+
+    private static func stripNullable(_ value: JSONValue) -> JSONValue {
+        guard var schema = value.objectValue else { return value }
+        if let types = schema["type"]?.arrayValue {
+            let nonNull = types.filter { $0 != .string("null") }
+            if nonNull.count == 1, let type = nonNull[0].stringValue {
+                schema["type"] = .string(type)
+            } else {
+                schema["type"] = .array(nonNull)
+            }
+        }
+        if let anyOf = schema["anyOf"]?.arrayValue {
+            schema["anyOf"] = .array(anyOf.filter { !isNullSchema($0) })
+        }
+        if let oneOf = schema["oneOf"]?.arrayValue {
+            schema["oneOf"] = .array(oneOf.filter { !isNullSchema($0) })
+        }
+        return .object(schema)
+    }
+
+    private static func isNullSchema(_ value: JSONValue) -> Bool {
+        guard let schema = value.objectValue else { return value == .null }
+        if schema["type"] == .string("null") { return true }
+        return false
+    }
+
+    private static func nullSchema(name: String) throws -> DynamicGenerationSchema {
+        if #available(macOS 26.4, *) {
+            return .null
+        }
+        throw CodecError.unsupportedSchema("null schema for \(name) requires macOS 26.4")
+    }
+
+    private static func description(in value: JSONValue) -> String? {
+        value.objectValue?["description"]?.stringValue
+    }
+
+    private static func intValue(_ value: JSONValue?) -> Int? {
+        switch value {
+        case .int(let i): i
+        case .double(let d): Int(d)
+        default: nil
+        }
+    }
+
+    private static func sanitizedTypeName(_ raw: String) -> String {
+        let parts = raw.split { !$0.isLetter && !$0.isNumber }
+        let joined = parts.map { part -> String in
+            guard let first = part.first else { return "" }
+            return String(first).uppercased() + String(part.dropFirst())
+        }.joined()
+        let candidate = joined.isEmpty ? "PanopsSchema" : joined
+        if candidate.first?.isNumber == true { return "Panops\(candidate)" }
+        return candidate
+    }
+}

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/Codecs.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/Codecs.swift
@@ -168,7 +168,12 @@ enum FoundationModelCodecs {
         do {
             return try JSONDecoder().decode(JSONValue.self, from: data)
         } catch {
-            throw CodecError.invalidGeneratedJSON(error.localizedDescription)
+            // Log decode details locally (stderr) only; keep the wire-facing
+            // error opaque so generated-content schema internals don't leak
+            // up the IPC chain to the engine/app.
+            FileHandle.standardError.write(
+                Data("panops-llm-mac: generated JSON decode failed: \(error)\n".utf8))
+            throw CodecError.invalidGeneratedJSON("could not decode generated content as JSON")
         }
     }
 

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/Generator.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/Generator.swift
@@ -2,6 +2,41 @@ import Foundation
 import FoundationModels
 
 @available(macOS 26.0, *)
+private let modelResponseTimeoutNanoseconds: UInt64 = 120 * 1_000_000_000
+
+@available(macOS 26.0, *)
+enum GeneratorError: Error, CustomStringConvertible {
+    case responseTimedOut
+
+    var description: String {
+        switch self {
+        case .responseTimedOut:
+            return "model response timed out"
+        }
+    }
+}
+
+@available(macOS 26.0, *)
+private func withModelResponseTimeout<T: Sendable>(
+    _ operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: modelResponseTimeoutNanoseconds)
+            throw GeneratorError.responseTimedOut
+        }
+        guard let result = try await group.next() else {
+            throw GeneratorError.responseTimedOut
+        }
+        group.cancelAll()
+        return result
+    }
+}
+
+@available(macOS 26.0, *)
 actor Generator {
     func probe() -> ProbeResult {
         switch SystemLanguageModel.default.availability {
@@ -25,18 +60,23 @@ actor Generator {
 
         if let schemaValue = params.schema {
             let schema = try FoundationModelCodecs.generationSchema(from: schemaValue)
-            let response = try await session.respond(
-                to: params.user,
-                schema: schema,
-                includeSchemaInPrompt: true,
-                options: options
-            )
-            let json = try FoundationModelCodecs.jsonValue(from: response.rawContent)
+            let json = try await withModelResponseTimeout {
+                let response = try await session.respond(
+                    to: params.user,
+                    schema: schema,
+                    includeSchemaInPrompt: true,
+                    options: options
+                )
+                return try FoundationModelCodecs.jsonValue(from: response.rawContent)
+            }
             return CompleteResult(json: json)
         }
 
-        let response = try await session.respond(to: params.user, options: options)
-        return CompleteResult(text: response.content)
+        let text = try await withModelResponseTimeout {
+            let response = try await session.respond(to: params.user, options: options)
+            return response.content
+        }
+        return CompleteResult(text: text)
     }
 
     private static func describeUnavailableReason(_ reason: SystemLanguageModel.Availability.UnavailableReason) -> String {

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/Generator.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/Generator.swift
@@ -1,0 +1,54 @@
+import Foundation
+import FoundationModels
+
+@available(macOS 26.0, *)
+actor Generator {
+    func probe() -> ProbeResult {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return ProbeResult(available: true, reason: nil)
+        case .unavailable(let reason):
+            return ProbeResult(available: false, reason: Self.describeUnavailableReason(reason))
+        }
+    }
+
+    func complete(_ params: CompleteParams) async throws -> CompleteResult {
+        let options = GenerationOptions(
+            temperature: params.temperature,
+            maximumResponseTokens: params.maxTokens
+        )
+        let session = LanguageModelSession(
+            model: .default,
+            tools: [],
+            instructions: params.system
+        )
+
+        if let schemaValue = params.schema {
+            let schema = try FoundationModelCodecs.generationSchema(from: schemaValue)
+            let response = try await session.respond(
+                to: params.user,
+                schema: schema,
+                includeSchemaInPrompt: true,
+                options: options
+            )
+            let json = try FoundationModelCodecs.jsonValue(from: response.rawContent)
+            return CompleteResult(json: json)
+        }
+
+        let response = try await session.respond(to: params.user, options: options)
+        return CompleteResult(text: response.content)
+    }
+
+    private static func describeUnavailableReason(_ reason: SystemLanguageModel.Availability.UnavailableReason) -> String {
+        switch reason {
+        case .deviceNotEligible:
+            return "device_not_eligible"
+        case .appleIntelligenceNotEnabled:
+            return "apple_intelligence_not_enabled"
+        case .modelNotReady:
+            return "model_not_ready"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/main.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/main.swift
@@ -39,15 +39,22 @@ guard #available(macOS 26.0, *) else {
     FileHandle.standardError.write(Data("FoundationModels requires macOS 26.0; probe will report unavailable\n".utf8))
     while let line = readLine(strippingNewline: true) {
         if line.isEmpty { continue }
-        let request = try? decoder.decode(JsonRpcRequest.self, from: Data(line.utf8))
-        if request?.method == "probe" || request?.method == "llm.probe" {
+        let request: JsonRpcRequest
+        do {
+            request = try decoder.decode(JsonRpcRequest.self, from: Data(line.utf8))
+        } catch {
+            FileHandle.standardError.write(Data("parse error: \(error)\n".utf8))
+            emit(errorResponse(id: nil, code: -32700, message: "parse error"))
+            continue
+        }
+        if request.method == "probe" || request.method == "llm.probe" {
             let result = try JSONValue.fromEncodable(ProbeResult(
                 available: false,
                 reason: "macos_26_required"
             ))
-            emit(JsonRpcResponse(id: request?.id, result: result))
+            emit(JsonRpcResponse(id: request.id, result: result))
         } else {
-            emit(errorResponse(id: request?.id, code: -32000, message: "FoundationModels unavailable"))
+            emit(errorResponse(id: request.id, code: -32000, message: "FoundationModels unavailable"))
         }
     }
     exit(0)

--- a/apps/panops-llm-mac/Sources/PanopsLlmMac/main.swift
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMac/main.swift
@@ -1,0 +1,91 @@
+import Foundation
+import FoundationModels
+
+FileHandle.standardError.write(Data("panops-llm-mac starting\n".utf8))
+
+let decoder = JSONDecoder()
+let encoder = JSONEncoder()
+
+func emit(_ response: JsonRpcResponse) {
+    guard let body = try? encoder.encode(response),
+          let line = String(data: body, encoding: .utf8) else {
+        let id = response.id.map { (try? String(data: encoder.encode($0), encoding: .utf8)) ?? "null" } ?? "null"
+        print("{\"jsonrpc\":\"2.0\",\"id\":\(id),\"error\":{\"code\":-32603,\"message\":\"response encode failed\"}}")
+        fflush(stdout)
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+func errorResponse(id: JSONValue?, code: Int, message: String) -> JsonRpcResponse {
+    JsonRpcResponse(id: id, error: JsonRpcError(code: code, message: message))
+}
+
+func decodeParams<T: Decodable>(_ type: T.Type, from params: JSONValue?) throws -> T {
+    guard let params else {
+        throw CodecError.invalidSchema("missing params")
+    }
+    if let array = params.arrayValue {
+        guard let first = array.first else {
+            throw CodecError.invalidSchema("params array is empty")
+        }
+        return try JSONValue.decode(type, from: first)
+    }
+    return try JSONValue.decode(type, from: params)
+}
+
+guard #available(macOS 26.0, *) else {
+    FileHandle.standardError.write(Data("FoundationModels requires macOS 26.0; probe will report unavailable\n".utf8))
+    while let line = readLine(strippingNewline: true) {
+        if line.isEmpty { continue }
+        let request = try? decoder.decode(JsonRpcRequest.self, from: Data(line.utf8))
+        if request?.method == "probe" || request?.method == "llm.probe" {
+            let result = try JSONValue.fromEncodable(ProbeResult(
+                available: false,
+                reason: "macos_26_required"
+            ))
+            emit(JsonRpcResponse(id: request?.id, result: result))
+        } else {
+            emit(errorResponse(id: request?.id, code: -32000, message: "FoundationModels unavailable"))
+        }
+    }
+    exit(0)
+}
+
+let generator = Generator()
+FileHandle.standardError.write(Data("panops-llm-mac ready\n".utf8))
+
+while let line = readLine(strippingNewline: true) {
+    if line.isEmpty { continue }
+    let request: JsonRpcRequest
+    do {
+        request = try decoder.decode(JsonRpcRequest.self, from: Data(line.utf8))
+    } catch {
+        FileHandle.standardError.write(Data("parse error: \(error)\n".utf8))
+        emit(errorResponse(id: nil, code: -32700, message: "parse error"))
+        continue
+    }
+
+    do {
+        switch request.method {
+        case "probe", "llm.probe":
+            let result = try JSONValue.fromEncodable(await generator.probe())
+            emit(JsonRpcResponse(id: request.id, result: result))
+        case "complete", "llm.complete":
+            let params = try decodeParams(CompleteParams.self, from: request.params)
+            let result = try JSONValue.fromEncodable(await generator.complete(params))
+            emit(JsonRpcResponse(id: request.id, result: result))
+        default:
+            emit(errorResponse(id: request.id, code: -32601, message: "method not found"))
+        }
+    } catch let error as CodecError {
+        FileHandle.standardError.write(Data("request failed: \(error)\n".utf8))
+        emit(errorResponse(id: request.id, code: -32001, message: error.description))
+    } catch {
+        FileHandle.standardError.write(Data("request failed: \(error)\n".utf8))
+        emit(errorResponse(id: request.id, code: -32000, message: "request failed"))
+    }
+}
+
+FileHandle.standardError.write(Data("panops-llm-mac EOF; exiting\n".utf8))

--- a/apps/panops-llm-mac/Sources/PanopsLlmMacTestsBootstrap/CodecsSelfTestBootstrap.c
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMacTestsBootstrap/CodecsSelfTestBootstrap.c
@@ -1,0 +1,6 @@
+extern void panops_codecs_self_test_run(void);
+
+__attribute__((constructor))
+static void panops_codecs_self_test_bootstrap(void) {
+    panops_codecs_self_test_run();
+}

--- a/apps/panops-llm-mac/Sources/PanopsLlmMacTestsBootstrap/include/PanopsLlmMacTestsBootstrap.h
+++ b/apps/panops-llm-mac/Sources/PanopsLlmMacTestsBootstrap/include/PanopsLlmMacTestsBootstrap.h
@@ -1,0 +1,1 @@
+// Empty public header to satisfy SwiftPM's C target layout.

--- a/apps/panops-llm-mac/Tests/PanopsLlmMacTests/CodecsTests.swift
+++ b/apps/panops-llm-mac/Tests/PanopsLlmMacTests/CodecsTests.swift
@@ -95,6 +95,34 @@ struct CodecsTests {
         ]))
     }
 
+    @Test func nestedAnyOfWithNonObjectBranchesRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["choice"],
+          "properties": {
+            "choice": {
+              "anyOf": [
+                {"type": "string"},
+                {
+                  "oneOf": [
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        #expect(!generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"choice":true}"#, equals: .object([
+            "choice": .bool(true),
+        ]))
+    }
+
     private func json(_ raw: String) throws -> JSONValue {
         try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
     }
@@ -202,6 +230,34 @@ final class CodecsTests: XCTestCase {
         ]))
     }
 
+    func testNestedAnyOfWithNonObjectBranchesRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["choice"],
+          "properties": {
+            "choice": {
+              "anyOf": [
+                {"type": "string"},
+                {
+                  "oneOf": [
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        XCTAssertFalse(generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"choice":true}"#, equals: .object([
+            "choice": .bool(true),
+        ]))
+    }
+
     private func json(_ raw: String) throws -> JSONValue {
         try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
     }
@@ -218,11 +274,11 @@ import FoundationModels
 @testable import PanopsLlmMac
 
 // Command Line Tools on this host exposes FoundationModels but no XCTest or
-// Swift Testing modules. Run the same codec checks through a module initializer
-// so `swift test` is still a meaningful gate under this CLT-only toolchain.
+// Swift Testing modules. A tiny C constructor in PanopsLlmMacTestsBootstrap
+// calls `panops_codecs_self_test_run`, so `swift test` is still a meaningful
+// gate under this CLT-only toolchain instead of building zero tests.
 @available(macOS 26.0, *)
-private let _panopsCodecsSelfTest: Void = {
-    do {
+private func runCodecsSelfTest() throws {
         try assertSchema(#"""
         {
           "type": "object",
@@ -292,10 +348,30 @@ private let _panopsCodecsSelfTest: Void = {
         try assertGeneratedContent(#"{"title":"Anchor A"}"#, equals: .object([
             "title": .string("Anchor A"),
         ]))
-    } catch {
-        fatalError("PanopsLlmMac codec self-test failed: \(error)")
-    }
-}()
+
+        try assertSchema(#"""
+        {
+          "type": "object",
+          "required": ["choice"],
+          "properties": {
+            "choice": {
+              "anyOf": [
+                {"type": "string"},
+                {
+                  "oneOf": [
+                    {"type": "integer"},
+                    {"type": "boolean"}
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """#)
+        try assertGeneratedContent(#"{"choice":true}"#, equals: .object([
+            "choice": .bool(true),
+        ]))
+}
 
 @available(macOS 26.0, *)
 private func assertSchema(_ raw: String) throws {
@@ -311,3 +387,16 @@ private func assertGeneratedContent(_ rawJSON: String, equals expected: JSONValu
     precondition(actual == expected, "expected \(expected), got \(actual)")
 }
 #endif
+
+@_cdecl("panops_codecs_self_test_run")
+public func panopsCodecsSelfTestRun() {
+#if !canImport(Testing) && !canImport(XCTest)
+    if #available(macOS 26.0, *) {
+        do {
+            try runCodecsSelfTest()
+        } catch {
+            fatalError("PanopsLlmMac codec self-test failed: \(error)")
+        }
+    }
+#endif
+}

--- a/apps/panops-llm-mac/Tests/PanopsLlmMacTests/CodecsTests.swift
+++ b/apps/panops-llm-mac/Tests/PanopsLlmMacTests/CodecsTests.swift
@@ -1,0 +1,313 @@
+#if canImport(Testing)
+import FoundationModels
+import Testing
+@testable import PanopsLlmMac
+
+@available(macOS 26.0, *)
+struct CodecsTests {
+    @Test func objectSchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["title", "count"],
+          "properties": {
+            "title": {"type": "string"},
+            "count": {"type": "integer"}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        #expect(!generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"title":"Daily notes","count":2}"#, equals: .object([
+            "title": .string("Daily notes"),
+            "count": .int(2),
+        ]))
+    }
+
+    @Test func enumSchemaMapsToAnyOfAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": {"type": "string", "enum": ["ok", "blocked"]}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        #expect(!generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"status":"blocked"}"#, equals: .object([
+            "status": .string("blocked"),
+        ]))
+    }
+
+    @Test func nestedSchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["action_items"],
+          "properties": {
+            "action_items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["description"],
+                "properties": {
+                  "description": {"type": "string"},
+                  "owner": {"type": ["string", "null"]}
+                }
+              }
+            }
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        #expect(!generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"action_items":[{"description":"Send notes","owner":"Fran"}]}"#, equals: .object([
+            "action_items": .array([
+                .object([
+                    "description": .string("Send notes"),
+                    "owner": .string("Fran"),
+                ]),
+            ]),
+        ]))
+    }
+
+    @Test func optionalPropertySchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["title"],
+          "properties": {
+            "title": {"type": "string"},
+            "summary": {"type": "string"}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        #expect(!generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"title":"Anchor A"}"#, equals: .object([
+            "title": .string("Anchor A"),
+        ]))
+    }
+
+    private func json(_ raw: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
+    }
+
+    private func assertGeneratedContent(_ rawJSON: String, equals expected: JSONValue) throws {
+        let content = try GeneratedContent(json: rawJSON)
+        let actual = try FoundationModelCodecs.jsonValue(from: content)
+        #expect(actual == expected)
+    }
+}
+#elseif canImport(XCTest)
+import XCTest
+import FoundationModels
+@testable import PanopsLlmMac
+
+@available(macOS 26.0, *)
+final class CodecsTests: XCTestCase {
+    func testObjectSchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["title", "count"],
+          "properties": {
+            "title": {"type": "string"},
+            "count": {"type": "integer"}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        XCTAssertFalse(generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"title":"Daily notes","count":2}"#, equals: .object([
+            "title": .string("Daily notes"),
+            "count": .int(2),
+        ]))
+    }
+
+    func testEnumSchemaMapsToAnyOfAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": {"type": "string", "enum": ["ok", "blocked"]}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        XCTAssertFalse(generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"status":"blocked"}"#, equals: .object([
+            "status": .string("blocked"),
+        ]))
+    }
+
+    func testNestedSchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["action_items"],
+          "properties": {
+            "action_items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["description"],
+                "properties": {
+                  "description": {"type": "string"},
+                  "owner": {"type": ["string", "null"]}
+                }
+              }
+            }
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        XCTAssertFalse(generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"action_items":[{"description":"Send notes","owner":"Fran"}]}"#, equals: .object([
+            "action_items": .array([
+                .object([
+                    "description": .string("Send notes"),
+                    "owner": .string("Fran"),
+                ]),
+            ]),
+        ]))
+    }
+
+    func testOptionalPropertySchemaAndGeneratedContentRoundTrip() throws {
+        let schema = try json(#"""
+        {
+          "type": "object",
+          "required": ["title"],
+          "properties": {
+            "title": {"type": "string"},
+            "summary": {"type": "string"}
+          }
+        }
+        """#)
+        let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+        XCTAssertFalse(generationSchema.debugDescription.isEmpty)
+
+        try assertGeneratedContent(#"{"title":"Anchor A"}"#, equals: .object([
+            "title": .string("Anchor A"),
+        ]))
+    }
+
+    private func json(_ raw: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
+    }
+
+    private func assertGeneratedContent(_ rawJSON: String, equals expected: JSONValue, file: StaticString = #filePath, line: UInt = #line) throws {
+        let content = try GeneratedContent(json: rawJSON)
+        let actual = try FoundationModelCodecs.jsonValue(from: content)
+        XCTAssertEqual(actual, expected, file: file, line: line)
+    }
+}
+#else
+import Foundation
+import FoundationModels
+@testable import PanopsLlmMac
+
+// Command Line Tools on this host exposes FoundationModels but no XCTest or
+// Swift Testing modules. Run the same codec checks through a module initializer
+// so `swift test` is still a meaningful gate under this CLT-only toolchain.
+@available(macOS 26.0, *)
+private let _panopsCodecsSelfTest: Void = {
+    do {
+        try assertSchema(#"""
+        {
+          "type": "object",
+          "required": ["title", "count"],
+          "properties": {
+            "title": {"type": "string"},
+            "count": {"type": "integer"}
+          }
+        }
+        """#)
+        try assertGeneratedContent(#"{"title":"Daily notes","count":2}"#, equals: .object([
+            "title": .string("Daily notes"),
+            "count": .int(2),
+        ]))
+
+        try assertSchema(#"""
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": {"type": "string", "enum": ["ok", "blocked"]}
+          }
+        }
+        """#)
+        try assertGeneratedContent(#"{"status":"blocked"}"#, equals: .object([
+            "status": .string("blocked"),
+        ]))
+
+        try assertSchema(#"""
+        {
+          "type": "object",
+          "required": ["action_items"],
+          "properties": {
+            "action_items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["description"],
+                "properties": {
+                  "description": {"type": "string"},
+                  "owner": {"type": ["string", "null"]}
+                }
+              }
+            }
+          }
+        }
+        """#)
+        try assertGeneratedContent(#"{"action_items":[{"description":"Send notes","owner":"Fran"}]}"#, equals: .object([
+            "action_items": .array([
+                .object([
+                    "description": .string("Send notes"),
+                    "owner": .string("Fran"),
+                ]),
+            ]),
+        ]))
+
+        try assertSchema(#"""
+        {
+          "type": "object",
+          "required": ["title"],
+          "properties": {
+            "title": {"type": "string"},
+            "summary": {"type": "string"}
+          }
+        }
+        """#)
+        try assertGeneratedContent(#"{"title":"Anchor A"}"#, equals: .object([
+            "title": .string("Anchor A"),
+        ]))
+    } catch {
+        fatalError("PanopsLlmMac codec self-test failed: \(error)")
+    }
+}()
+
+@available(macOS 26.0, *)
+private func assertSchema(_ raw: String) throws {
+    let schema = try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
+    let generationSchema = try FoundationModelCodecs.generationSchema(from: schema)
+    precondition(!generationSchema.debugDescription.isEmpty)
+}
+
+@available(macOS 26.0, *)
+private func assertGeneratedContent(_ rawJSON: String, equals expected: JSONValue) throws {
+    let content = try GeneratedContent(json: rawJSON)
+    let actual = try FoundationModelCodecs.jsonValue(from: content)
+    precondition(actual == expected, "expected \(expected), got \(actual)")
+}
+#endif

--- a/crates/panops-engine/src/asr_resolver.rs
+++ b/crates/panops-engine/src/asr_resolver.rs
@@ -34,25 +34,6 @@ pub fn pick_asr(
 
 #[cfg(target_os = "macos")]
 fn sidecar_binary() -> Option<std::path::PathBuf> {
-    use std::os::unix::fs::PermissionsExt;
-
     let bin = std::env::var("PANOPS_ASR_SIDECAR_BIN").ok()?;
-    // Canonicalize before the metadata check to narrow the symlink-swap
-    // window between validation and `Command::spawn`. Note this is
-    // best-effort UX (clean fallback to whisper-rs on bad input), not
-    // a security boundary — a sufficiently fast swap *after* canonicalize
-    // can still race the spawn. The path is local-only and operator-set,
-    // so the threat model accepts this.
-    let path = std::fs::canonicalize(bin).ok()?;
-    let meta = std::fs::metadata(&path).ok()?;
-    if !meta.is_file() {
-        return None;
-    }
-    // Verify execute permission for owner/group/other (0o111). A regular
-    // file without exec bits would `spawn`-fail at runtime; cleaner to
-    // reject up front and fall back to whisper-rs.
-    if meta.permissions().mode() & 0o111 == 0 {
-        return None;
-    }
-    Some(path)
+    crate::sidecar_binary::executable_file(std::path::PathBuf::from(bin))
 }

--- a/crates/panops-engine/src/lib.rs
+++ b/crates/panops-engine/src/lib.rs
@@ -2,4 +2,5 @@
 //! the server in-process. The binary entry point lives in `main.rs`.
 pub mod asr_resolver;
 pub mod capture_resolver;
+pub mod llm_resolver;
 pub mod server;

--- a/crates/panops-engine/src/lib.rs
+++ b/crates/panops-engine/src/lib.rs
@@ -4,3 +4,4 @@ pub mod asr_resolver;
 pub mod capture_resolver;
 pub mod llm_resolver;
 pub mod server;
+mod sidecar_binary;

--- a/crates/panops-engine/src/llm_resolver.rs
+++ b/crates/panops-engine/src/llm_resolver.rs
@@ -1,0 +1,114 @@
+//! Resolve which `LlmProvider` impl the engine uses at startup.
+//!
+//! On macOS, if `PANOPS_LLM_SIDECAR_BIN` is set AND that path is an
+//! executable file, probe the FoundationModels sidecar (`panops_mac::FoundationLlm`).
+//! If `SystemLanguageModel.availability` reports available, use it;
+//! otherwise fall back to `GenaiLlm` (Ollama / provider env auto-detect).
+//!
+//! Slice 15 design:
+//! `docs/superpowers/specs/2026-06-06-slice-15-foundationmodels-llm-sidecar-design.md`.
+
+use std::sync::Arc;
+
+use panops_core::llm::LlmProvider;
+use panops_portable::genai_llm::GenaiLlm;
+
+/// Resolve the LLM adapter as an `Arc<dyn LlmProvider + Send + Sync>`.
+///
+/// `sidecar_path` is intentionally an explicit argument instead of a
+/// hidden read inside this function so `main.rs` owns the dev/CI-only
+/// `PANOPS_LLM_SIDECAR_BIN` gate and production bundle resolution can
+/// land later without changing the provider-selection policy.
+pub fn pick_llm(
+    handle: tokio::runtime::Handle,
+    sidecar_path: Option<std::path::PathBuf>,
+) -> Arc<dyn LlmProvider + Send + Sync> {
+    #[cfg(not(target_os = "macos"))]
+    let _ = sidecar_path;
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(sidecar) = sidecar_path.and_then(validate_sidecar_binary) {
+            let llm = panops_mac::FoundationLlm::new(sidecar.clone());
+            match llm.probe() {
+                Ok(probe) if probe.available => {
+                    tracing::info!(
+                        sidecar = %sidecar.display(),
+                        "selecting FoundationModels LLM sidecar"
+                    );
+                    return Arc::new(llm);
+                }
+                Ok(probe) => {
+                    tracing::info!(
+                        sidecar = %sidecar.display(),
+                        reason = probe.reason.as_deref().unwrap_or("unavailable"),
+                        "FoundationModels unavailable; falling back to GenaiLlm"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        sidecar = %sidecar.display(),
+                        error = %e,
+                        "FoundationModels sidecar probe failed; falling back to GenaiLlm"
+                    );
+                }
+            }
+        }
+    }
+    Arc::new(genai_with_handle(handle))
+}
+
+/// Read the dev/CI-only `PANOPS_LLM_SIDECAR_BIN` gate. The returned
+/// path is not validated here; [`pick_llm`] canonicalizes + exec-bit
+/// checks before spawning so tests can inject non-existent paths and
+/// observe fallback.
+pub fn sidecar_binary_from_env() -> Option<std::path::PathBuf> {
+    std::env::var_os("PANOPS_LLM_SIDECAR_BIN").map(std::path::PathBuf::from)
+}
+
+fn genai_with_handle(handle: tokio::runtime::Handle) -> GenaiLlm {
+    let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        "claude-haiku-4-5-20251001"
+    } else if std::env::var("OPENAI_API_KEY").is_ok() {
+        "gpt-4o-mini"
+    } else if std::env::var("OLLAMA_HOST").is_ok() {
+        "gemma3:4b"
+    } else {
+        // Last-resort default. Matches `GenaiLlm::auto` so the IPC
+        // server is no more restrictive than the CLI's auto mode.
+        "gemma3:4b"
+    };
+    GenaiLlm::with_handle(model, handle)
+}
+
+#[cfg(target_os = "macos")]
+fn validate_sidecar_binary(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Canonicalize before the metadata check to narrow the symlink-swap
+    // window between validation and `Command::spawn`. This is best-effort
+    // UX (clean fallback on bad dev input), not a security boundary.
+    let path = std::fs::canonicalize(path).ok()?;
+    let meta = std::fs::metadata(&path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+    // Verify execute permission for owner/group/other (0o111). A regular
+    // file without exec bits would `spawn`-fail at runtime; cleaner to
+    // reject up front and fall back to GenaiLlm.
+    if meta.permissions().mode() & 0o111 == 0 {
+        return None;
+    }
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn genai_default_model_is_constructible_without_env() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _llm = genai_with_handle(rt.handle().clone());
+    }
+}

--- a/crates/panops-engine/src/llm_resolver.rs
+++ b/crates/panops-engine/src/llm_resolver.rs
@@ -28,7 +28,7 @@ pub fn pick_llm(
 
     #[cfg(target_os = "macos")]
     {
-        if let Some(sidecar) = sidecar_path.and_then(validate_sidecar_binary) {
+        if let Some(sidecar) = sidecar_path.and_then(crate::sidecar_binary::executable_file) {
             let llm = panops_mac::FoundationLlm::new(sidecar.clone());
             match llm.probe() {
                 Ok(probe) if probe.available => {
@@ -79,27 +79,6 @@ fn genai_with_handle(handle: tokio::runtime::Handle) -> GenaiLlm {
         "gemma3:4b"
     };
     GenaiLlm::with_handle(model, handle)
-}
-
-#[cfg(target_os = "macos")]
-fn validate_sidecar_binary(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
-    use std::os::unix::fs::PermissionsExt;
-
-    // Canonicalize before the metadata check to narrow the symlink-swap
-    // window between validation and `Command::spawn`. This is best-effort
-    // UX (clean fallback on bad dev input), not a security boundary.
-    let path = std::fs::canonicalize(path).ok()?;
-    let meta = std::fs::metadata(&path).ok()?;
-    if !meta.is_file() {
-        return None;
-    }
-    // Verify execute permission for owner/group/other (0o111). A regular
-    // file without exec bits would `spawn`-fail at runtime; cleaner to
-    // reject up front and fall back to GenaiLlm.
-    if meta.permissions().mode() & 0o111 == 0 {
-        return None;
-    }
-    Some(path)
 }
 
 #[cfg(test)]

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -128,7 +128,11 @@ fn main() -> ExitCode {
             language,
             data_dir.clone(),
         ),
-        Some(Cmd::Serve { socket }) => panops_engine::server::run_serve(socket, data_dir),
+        Some(Cmd::Serve { socket }) => panops_engine::server::run_serve(
+            socket,
+            data_dir,
+            panops_engine::llm_resolver::sidecar_binary_from_env(),
+        ),
     };
     match res {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -161,7 +161,11 @@ impl EngineServices {
 }
 
 /// CLI entry point — owns both tokio runtimes and the signal handler.
-pub fn run_serve(socket: Option<PathBuf>, data_dir: PathBuf) -> Result<(), (u8, String)> {
+pub fn run_serve(
+    socket: Option<PathBuf>,
+    data_dir: PathBuf,
+    llm_sidecar_path: Option<PathBuf>,
+) -> Result<(), (u8, String)> {
     let path = match socket {
         Some(p) => p,
         None => socket::default_socket_path().map_err(|e| (3, e))?,
@@ -201,7 +205,7 @@ pub fn run_serve(socket: Option<PathBuf>, data_dir: PathBuf) -> Result<(), (u8, 
         // with the accept loop, so the socket binds within the 5s
         // budget and `notes.generate` is gated with
         // `ProviderUnavailable` until the trio is ready.
-        let llm = build_llm(llm_handle);
+        let llm = crate::llm_resolver::pick_llm(llm_handle, llm_sidecar_path);
         let (services, heavy_lock) = EngineServices::pending(llm, storage, data_dir);
         spawn_heavy_init(heavy_lock);
         run_serve_in_process(&path, services, None).await
@@ -223,31 +227,6 @@ pub fn run_serve(socket: Option<PathBuf>, data_dir: PathBuf) -> Result<(), (u8, 
         }
     };
     std::process::exit(i32::from(exit_code));
-}
-
-/// LLM adapter for `serve` mode. Picks a model based on environment
-/// (mirrors `GenaiLlm::auto`'s precedence) and wires it to Runtime B
-/// via `with_handle`. We don't delegate to `GenaiLlm::auto` directly
-/// because `auto` uses the lazy shared CLI runtime — `serve` mode
-/// must route outbound HTTP through Runtime B, not the CLI runtime.
-/// Provider precedence stays in sync with `GenaiLlm::auto`'s order
-/// (ANTHROPIC_API_KEY → OPENAI_API_KEY → OLLAMA_HOST → default).
-/// Both should collapse when `panops-portable::genai_llm` grows an
-/// `auto_with_handle` helper.
-fn build_llm(handle: tokio::runtime::Handle) -> Arc<dyn LlmProvider + Send + Sync> {
-    use panops_portable::genai_llm::GenaiLlm;
-    let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-        "claude-haiku-4-5-20251001"
-    } else if std::env::var("OPENAI_API_KEY").is_ok() {
-        "gpt-4o-mini"
-    } else if std::env::var("OLLAMA_HOST").is_ok() {
-        "gemma3:4b"
-    } else {
-        // Last-resort default. Matches `GenaiLlm::auto` so the IPC
-        // server is no more restrictive than the CLI's auto mode.
-        "gemma3:4b"
-    };
-    Arc::new(GenaiLlm::with_handle(model, handle))
 }
 
 /// Spawn the heavy-adapter init task. Runs on tokio's blocking pool

--- a/crates/panops-engine/src/sidecar_binary.rs
+++ b/crates/panops-engine/src/sidecar_binary.rs
@@ -1,0 +1,22 @@
+//! Shared sidecar binary validation for macOS adapter resolvers.
+
+#[cfg(target_os = "macos")]
+pub(crate) fn executable_file(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Canonicalize before the metadata check to narrow the symlink-swap
+    // window between validation and `Command::spawn`. This is best-effort
+    // UX (clean fallback on bad dev input), not a security boundary.
+    let path = std::fs::canonicalize(path).ok()?;
+    let meta = std::fs::metadata(&path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+    // Verify execute permission for owner/group/other (0o111). A regular
+    // file without exec bits would `spawn`-fail at runtime; cleaner to
+    // reject up front and fall back to the portable provider.
+    if meta.permissions().mode() & 0o111 == 0 {
+        return None;
+    }
+    Some(path)
+}

--- a/crates/panops-engine/tests/llm_resolver.rs
+++ b/crates/panops-engine/tests/llm_resolver.rs
@@ -1,0 +1,61 @@
+#![cfg(target_os = "macos")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn write_fake_sidecar(
+    available: bool,
+) -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("fake-panops-llm-mac");
+    let result = if available {
+        r#"{"available":true}"#
+    } else {
+        r#"{"available":false,"reason":"fake unavailable"}"#
+    };
+    let script = format!(
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+  printf '{{"jsonrpc":"2.0","id":%s,"result":{result}}}\n' "$id"
+done
+"#,
+        result = result
+    );
+    std::fs::write(&path, script)?;
+    let mut perms = std::fs::metadata(&path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms)?;
+    Ok((dir, path))
+}
+
+#[test]
+fn resolver_accepts_available_sidecar() -> TestResult {
+    let (_dir, bin) = write_fake_sidecar(true)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    drop(llm);
+    Ok(())
+}
+
+#[test]
+fn resolver_falls_back_when_probe_unavailable() -> TestResult {
+    let (_dir, bin) = write_fake_sidecar(false)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    drop(llm);
+    Ok(())
+}
+
+#[test]
+fn resolver_falls_back_when_sidecar_is_not_executable() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let bin = dir.path().join("not-executable");
+    std::fs::write(&bin, "#!/bin/sh\nexit 0\n")?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    drop(llm);
+    Ok(())
+}

--- a/crates/panops-engine/tests/llm_resolver.rs
+++ b/crates/panops-engine/tests/llm_resolver.rs
@@ -59,3 +59,13 @@ fn resolver_falls_back_when_sidecar_is_not_executable() -> TestResult {
     drop(llm);
     Ok(())
 }
+
+#[test]
+fn resolver_falls_back_when_sidecar_path_does_not_exist() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let missing = dir.path().join("missing-panops-llm-mac");
+    let rt = tokio::runtime::Runtime::new()?;
+    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(missing));
+    drop(llm);
+    Ok(())
+}

--- a/crates/panops-mac/src/foundation_llm.rs
+++ b/crates/panops-mac/src/foundation_llm.rs
@@ -3,10 +3,13 @@
 //! stdio. Lazy spawn on first probe/complete; reused across calls to
 //! amortize FoundationModels session setup.
 
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, ErrorKind, Write};
+use std::os::fd::AsRawFd;
+use std::os::raw::{c_int, c_short};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -15,6 +18,30 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// is expected to be small; this is a safety bound against a wedged
 /// sidecar emitting an unbounded line.
 const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+/// Startup probes run before the IPC socket binds; keep this short so a
+/// wedged sidecar cannot prevent `serve` from starting and falling back.
+const PROBE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Completion can legitimately take longer, but still must be bounded so a
+/// wedged model/sidecar does not poison the adapter forever.
+const COMPLETE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+const F_GETFL: c_int = 3;
+const F_SETFL: c_int = 4;
+const O_NONBLOCK: c_int = 0x0004;
+const POLLIN: c_short = 0x0001;
+const POLLNVAL: c_short = 0x0020;
+
+#[repr(C)]
+struct PollFd {
+    fd: c_int,
+    events: c_short,
+    revents: c_short,
+}
+
+unsafe extern "C" {
+    fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;
+    fn poll(fds: *mut PollFd, nfds: u32, timeout: c_int) -> c_int;
+}
 
 pub struct FoundationLlm {
     binary: PathBuf,
@@ -143,9 +170,24 @@ impl FoundationLlm {
             // FoundationModels availability/errors land in Console.app.
             .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|e| LlmError::Provider(format!("sidecar spawn: {e}")))?;
+            .map_err(|e| {
+                tracing::warn!(
+                    binary = %self.binary.display(),
+                    error = %e,
+                    "panops-llm-mac sidecar spawn failed"
+                );
+                LlmError::Provider("sidecar spawn failed".into())
+            })?;
         let stdin = child.stdin.take().expect("stdin piped");
         let stdout = child.stdout.take().expect("stdout piped");
+        set_nonblocking(&stdout).map_err(|e| {
+            tracing::warn!(
+                binary = %self.binary.display(),
+                error = %e,
+                "panops-llm-mac sidecar stdout nonblocking setup failed"
+            );
+            LlmError::Provider("sidecar setup failed".into())
+        })?;
         *slot = Some(SidecarState {
             child: Some(child),
             stdin: Some(stdin),
@@ -202,19 +244,25 @@ impl FoundationLlm {
             return Err(LlmError::Provider(format!("stdio write: {e}")));
         }
 
-        // Bound the response read against a wedged sidecar emitting an
-        // unbounded line. `take(MAX_RESPONSE_BYTES)` + `read_until(b'\n')`
-        // gives us a strict cap; if we read the cap and the last byte
-        // isn't a newline, the line was truncated and framing is lost.
+        // Bound the response read by size AND by deadline. The probe path is
+        // exercised before the IPC socket binds, so timeout must surface as a
+        // provider error and let the resolver fall back instead of hanging
+        // `serve` forever.
         let mut buf: Vec<u8> = Vec::new();
+        let timeout = response_timeout(method);
         let read_result = {
             let state = slot.as_mut().expect("still spawned");
-            (&mut state.stdout)
-                .take(MAX_RESPONSE_BYTES)
-                .read_until(b'\n', &mut buf)
+            read_response_line(&mut state.stdout, &mut buf, timeout)
         };
         let n = match read_result {
             Ok(n) => n,
+            Err(e) if e.kind() == ErrorKind::TimedOut => {
+                *slot = None;
+                return Err(LlmError::Provider(format!(
+                    "sidecar response timed out after {}s",
+                    timeout.as_secs()
+                )));
+            }
             Err(e) => {
                 *slot = None;
                 return Err(LlmError::Provider(format!("stdio read: {e}")));
@@ -281,6 +329,107 @@ impl FoundationLlm {
         }
         resp.result
             .ok_or_else(|| LlmError::Provider("response missing result".into()))
+    }
+}
+
+fn response_timeout(method: &str) -> Duration {
+    if method == "probe" || method == "llm.probe" {
+        PROBE_RESPONSE_TIMEOUT
+    } else {
+        COMPLETE_RESPONSE_TIMEOUT
+    }
+}
+
+fn set_nonblocking(stdout: &ChildStdout) -> io::Result<()> {
+    let fd = stdout.as_raw_fd();
+    // SAFETY: `fd` is a live stdout pipe owned by `ChildStdout`. `fcntl` does
+    // not take ownership and only updates descriptor flags.
+    let flags = unsafe { fcntl(fd, F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: Same live fd; OR-ing O_NONBLOCK preserves the existing flags.
+    let rc = unsafe { fcntl(fd, F_SETFL, flags | O_NONBLOCK) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn read_response_line(
+    stdout: &mut BufReader<ChildStdout>,
+    buf: &mut Vec<u8>,
+    timeout: Duration,
+) -> io::Result<usize> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match stdout.fill_buf() {
+            Ok([]) if buf.is_empty() => return Ok(0),
+            Ok([]) => return Ok(buf.len()),
+            Ok(available) => {
+                let consumed = if let Some(pos) = available.iter().position(|b| *b == b'\n') {
+                    let end = pos + 1;
+                    buf.extend_from_slice(&available[..end]);
+                    end
+                } else {
+                    buf.extend_from_slice(available);
+                    available.len()
+                };
+                stdout.consume(consumed);
+                if buf.len() as u64 >= MAX_RESPONSE_BYTES {
+                    return Ok(buf.len());
+                }
+                if buf.last() == Some(&b'\n') {
+                    return Ok(buf.len());
+                }
+            }
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                wait_readable(stdout.get_ref().as_raw_fd(), deadline)?;
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn wait_readable(fd: i32, deadline: Instant) -> io::Result<()> {
+    let now = Instant::now();
+    if now >= deadline {
+        return Err(io::Error::new(
+            ErrorKind::TimedOut,
+            "sidecar response timed out",
+        ));
+    }
+    let remaining = deadline.saturating_duration_since(now);
+    let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+    let mut fds = PollFd {
+        fd,
+        events: POLLIN,
+        revents: 0,
+    };
+    loop {
+        // SAFETY: `fds` points to one initialized pollfd for a live pipe fd;
+        // poll does not retain the pointer after returning.
+        let rc = unsafe { poll(&mut fds, 1, timeout_ms) };
+        if rc > 0 {
+            if fds.revents & POLLNVAL != 0 {
+                return Err(io::Error::new(
+                    ErrorKind::BrokenPipe,
+                    "sidecar stdout descriptor invalid",
+                ));
+            }
+            return Ok(());
+        }
+        if rc == 0 {
+            return Err(io::Error::new(
+                ErrorKind::TimedOut,
+                "sidecar response timed out",
+            ));
+        }
+        let e = io::Error::last_os_error();
+        if e.kind() != ErrorKind::Interrupted {
+            return Err(e);
+        }
     }
 }
 

--- a/crates/panops-mac/src/foundation_llm.rs
+++ b/crates/panops-mac/src/foundation_llm.rs
@@ -1,0 +1,329 @@
+//! FoundationModels LLM sidecar adapter. Spawns `panops-llm-mac` as a
+//! child process and communicates via newline-delimited JSON-RPC over
+//! stdio. Lazy spawn on first probe/complete; reused across calls to
+//! amortize FoundationModels session setup.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::Mutex;
+
+use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Reject sidecar response lines larger than 16 MiB. Guided notes JSON
+/// is expected to be small; this is a safety bound against a wedged
+/// sidecar emitting an unbounded line.
+const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+
+pub struct FoundationLlm {
+    binary: PathBuf,
+    state: Mutex<Option<SidecarState>>,
+    next_id: Mutex<u64>,
+}
+
+struct SidecarState {
+    /// `Option` so `Drop` can `take()` the child + close pipes before
+    /// `kill()` / `wait()`. Always `Some` while the sidecar is alive.
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl Drop for SidecarState {
+    fn drop(&mut self) {
+        // Closing stdin first lets the sidecar's readLine loop see EOF
+        // and exit cleanly. kill + wait afterward catches the wedged
+        // case so we never leak a zombie when `*slot = None` runs on
+        // an error path.
+        drop(self.stdin.take());
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProbeResult {
+    pub available: bool,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ProbeParams {}
+
+#[derive(Serialize)]
+struct CompleteParams<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<&'a str>,
+    user: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<&'a serde_json::Value>,
+    temperature: f32,
+    max_tokens: u32,
+}
+
+#[derive(Serialize)]
+struct RpcRequest<P> {
+    jsonrpc: &'static str,
+    id: u64,
+    method: &'static str,
+    params: P,
+}
+
+#[derive(Deserialize)]
+struct RpcResponse<R> {
+    #[serde(rename = "jsonrpc", deserialize_with = "deserialize_jsonrpc_version")]
+    _jsonrpc: (),
+    /// `Option` so a sidecar parse-error response with `id: null`
+    /// (JSON-RPC 2.0 §4) decodes instead of failing — we still
+    /// surface it as an error because we can't pair it to a request.
+    id: Option<u64>,
+    result: Option<R>,
+    error: Option<RpcError>,
+}
+
+#[derive(Deserialize, Debug)]
+struct RpcError {
+    code: i32,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct CompleteResult {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    json: Option<serde_json::Value>,
+}
+
+/// Reject responses whose `jsonrpc` field is anything but `"2.0"`. A
+/// silent mismatch would hide framing-version drift between the engine
+/// and the sidecar.
+fn deserialize_jsonrpc_version<'de, D>(de: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v = String::deserialize(de)?;
+    if v != "2.0" {
+        return Err(serde::de::Error::custom(format!(
+            "unsupported jsonrpc version: {v}"
+        )));
+    }
+    Ok(())
+}
+
+impl FoundationLlm {
+    pub fn new(binary: PathBuf) -> Self {
+        Self {
+            binary,
+            state: Mutex::new(None),
+            next_id: Mutex::new(1),
+        }
+    }
+
+    /// Probe `SystemLanguageModel.availability` through the sidecar.
+    /// Called by the engine resolver at startup and by tests; keeps the
+    /// spawned process alive so a subsequent `complete` reuses it.
+    pub fn probe(&self) -> Result<ProbeResult, LlmError> {
+        self.send_request("probe", ProbeParams {})
+    }
+
+    fn ensure_spawned(&self, slot: &mut Option<SidecarState>) -> Result<(), LlmError> {
+        if slot.is_some() {
+            return Ok(());
+        }
+        tracing::info!(binary = %self.binary.display(), "spawning panops-llm-mac sidecar");
+        let mut child = Command::new(&self.binary)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Sidecar's stderr passes through to engine's stderr so
+            // FoundationModels availability/errors land in Console.app.
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| LlmError::Provider(format!("sidecar spawn: {e}")))?;
+        let stdin = child.stdin.take().expect("stdin piped");
+        let stdout = child.stdout.take().expect("stdout piped");
+        *slot = Some(SidecarState {
+            child: Some(child),
+            stdin: Some(stdin),
+            stdout: BufReader::new(stdout),
+        });
+        Ok(())
+    }
+
+    fn next_id(&self) -> Result<u64, LlmError> {
+        let mut id = self
+            .next_id
+            .lock()
+            .map_err(|e| LlmError::Provider(format!("next_id mutex poisoned: {e}")))?;
+        let v = *id;
+        *id += 1;
+        Ok(v)
+    }
+
+    fn send_request<P, R>(&self, method: &'static str, params: P) -> Result<R, LlmError>
+    where
+        P: Serialize,
+        R: for<'de> Deserialize<'de>,
+    {
+        let mut slot = self
+            .state
+            .lock()
+            .map_err(|e| LlmError::Provider(format!("sidecar state mutex poisoned: {e}")))?;
+        self.ensure_spawned(&mut slot)?;
+
+        let id = self.next_id()?;
+        let req = RpcRequest {
+            jsonrpc: "2.0",
+            id,
+            method,
+            params,
+        };
+        let body =
+            serde_json::to_vec(&req).map_err(|e| LlmError::Provider(format!("encode: {e}")))?;
+
+        // Clear the sidecar state on any stdio failure so the next call
+        // respawns cleanly. A BrokenPipe (sidecar died mid-write) without
+        // this would leave the slot populated and every subsequent call
+        // would fail on the same dead pipe.
+        let write_result = {
+            let state = slot.as_mut().expect("just spawned");
+            let stdin = state.stdin.as_mut().expect("stdin live while spawned");
+            stdin
+                .write_all(&body)
+                .and_then(|()| stdin.write_all(b"\n"))
+                .and_then(|()| stdin.flush())
+        };
+        if let Err(e) = write_result {
+            *slot = None;
+            return Err(LlmError::Provider(format!("stdio write: {e}")));
+        }
+
+        // Bound the response read against a wedged sidecar emitting an
+        // unbounded line. `take(MAX_RESPONSE_BYTES)` + `read_until(b'\n')`
+        // gives us a strict cap; if we read the cap and the last byte
+        // isn't a newline, the line was truncated and framing is lost.
+        let mut buf: Vec<u8> = Vec::new();
+        let read_result = {
+            let state = slot.as_mut().expect("still spawned");
+            (&mut state.stdout)
+                .take(MAX_RESPONSE_BYTES)
+                .read_until(b'\n', &mut buf)
+        };
+        let n = match read_result {
+            Ok(n) => n,
+            Err(e) => {
+                *slot = None;
+                return Err(LlmError::Provider(format!("stdio read: {e}")));
+            }
+        };
+        if n == 0 {
+            *slot = None;
+            return Err(LlmError::Provider(
+                "sidecar exited before responding".into(),
+            ));
+        }
+        if buf.last() != Some(&b'\n') {
+            *slot = None;
+            let msg = if (n as u64) >= MAX_RESPONSE_BYTES {
+                format!("sidecar response exceeded {MAX_RESPONSE_BYTES} bytes without newline")
+            } else {
+                format!("sidecar response truncated at {n} bytes (EOF mid-line)")
+            };
+            return Err(LlmError::Provider(msg));
+        }
+        let line = std::str::from_utf8(&buf)
+            .map_err(|e| LlmError::Provider(format!("response not utf-8: {e}")))?;
+        let resp: RpcResponse<R> = serde_json::from_str(line.trim_end()).map_err(|e| {
+            *slot = None;
+            LlmError::Provider(format!("decode: {e}"))
+        })?;
+        match resp.id {
+            Some(rid) if rid == id => {}
+            Some(rid) => {
+                *slot = None;
+                return Err(LlmError::Provider(format!(
+                    "JSON-RPC id mismatch: expected {id}, got {rid}"
+                )));
+            }
+            None => {
+                *slot = None;
+                let detail = resp
+                    .error
+                    .as_ref()
+                    .map(|e| format!(" (sidecar code {})", e.code))
+                    .unwrap_or_default();
+                return Err(LlmError::Provider(format!(
+                    "sidecar returned null id{detail}"
+                )));
+            }
+        }
+        if let Some(err) = resp.error {
+            tracing::error!(
+                code = err.code,
+                message = %err.message,
+                "panops-llm-mac sidecar returned error"
+            );
+            return match err.code {
+                -32001 | -32602 => Err(LlmError::InvalidSchema {
+                    expected: "valid JSON Schema convertible to FoundationModels".into(),
+                    got: format!("sidecar error (code {})", err.code),
+                }),
+                -32002 => Err(LlmError::EmptyResponse),
+                _ => Err(LlmError::Provider(format!(
+                    "sidecar error (code {})",
+                    err.code
+                ))),
+            };
+        }
+        resp.result
+            .ok_or_else(|| LlmError::Provider("response missing result".into()))
+    }
+}
+
+impl LlmProvider for FoundationLlm {
+    fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let result: CompleteResult = self.send_request(
+            "complete",
+            CompleteParams {
+                system: req.system.as_deref(),
+                user: &req.user,
+                schema: req.schema.as_ref(),
+                temperature: req.temperature,
+                max_tokens: req.max_tokens,
+            },
+        )?;
+        match (result.json, result.text) {
+            (Some(v), _) => Ok(LlmResponse::Json(v)),
+            (None, Some(s)) if !s.is_empty() => Ok(LlmResponse::Text(s)),
+            (None, Some(_)) => Err(LlmError::EmptyResponse),
+            (None, None) => Err(LlmError::EmptyResponse),
+        }
+    }
+}
+
+impl Drop for FoundationLlm {
+    fn drop(&mut self) {
+        // `SidecarState`'s own `Drop` closes stdin and reaps the child;
+        // we just need to take the slot here so it runs even if the
+        // mutex is held by no one.
+        if let Ok(mut slot) = self.state.lock() {
+            slot.take();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_id_monotonic() {
+        let llm = FoundationLlm::new(PathBuf::from("/nonexistent"));
+        let ids: Vec<u64> = (0..5).map(|_| llm.next_id().expect("next_id")).collect();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+    }
+}

--- a/crates/panops-mac/src/lib.rs
+++ b/crates/panops-mac/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![cfg(target_os = "macos")]
 
+mod foundation_llm;
 mod whisperkit_asr;
 
+pub use foundation_llm::{FoundationLlm, ProbeResult};
 pub use whisperkit_asr::WhisperKitAsr;

--- a/crates/panops-mac/tests/conformance_foundation_llm.rs
+++ b/crates/panops-mac/tests/conformance_foundation_llm.rs
@@ -1,0 +1,69 @@
+//! Conformance harness for `FoundationLlm` using a fake sidecar binary
+//! that speaks the same newline-delimited JSON-RPC protocol as
+//! `panops-llm-mac`.
+
+#![cfg(target_os = "macos")]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use panops_core::conformance::llm::run_suite;
+use panops_mac::FoundationLlm;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn write_fake_sidecar(
+    available: bool,
+) -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("fake-panops-llm-mac");
+    let probe = if available {
+        r#"{"available":true}"#
+    } else {
+        r#"{"available":false,"reason":"fake unavailable"}"#
+    };
+    let script = format!(
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+  if printf '%s' "$line" | grep -q '"method":"probe"'; then
+    printf '{{"jsonrpc":"2.0","id":%s,"result":{probe}}}\n' "$id"
+  elif printf '%s' "$line" | grep -q '"method":"complete"'; then
+    if printf '%s' "$line" | grep -q '"schema"'; then
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"json":{{"ok":true}}}}}}\n' "$id"
+    else
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"text":"hello from fake foundation"}}}}\n' "$id"
+    fi
+  else
+    printf '{{"jsonrpc":"2.0","id":%s,"error":{{"code":-32601,"message":"method not found"}}}}\n' "$id"
+  fi
+done
+"#,
+        probe = probe
+    );
+    std::fs::write(&path, script)?;
+    let mut perms = std::fs::metadata(&path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms)?;
+    Ok((dir, path))
+}
+
+#[test]
+fn fake_foundation_llm_passes_conformance_suite() -> TestResult {
+    let (_dir, bin) = write_fake_sidecar(true)?;
+    let llm = FoundationLlm::new(bin);
+    let probe = llm.probe()?;
+    assert!(probe.available);
+    run_suite(&llm);
+    Ok(())
+}
+
+#[test]
+fn fake_probe_can_report_unavailable() -> TestResult {
+    let (_dir, bin) = write_fake_sidecar(false)?;
+    let llm = FoundationLlm::new(bin);
+    let probe = llm.probe()?;
+    assert!(!probe.available);
+    assert_eq!(probe.reason.as_deref(), Some("fake unavailable"));
+    Ok(())
+}

--- a/crates/panops-mac/tests/conformance_foundation_llm.rs
+++ b/crates/panops-mac/tests/conformance_foundation_llm.rs
@@ -48,6 +48,26 @@ done
     Ok((dir, path))
 }
 
+fn write_static_response_sidecar(
+    response: &'static str,
+) -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("fake-panops-llm-mac-static");
+    let script = format!(
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  printf '%s\n' '{response}'
+done
+"#,
+        response = response.replace('\'', r"'\''")
+    );
+    std::fs::write(&path, script)?;
+    let mut perms = std::fs::metadata(&path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms)?;
+    Ok((dir, path))
+}
+
 #[test]
 fn fake_foundation_llm_passes_conformance_suite() -> TestResult {
     let (_dir, bin) = write_fake_sidecar(true)?;
@@ -65,5 +85,33 @@ fn fake_probe_can_report_unavailable() -> TestResult {
     let probe = llm.probe()?;
     assert!(!probe.available);
     assert_eq!(probe.reason.as_deref(), Some("fake unavailable"));
+    Ok(())
+}
+
+#[test]
+fn rejects_jsonrpc_id_mismatch() -> TestResult {
+    let (_dir, bin) =
+        write_static_response_sidecar(r#"{"jsonrpc":"2.0","id":999,"result":{"available":true}}"#)?;
+    let llm = FoundationLlm::new(bin);
+    let err = llm.probe().expect_err("mismatched id must fail");
+    assert!(
+        matches!(err, panops_core::llm::LlmError::Provider(ref message) if message.contains("JSON-RPC id mismatch")),
+        "unexpected error: {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_jsonrpc_version_mismatch() -> TestResult {
+    let (_dir, bin) =
+        write_static_response_sidecar(r#"{"jsonrpc":"1.0","id":1,"result":{"available":true}}"#)?;
+    let llm = FoundationLlm::new(bin);
+    let err = llm
+        .probe()
+        .expect_err("unsupported JSON-RPC version must fail");
+    assert!(
+        matches!(err, panops_core::llm::LlmError::Provider(ref message) if message.contains("unsupported jsonrpc version")),
+        "unexpected error: {err:?}"
+    );
     Ok(())
 }

--- a/docs/superpowers/specs/2026-06-06-slice-15-foundationmodels-llm-sidecar-design.md
+++ b/docs/superpowers/specs/2026-06-06-slice-15-foundationmodels-llm-sidecar-design.md
@@ -1,0 +1,104 @@
+# Slice 15 — FoundationModels LLM Sidecar (Anchor A completion)
+
+**Status:** design approved 2026-06-06 (maintainer). Brainstorm: this file. Plan: forthcoming via `superpowers:writing-plans`.
+
+## Problem
+
+Notes generation runs through the `LlmProvider` port. The only real adapter today is `GenaiLlm` (`crates/panops-portable/src/genai_llm.rs`, via the `genai` crate → a local Ollama `gemma3:4b`), built inline in `crates/panops-engine/src/server/mod.rs::n()`. For a signed, notarized, clean-Mac `.app` (v0.1 criterion #6) the product should generate notes **on-device** with Apple's FoundationModels (no separate Ollama install), while still working where FoundationModels isn't available.
+
+## Goal
+
+An on-device LLM via a Swift `panops-llm-mac` sidecar, selected automatically when available, falling back to the existing Ollama path otherwise. Completes **Anchor A** (Mac shell + sidecars). No change to the notes pipeline or the `LlmProvider` contract.
+
+## Decisions (locked)
+
+- **Option B — FoundationModels + Ollama fallback** (maintainer, on macOS 26). Auto-detected; no user-facing env var.
+- **Guided generation.** Convert `LlmRequest.schema` → `DynamicGenerationSchema` at runtime, `respond(to:schema:)`, serialize the structured `GeneratedContent` → JSON. Constrains output to the schema (valid-by-construction). Not text-JSON parsing.
+- **Resolver-time availability probe.** `pick_llm` spawns the sidecar once at startup and probes `SystemLanguageModel.availability`; available → FoundationModels, else → Ollama. One-time cost; clean startup decision.
+- **Mirror the ASR sidecar** (`whisperkit_asr.rs` / `asr_resolver.rs` / `apps/panops-asr-mac/`) for spawn/stdio/JSON-RPC/Drop/respawn + resolver.
+
+## Scope
+
+### In
+- `crates/panops-mac/src/foundation_llm.rs` — `FoundationLlm` impl `LlmProvider`; lazy-spawn `panops-llm-mac`, JSON-RPC over stdio (`complete`, `probe`), reuse, `Drop` closes stdin, respawn on broken pipe. Reuses the spawn/stdio machinery shape from `whisperkit_asr.rs`.
+- `crates/panops-engine/src/llm_resolver.rs` — `pick_llm()` mirroring `asr_resolver::pick_asr`; extracts the inline build from `server/mod.rs::n()`.
+- `apps/panops-llm-mac/` SwiftPM executable — `Sources/PanopsLlmMac/{main.swift, Codecs.swift, Generator.swift}`: stdio JSON-RPC loop; `Generator` wraps `LanguageModelSession`; `Codecs` does JSON-Schema ↔ `DynamicGenerationSchema` and `GeneratedContent` → JSON.
+- Engine wiring: `server/mod.rs::n()` → `llm_resolver::pick_llm(...)`; `main.rs` passes the sidecar path (env gate dev/CI).
+- Tests: `FoundationLlm` against the `LlmProvider` conformance suite via a fake sidecar binary; Swift unit tests for the codec.
+
+### Out (file as debt if surfaced)
+- Streaming / partial tokens (notes generation is batch).
+- Per-request model/provider selection (#98 — separate).
+- Production `Bundle.main` sidecar resolution + notarization (lands in the packaging slice; this slice keeps the env gate).
+- Multi-turn session reuse beyond one `complete` (each `complete` is stateless, matching the port).
+
+## Architecture
+
+```
+panops-core (LlmProvider port; UNTOUCHED)
+        ▲
+        │ impl
+crates/panops-engine/src/llm_resolver.rs ── pick_llm() ──┐
+        │  macOS + sidecar available + probe OK           │ else
+        ▼                                                 ▼
+crates/panops-mac/FoundationLlm  ──spawn/stdio JSON-RPC──►  panops-portable/GenaiLlm (Ollama)
+        │
+        ▼
+apps/panops-llm-mac (Swift): main ↔ Generator(LanguageModelSession) ↔ Codecs(DynamicGenerationSchema/GeneratedContent)
+```
+
+## Wire protocol (JSON-RPC 2.0 over stdio, mirrors ASR sidecar)
+
+- `probe` → `{ available: bool, reason?: string }` (maps `SystemLanguageModel.availability`).
+- `complete` params `{ system?, user, schema?, temperature, max_tokens }` → result `{ json: <object> }` (guided) or `{ text: <string> }` (no schema) → `LlmResponse::Json | Text`. Errors map to `LlmError` (`Provider`/`EmptyResponse`/`InvalidSchema`).
+
+## Data flow (one `complete`)
+
+1. Pipeline calls `LlmProvider::complete(req)` → `FoundationLlm`.
+2. Adapter ensures the sidecar is spawned, writes one JSON-RPC line, reads one response line.
+3. Swift: `Codecs` builds `DynamicGenerationSchema` from `req.schema` → `GenerationSchema(root:dependencies:)`; `Generator` runs `session.respond(to: req.user, schema:)` (system → session instructions); `Codecs` walks `GeneratedContent` → JSON.
+4. Adapter returns `LlmResponse::Json`.
+
+## Testing
+
+- **Unit (Rust, cheap):** `FoundationLlm` ↔ fake sidecar binary (a stub that speaks the JSON-RPC protocol with canned `probe`/`complete` responses) — passes the same `LlmProvider` conformance suite as `GenaiLlm`/`MockLlm`. Resolver-probe fallback path tested with a fake that reports `available:false`.
+- **Unit (Swift):** `Codecs` round-trips for a few schema shapes (object, enum→anyOf, nested, optional) and `GeneratedContent`→JSON.
+- **Heavy/gated:** a real-FoundationModels smoke (macOS 26 only, gated like the WhisperKit conformance) producing a valid notes-section JSON. The #149 prompt-regression gate already guards prompt drift.
+
+## Three-tier boundaries
+
+### ✅ Always do
+- Run `cargo fmt --all && cargo build --workspace --locked && cargo test --workspace --locked && cargo clippy --workspace --all-targets --locked -- -D warnings` per task; Swift sidecar built with `swift build --configuration release` + `swift test`.
+- Keep `panops-core` platform-free; the adapter is `#[cfg(target_os="macos")]` in `panops-mac`.
+- Open issues for any deferred item; commit per plan task.
+- Verify pushed == local before relying on CI.
+
+### ⚠️ Ask first
+- Changing the `LlmProvider` trait signature or `LlmRequest`/`LlmResponse` shape.
+- Dropping or replacing the Ollama/`GenaiLlm` fallback.
+- Adding any new runtime dependency to `panops-core` or `panops-portable`.
+- Changing the `genai`/Ollama default model.
+
+### 🚫 Never do
+- Introduce a trait without one real impl + one fake.
+- Any network egress / telemetry from the sidecar (on-device only).
+- A user-facing env var for config (the `PANOPS_LLM_SIDECAR_BIN` gate is dev/CI-only, flagged here).
+- Open or merge the PR autonomously.
+
+## Acceptance criteria
+
+1. On macOS 26 with the sidecar present + FoundationModels available, `notes.generate` produces valid structured notes via the sidecar (no Ollama).
+2. With the sidecar absent OR `probe` reporting unavailable, the engine logs the reason and falls back to `GenaiLlm` (Ollama) — notes still generate.
+3. `panops-core` unchanged; `cargo test --workspace` green; `FoundationLlm` passes the `LlmProvider` conformance suite.
+4. No network egress from the sidecar; no new user env vars.
+
+## Risks
+
+- **`GeneratedContent` → JSON** mapping for nested/array shapes — covered by Codec unit tests; the notes schemas are shallow (title/narrative/key_points/action_items).
+- **macOS 26 availability** — model may be downloading/unavailable; the resolver probe handles it via fallback.
+- **`server/mod.rs` conflict with #141** — both touch `n()`/wiring → sequence this slice **after #141 merges**.
+
+## Open questions (deferred)
+
+- Production `Bundle.main` resolution + notarized entitlements → packaging slice.
+- Whether to expose temperature/max_tokens per provider → tie to #98.


### PR DESCRIPTION
Implements the on-device FoundationModels LLM sidecar per `docs/superpowers/specs/2026-06-06-slice-15-foundationmodels-llm-sidecar-design.md`. Auto-detects FoundationModels on macOS 26, falls back to Ollama otherwise. Mirrors the ASR sidecar (spawn/stdio/JSON-RPC/Drop/resolver). Tracks https://github.com/vfmatzkin/panops/issues/154.\n\n**Status:** spec landed; Rust adapter + resolver + Swift sidecar in progress. DRAFT until convergence.