### PR TITLE
Surface raw Whisper transcript alongside notes (#111)

### DIFF
--- a/crates/panops-core/src/notes/mod.rs
+++ b/crates/panops-core/src/notes/mod.rs
@@ -4,6 +4,7 @@ pub mod input;
 pub mod ir;
 pub mod pipeline;
 pub mod prompts;
+pub mod raw_transcript;
 pub mod screenshot_anchoring;
 pub mod topic_segmentation;
 pub mod verifier;

--- a/crates/panops-core/src/notes/raw_transcript.rs
+++ b/crates/panops-core/src/notes/raw_transcript.rs
@@ -48,8 +48,8 @@ pub fn render_raw_transcript(segments: &[Segment]) -> String {
     out
 }
 
-/// Format a millisecond timestamp as `m:ss.mmm` (minutes unpadded, matching
-/// the `m:ss` convention used elsewhere; milliseconds keep the value lossless).
+/// Format a millisecond timestamp as `m:ss.mmm` (minutes unpadded, human-readable;
+/// the `.mmm` milliseconds keep the value lossless / round-trippable).
 fn format_ts(ms: u64) -> String {
     let total_s = ms / 1000;
     let millis = ms % 1000;

--- a/crates/panops-core/src/notes/raw_transcript.rs
+++ b/crates/panops-core/src/notes/raw_transcript.rs
@@ -1,0 +1,163 @@
+//! Additive raw-transcript sidecar.
+//!
+//! The notes pipeline feeds raw ASR segments through an LLM that rewrites and
+//! translates content, so `notes.md` is a synthesis, not a faithful record of
+//! what Whisper heard. This module renders the raw segments to a
+//! human-readable, grep-friendly `transcript.txt` written *alongside*
+//! `notes.md`. It is deliberately **not** part of the [`NotesExporter`] contract
+//! — the sidecar is an extra source-of-truth artifact, never a replacement, so
+//! users can compare the synthesized notes against the original transcript.
+//!
+//! [`NotesExporter`]: crate::exporter::NotesExporter
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::Segment;
+
+/// Filename of the raw-transcript sidecar, written next to `notes.md`.
+pub const RAW_TRANSCRIPT_FILENAME: &str = "transcript.txt";
+
+/// Render raw ASR segments to a grep-friendly transcript body.
+///
+/// One line per segment:
+/// `[m:ss.mmm-m:ss.mmm] <speaker_id> (<lang>): <text>`
+///
+/// - Timestamps carry millisecond precision so `start_ms`/`end_ms` survive the
+///   round-trip (the human-readable `m:ss.mmm` form still reads cleanly).
+/// - `<speaker_id>` is `speaker_N` when diarized, else `unknown`.
+/// - `<lang>` is the detected language code, else `und` (undetermined).
+/// - `<text>` is trimmed and newline-collapsed so every segment stays on one
+///   line — the exact, untrimmed text remains in the sibling `transcript.json`.
+pub fn render_raw_transcript(segments: &[Segment]) -> String {
+    let mut out = String::new();
+    for seg in segments {
+        let speaker = match seg.speaker_id {
+            Some(id) => format!("speaker_{id}"),
+            None => "unknown".to_string(),
+        };
+        let lang = seg.language_detected.as_deref().unwrap_or("und");
+        let text = seg.text.replace(['\n', '\r'], " ");
+        out.push_str(&format!(
+            "[{}-{}] {speaker} ({lang}): {}\n",
+            format_ts(seg.start_ms),
+            format_ts(seg.end_ms),
+            text.trim(),
+        ));
+    }
+    out
+}
+
+/// Format a millisecond timestamp as `m:ss.mmm` (minutes unpadded, matching
+/// the `m:ss` convention used elsewhere; milliseconds keep the value lossless).
+fn format_ts(ms: u64) -> String {
+    let total_s = ms / 1000;
+    let millis = ms % 1000;
+    let m = total_s / 60;
+    let s = total_s % 60;
+    format!("{m}:{s:02}.{millis:03}")
+}
+
+/// Write the raw-transcript sidecar into `dest`, returning the written path.
+///
+/// `dest` is the notes output directory (the same dir `notes.md` lands in).
+/// This is additive and best-effort at the call sites: a failure here must not
+/// abort notes generation.
+pub fn write_raw_transcript(segments: &[Segment], dest: &Path) -> io::Result<PathBuf> {
+    let path = dest.join(RAW_TRANSCRIPT_FILENAME);
+    std::fs::write(&path, render_raw_transcript(segments))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_segments() -> Vec<Segment> {
+        vec![
+            Segment {
+                start_ms: 0,
+                end_ms: 4_500,
+                text: "Hello, everyone.".into(),
+                language_detected: Some("en".into()),
+                confidence: 0.95,
+                is_partial: false,
+                speaker_id: Some(0),
+            },
+            Segment {
+                start_ms: 4_500,
+                end_ms: 9_200,
+                text: "  Hola a todos.  ".into(),
+                language_detected: Some("es".into()),
+                confidence: 0.91,
+                is_partial: false,
+                speaker_id: Some(1),
+            },
+            Segment {
+                start_ms: 65_000,
+                end_ms: 70_000,
+                text: "Crosses a\nline break.".into(),
+                language_detected: None,
+                confidence: 0.5,
+                is_partial: false,
+                speaker_id: None,
+            },
+        ]
+    }
+
+    const EXPECTED: &str = "\
+[0:00.000-0:04.500] speaker_0 (en): Hello, everyone.
+[0:04.500-0:09.200] speaker_1 (es): Hola a todos.
+[1:05.000-1:10.000] unknown (und): Crosses a line break.
+";
+
+    #[test]
+    fn render_emits_one_line_per_segment_with_all_fields() {
+        assert_eq!(render_raw_transcript(&fixture_segments()), EXPECTED);
+    }
+
+    #[test]
+    fn render_empty_transcript_is_empty_string() {
+        assert_eq!(render_raw_transcript(&[]), "");
+    }
+
+    #[test]
+    fn write_creates_named_file_with_rendered_body() {
+        let tmp = tempdir();
+        let segs = fixture_segments();
+        let path = write_raw_transcript(&segs, tmp.path()).expect("write should succeed");
+
+        assert_eq!(path, tmp.path().join(RAW_TRANSCRIPT_FILENAME));
+        assert!(path.exists(), "sidecar should exist on disk: {path:?}");
+        let body = std::fs::read_to_string(&path).expect("read back sidecar");
+        assert_eq!(body, EXPECTED);
+    }
+
+    /// std-only tempdir, mirroring the exporter conformance harness — this
+    /// crate intentionally has no `tempfile` dependency.
+    fn tempdir() -> TempDirHandle {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("panops-raw-transcript-{}-{n}", std::process::id()));
+        std::fs::create_dir_all(&path).expect("create tempdir");
+        TempDirHandle { path }
+    }
+
+    struct TempDirHandle {
+        path: PathBuf,
+    }
+
+    impl TempDirHandle {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDirHandle {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/crates/panops-core/src/notes/raw_transcript.rs
+++ b/crates/panops-core/src/notes/raw_transcript.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use crate::Segment;
 
 /// Filename of the raw-transcript sidecar, written next to `notes.md`.
-pub const RAW_TRANSCRIPT_FILENAME: &str = "transcript.txt";
+pub(crate) const RAW_TRANSCRIPT_FILENAME: &str = "transcript.txt";
 
 /// Render raw ASR segments to a grep-friendly transcript body.
 ///

--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -14,6 +14,7 @@ use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::ir::Screenshot;
 use panops_core::notes::pipeline::NotesGenerator;
+use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_core::storage::{MeetingDraft, NoteDraft, Storage};
 use panops_core::vad::Vad;
 use panops_portable::SherpaDiarizer;
@@ -246,6 +247,14 @@ fn run_notes(
     std::fs::write(&transcript_path, &transcript_json)
         .map_err(|e| (3, format!("write transcript.json: {e}")))?;
     tracing::info!(file = ?transcript_path, "wrote transcript");
+
+    // Additive raw-transcript sidecar: a human-readable, grep-friendly view of
+    // the raw Whisper segments next to notes.md, so the LLM synthesis can be
+    // compared against the source. Best-effort — never block on it.
+    match write_raw_transcript(&transcript.segments, &out_dir) {
+        Ok(p) => tracing::info!(file = ?p, "wrote raw transcript sidecar"),
+        Err(e) => tracing::warn!(error = %e, "write transcript.txt failed; continuing"),
+    }
 
     let llm = match llm_provider.as_str() {
         "auto" => match llm_model {

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -23,6 +23,7 @@ use panops_core::merge::merge_speaker_turns;
 use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::pipeline::NotesGenerator;
+use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
     AudioSourcesWire, Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting,
     MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
@@ -664,6 +665,18 @@ pub(super) fn run_notes_pipeline(
         Err(e) => {
             tracing::warn!(error = %e, "notes.generate: serialize transcript.json failed");
         }
+    }
+
+    // Additive raw-transcript sidecar (transcript.txt): a human-readable,
+    // grep-friendly view of the raw Whisper segments alongside notes.md, so the
+    // LLM synthesis can be compared against the source. Best-effort, mirroring
+    // the transcript.json write above — a failure logs but never aborts.
+    match write_raw_transcript(&transcript.segments, &out_dir) {
+        Ok(p) => tracing::info!(file = ?p, "notes.generate: wrote raw transcript sidecar"),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "notes.generate: write transcript.txt failed; continuing"
+        ),
     }
 
     let dialect = match params.dialect {


### PR DESCRIPTION
Closes #111. Writes a `transcript.txt` sidecar next to `notes.md`/`transcript.json` with one grep-friendly line per segment: `[m:ss.mmm-m:ss.mmm] speaker_N (lang): text` — lossless start/end ms, additive (NotesExporter contract unchanged), best-effort. DRAFT pending review.