### PR TITLE
Accept video/audio input (mov/mp4/m4a/mp3) via afconvert

### DIFF
--- a/crates/panops-engine/src/main.rs
+++ b/crates/panops-engine/src/main.rs
@@ -458,10 +458,11 @@ fn transcribe_with_vad(
     vad: &dyn Vad,
     language: Option<&str>,
 ) -> Result<panops_core::Transcript, (u8, String)> {
-    let (samples, sample_rate) = panops_portable::audio::load_wav_mono16k(audio).map_err(|e| {
-        tracing::error!(error = %e, "audio loading failed");
-        (2, "audio decode failed".to_string())
-    })?;
+    let (samples, sample_rate) =
+        panops_portable::audio::load_audio_mono16k(audio).map_err(|e| {
+            tracing::error!(error = %e, "audio loading failed");
+            (2, "audio decode failed".to_string())
+        })?;
     let regions = vad.detect_speech(&samples, sample_rate).map_err(|e| {
         tracing::error!(error = %e, "vad detect_speech failed");
         (2, "vad failed".to_string())

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -571,7 +571,7 @@ pub(super) fn run_notes_pipeline(
     //      with lang_hint=None to trigger per-region auto-detect.
     //   5. Stitch transcripts back with absolute-time offsets.
     let (samples, sample_rate) =
-        panops_portable::audio::load_wav_mono16k(&audio_path).map_err(IpcError::from)?;
+        panops_portable::audio::load_audio_mono16k(&audio_path).map_err(IpcError::from)?;
 
     let regions = heavy
         .vad

--- a/crates/panops-portable/src/audio.rs
+++ b/crates/panops-portable/src/audio.rs
@@ -70,6 +70,75 @@ pub fn load_wav_mono16k(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
     Ok((audio, 16_000))
 }
 
+fn is_wav(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("wav"))
+        .unwrap_or(false)
+}
+
+/// Load audio from any container CoreAudio can decode (WAV, MOV, MP4, M4A,
+/// MP3, AAC, …) as 16 kHz mono `f32` samples — the format the ASR + VAD
+/// pipeline consumes. A ready 16 kHz WAV is read directly; anything else (a
+/// video, a compressed audio file, or a WAV at the wrong rate/depth) is
+/// transcoded to a temporary 16 kHz mono 16-bit WAV via macOS `afconvert`
+/// first, then read. On non-macOS only 16 kHz WAV input is supported
+/// (afconvert is macOS-only; a cross-platform decoder can be added later).
+pub fn load_audio_mono16k(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+    if !path.exists() {
+        return Err(AsrError::AudioNotFound(path.to_path_buf()));
+    }
+    // Fast path: a ready 16 kHz WAV loads directly (no transcode).
+    if is_wav(path) {
+        match load_wav_mono16k(path) {
+            Ok(out) => return Ok(out),
+            // Wrong rate/depth/format → fall through to transcode + retry.
+            Err(AsrError::InvalidAudio(_)) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    transcode_to_wav16k_and_load(path)
+}
+
+#[cfg(target_os = "macos")]
+fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let tmp = std::env::temp_dir().join(format!(
+        "panops-transcode-{}-{}.wav",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    // macOS CoreAudio `afconvert`: decode the input's audio track to
+    // 16 kHz mono signed-16-bit little-endian WAV.
+    let status = std::process::Command::new("/usr/bin/afconvert")
+        .args(["-f", "WAVE", "-d", "LEI16@16000", "-c", "1"])
+        .arg(path)
+        .arg(&tmp)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    let result = match status {
+        Ok(s) if s.success() => load_wav_mono16k(&tmp),
+        Ok(s) => Err(AsrError::InvalidAudio(format!(
+            "afconvert could not decode {path:?} (exit {:?})",
+            s.code()
+        ))),
+        Err(e) => Err(AsrError::InvalidAudio(format!(
+            "afconvert spawn failed: {e}"
+        ))),
+    };
+    let _ = std::fs::remove_file(&tmp);
+    result
+}
+
+#[cfg(not(target_os = "macos"))]
+fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+    Err(AsrError::InvalidAudio(format!(
+        "unsupported audio container {path:?}: only 16 kHz WAV input is supported on this platform"
+    )))
+}
+
 /// Collapse adjacent speech regions whose gap is `<= gap_ms` into
 /// single contiguous regions. Pure function. Accepts unsorted input
 /// (sorts internally). The 5s default the pipeline uses matches
@@ -92,4 +161,47 @@ pub fn merge_adjacent_regions(mut regions: Vec<SpeechRegion>, gap_ms: u64) -> Ve
         out.push(r);
     }
     out
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod media_tests {
+    use super::*;
+
+    /// A 48 kHz WAV is rejected by `load_wav_mono16k` but `load_audio_mono16k`
+    /// transcodes it (via afconvert) to 16 kHz and loads it.
+    #[test]
+    fn load_audio_mono16k_transcodes_non_16k_wav() {
+        let dir = std::env::temp_dir().join(format!("panops-audiotest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("src48k.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 48_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut w = hound::WavWriter::create(&src, spec).unwrap();
+        for i in 0..48_000i32 {
+            // 1s of a quiet tone
+            w.write_sample((((i as f32) * 0.05).sin() * 6000.0) as i16)
+                .unwrap();
+        }
+        w.finalize().unwrap();
+
+        // Direct 16k loader rejects the 48 kHz rate...
+        assert!(matches!(
+            load_wav_mono16k(&src),
+            Err(AsrError::InvalidAudio(_))
+        ));
+        // ...but the media loader transcodes to 16 kHz.
+        let (samples, rate) = load_audio_mono16k(&src).expect("transcode + load");
+        assert_eq!(rate, 16_000);
+        // 1s @ 16 kHz ≈ 16000 samples (resampled; allow tolerance).
+        assert!(
+            samples.len() > 12_000 && samples.len() < 20_000,
+            "unexpected sample count {}",
+            samples.len()
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/panops-portable/src/audio.rs
+++ b/crates/panops-portable/src/audio.rs
@@ -1,9 +1,10 @@
-//! Pure utilities used by the VAD-aware ASR pipeline:
-//! `load_wav_mono16k` decodes a WAV file into 16 kHz mono `f32`
-//! samples (the format `WhisperRsAsr` and `WhisperVad` both accept).
-//! `merge_adjacent_regions` collapses VAD output across short gaps
-//! so per-region Whisper calls get >= 30s of speech for reliable
-//! language detection.
+//! Audio utilities for the VAD-aware ASR pipeline:
+//! `load_audio_mono16k` is the entry point — it loads any CoreAudio-decodable
+//! file (WAV, MOV, MP4, M4A, MP3, …) as 16 kHz mono `f32` samples, transcoding
+//! non-WAV / wrong-rate input via macOS `afconvert`. `load_wav_mono16k` is the
+//! direct 16 kHz-WAV reader it builds on. `merge_adjacent_regions` collapses
+//! VAD output across short gaps so per-region Whisper calls get >= 30s of
+//! speech for reliable language detection.
 
 use std::path::Path;
 
@@ -110,23 +111,33 @@ fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError
         SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     // macOS CoreAudio `afconvert`: decode the input's audio track to
-    // 16 kHz mono signed-16-bit little-endian WAV.
-    let status = std::process::Command::new("/usr/bin/afconvert")
+    // 16 kHz mono signed-16-bit little-endian WAV. Capture output so the
+    // CoreAudio failure reason is logged; the returned (wire-facing) error
+    // stays opaque — no path/stderr — so it can't leak over the IPC boundary.
+    let output = std::process::Command::new("/usr/bin/afconvert")
         .args(["-f", "WAVE", "-d", "LEI16@16000", "-c", "1"])
         .arg(path)
         .arg(&tmp)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-    let result = match status {
-        Ok(s) if s.success() => load_wav_mono16k(&tmp),
-        Ok(s) => Err(AsrError::InvalidAudio(format!(
-            "afconvert could not decode {path:?} (exit {:?})",
-            s.code()
-        ))),
-        Err(e) => Err(AsrError::InvalidAudio(format!(
-            "afconvert spawn failed: {e}"
-        ))),
+        .output();
+    let result = match output {
+        Ok(o) if o.status.success() => load_wav_mono16k(&tmp),
+        Ok(o) => {
+            tracing::error!(
+                path = ?path,
+                exit = ?o.status.code(),
+                stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                "afconvert failed to decode audio"
+            );
+            Err(AsrError::InvalidAudio(
+                "could not decode audio (unsupported or corrupt media file)".to_string(),
+            ))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "afconvert spawn failed");
+            Err(AsrError::InvalidAudio(
+                "audio decoder (afconvert) unavailable".to_string(),
+            ))
+        }
     };
     let _ = std::fs::remove_file(&tmp);
     result
@@ -134,9 +145,10 @@ fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError
 
 #[cfg(not(target_os = "macos"))]
 fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
-    Err(AsrError::InvalidAudio(format!(
-        "unsupported audio container {path:?}: only 16 kHz WAV input is supported on this platform"
-    )))
+    tracing::error!(path = ?path, "non-WAV audio on a platform without afconvert");
+    Err(AsrError::InvalidAudio(
+        "unsupported audio format: only 16 kHz WAV is supported on this platform".to_string(),
+    ))
 }
 
 /// Collapse adjacent speech regions whose gap is `<= gap_ms` into

--- a/crates/panops-portable/src/audio.rs
+++ b/crates/panops-portable/src/audio.rs
@@ -2,11 +2,14 @@
 //! `load_audio_mono16k` is the entry point — it loads any CoreAudio-decodable
 //! file (WAV, MOV, MP4, M4A, MP3, …) as 16 kHz mono `f32` samples, transcoding
 //! non-WAV / wrong-rate input via macOS `afconvert`. `load_wav_mono16k` is the
-//! direct 16 kHz-WAV reader it builds on. `merge_adjacent_regions` collapses
-//! VAD output across short gaps so per-region Whisper calls get >= 30s of
-//! speech for reliable language detection.
+//! direct 16 kHz-WAV reader it builds on. `ensure_wav16k` gives file-reading
+//! consumers (e.g. the sherpa diarizer, which decodes the file itself) a
+//! 16 kHz-WAV *path* — borrowing a ready WAV or transcoding to a temp one.
+//! `merge_adjacent_regions` collapses VAD output across short gaps so
+//! per-region Whisper calls get >= 30s of speech for reliable language
+//! detection.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use hound::WavReader;
 use panops_core::asr::AsrError;
@@ -86,23 +89,77 @@ fn is_wav(path: &Path) -> bool {
 /// first, then read. On non-macOS only 16 kHz WAV input is supported
 /// (afconvert is macOS-only; a cross-platform decoder can be added later).
 pub fn load_audio_mono16k(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+    // `ensure_wav16k` borrows a ready 16 kHz WAV or transcodes anything else
+    // to a temp WAV — removed when `wav` drops, so cleanup is panic-safe even
+    // if `load_wav_mono16k` unwinds on a malformed body.
+    let wav = ensure_wav16k(path)?;
+    load_wav_mono16k(wav.path())
+}
+
+/// A 16 kHz-WAV path for consumers that decode the audio *file* themselves
+/// (e.g. the sherpa diarizer, which calls its own reader). Either borrows
+/// the caller's already-16 kHz WAV, or owns a temporary transcoded copy
+/// that is removed on drop.
+pub enum Wav16kPath {
+    /// The caller's path was already a 16 kHz WAV; used as-is.
+    Borrowed(PathBuf),
+    /// A temp WAV transcoded from non-WAV / wrong-rate input; deleted on drop.
+    Temp(PathBuf),
+}
+
+impl Wav16kPath {
+    /// The on-disk path to a 16 kHz WAV, valid until this guard is dropped.
+    pub fn path(&self) -> &Path {
+        match self {
+            Wav16kPath::Borrowed(p) | Wav16kPath::Temp(p) => p,
+        }
+    }
+}
+
+impl Drop for Wav16kPath {
+    fn drop(&mut self) {
+        if let Wav16kPath::Temp(p) = self {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+}
+
+/// Ensure `path` resolves to a 16 kHz WAV that file-reading audio tools can
+/// decode. A ready 16 kHz WAV is borrowed unchanged; any other input (a
+/// video, compressed audio, or a WAV at the wrong sample rate) is transcoded
+/// to a temporary 16 kHz mono WAV via macOS `afconvert`. The returned guard
+/// deletes any temp file when dropped. Mirrors [`load_audio_mono16k`] for the
+/// path-consuming case (samples vs file). On non-macOS only 16 kHz WAV input
+/// is supported (afconvert is macOS-only).
+pub fn ensure_wav16k(path: &Path) -> Result<Wav16kPath, AsrError> {
     if !path.exists() {
         return Err(AsrError::AudioNotFound(path.to_path_buf()));
     }
-    // Fast path: a ready 16 kHz WAV loads directly (no transcode).
+    // A WAV that `load_wav_mono16k` would accept as-is (16 kHz, 16-bit PCM,
+    // mono or stereo) is borrowed unchanged — no transcode. Anything else
+    // (video, compressed audio, wrong rate/depth/channels) is transcoded.
     if is_wav(path) {
-        match load_wav_mono16k(path) {
-            Ok(out) => return Ok(out),
-            // Wrong rate/depth/format → fall through to transcode + retry.
-            Err(AsrError::InvalidAudio(_)) => {}
-            Err(e) => return Err(e),
+        if let Ok(reader) = WavReader::open(path) {
+            let spec = reader.spec();
+            if spec.sample_rate == 16_000
+                && spec.bits_per_sample == 16
+                && spec.sample_format == hound::SampleFormat::Int
+                && (spec.channels == 1 || spec.channels == 2)
+            {
+                return Ok(Wav16kPath::Borrowed(path.to_path_buf()));
+            }
         }
     }
-    transcode_to_wav16k_and_load(path)
+    Ok(Wav16kPath::Temp(transcode_to_wav16k(path)?))
 }
 
+/// Transcode any CoreAudio-decodable file to a temporary 16 kHz mono 16-bit
+/// WAV via macOS `afconvert`, returning the temp path. The caller owns the
+/// temp file. The returned (wire-facing) error stays opaque — no path/stderr —
+/// so it can't leak over the IPC boundary; the CoreAudio failure reason is
+/// logged instead.
 #[cfg(target_os = "macos")]
-fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+fn transcode_to_wav16k(path: &Path) -> Result<PathBuf, AsrError> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
     let tmp = std::env::temp_dir().join(format!(
@@ -110,17 +167,13 @@ fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError
         std::process::id(),
         SEQ.fetch_add(1, Ordering::Relaxed)
     ));
-    // macOS CoreAudio `afconvert`: decode the input's audio track to
-    // 16 kHz mono signed-16-bit little-endian WAV. Capture output so the
-    // CoreAudio failure reason is logged; the returned (wire-facing) error
-    // stays opaque — no path/stderr — so it can't leak over the IPC boundary.
     let output = std::process::Command::new("/usr/bin/afconvert")
         .args(["-f", "WAVE", "-d", "LEI16@16000", "-c", "1"])
         .arg(path)
         .arg(&tmp)
         .output();
-    let result = match output {
-        Ok(o) if o.status.success() => load_wav_mono16k(&tmp),
+    match output {
+        Ok(o) if o.status.success() => Ok(tmp),
         Ok(o) => {
             tracing::error!(
                 path = ?path,
@@ -128,6 +181,7 @@ fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError
                 stderr = %String::from_utf8_lossy(&o.stderr).trim(),
                 "afconvert failed to decode audio"
             );
+            let _ = std::fs::remove_file(&tmp);
             Err(AsrError::InvalidAudio(
                 "could not decode audio (unsupported or corrupt media file)".to_string(),
             ))
@@ -138,13 +192,11 @@ fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError
                 "audio decoder (afconvert) unavailable".to_string(),
             ))
         }
-    };
-    let _ = std::fs::remove_file(&tmp);
-    result
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
-fn transcode_to_wav16k_and_load(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
+fn transcode_to_wav16k(path: &Path) -> Result<PathBuf, AsrError> {
     tracing::error!(path = ?path, "non-WAV audio on a platform without afconvert");
     Err(AsrError::InvalidAudio(
         "unsupported audio format: only 16 kHz WAV is supported on this platform".to_string(),
@@ -214,6 +266,54 @@ mod media_tests {
             "unexpected sample count {}",
             samples.len()
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `ensure_wav16k` borrows a ready 16 kHz WAV (path unchanged, no temp)
+    /// but transcodes a 48 kHz WAV to a temp 16 kHz WAV that loads cleanly —
+    /// the file-path counterpart of `load_audio_mono16k`, used by the diarizer.
+    #[test]
+    fn ensure_wav16k_borrows_16k_and_transcodes_others() {
+        let dir = std::env::temp_dir().join(format!("panops-ensurewav-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let write_tone = |name: &str, rate: u32| {
+            let p = dir.join(name);
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate: rate,
+                bits_per_sample: 16,
+                sample_format: hound::SampleFormat::Int,
+            };
+            let mut w = hound::WavWriter::create(&p, spec).unwrap();
+            for i in 0..rate as i32 {
+                w.write_sample((((i as f32) * 0.05).sin() * 6000.0) as i16)
+                    .unwrap();
+            }
+            w.finalize().unwrap();
+            p
+        };
+
+        // 16 kHz WAV → borrowed as-is (no transcode, original path).
+        let ready = write_tone("ready16k.wav", 16_000);
+        let borrowed = ensure_wav16k(&ready).expect("borrow 16k wav");
+        assert!(matches!(borrowed, Wav16kPath::Borrowed(_)));
+        assert_eq!(borrowed.path(), ready.as_path());
+
+        // 48 kHz WAV → transcoded to a temp 16 kHz WAV (different path),
+        // which loads at 16 kHz.
+        let high = write_tone("src48k.wav", 48_000);
+        let transcoded = ensure_wav16k(&high).expect("transcode to 16k wav");
+        assert!(matches!(transcoded, Wav16kPath::Temp(_)));
+        assert_ne!(transcoded.path(), high.as_path());
+        let (_samples, rate) = load_wav_mono16k(transcoded.path()).expect("load temp wav");
+        assert_eq!(rate, 16_000);
+
+        // Temp file is cleaned up when the guard drops.
+        let temp_path = transcoded.path().to_path_buf();
+        drop(transcoded);
+        assert!(!temp_path.exists(), "temp wav should be removed on drop");
+
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/panops-portable/src/audio.rs
+++ b/crates/panops-portable/src/audio.rs
@@ -99,8 +99,9 @@ pub fn load_audio_mono16k(path: &Path) -> Result<(Vec<f32>, u32), AsrError> {
 /// A 16 kHz-WAV path for consumers that decode the audio *file* themselves
 /// (e.g. the sherpa diarizer, which calls its own reader). Either borrows
 /// the caller's already-16 kHz WAV, or owns a temporary transcoded copy
-/// that is removed on drop.
-pub enum Wav16kPath {
+/// that is removed on drop. Crate-internal: the only consumers are
+/// `load_audio_mono16k` (samples) and the sherpa diarizer (file path).
+pub(crate) enum Wav16kPath {
     /// The caller's path was already a 16 kHz WAV; used as-is.
     Borrowed(PathBuf),
     /// A temp WAV transcoded from non-WAV / wrong-rate input; deleted on drop.
@@ -109,7 +110,7 @@ pub enum Wav16kPath {
 
 impl Wav16kPath {
     /// The on-disk path to a 16 kHz WAV, valid until this guard is dropped.
-    pub fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         match self {
             Wav16kPath::Borrowed(p) | Wav16kPath::Temp(p) => p,
         }
@@ -119,7 +120,11 @@ impl Wav16kPath {
 impl Drop for Wav16kPath {
     fn drop(&mut self) {
         if let Wav16kPath::Temp(p) = self {
-            let _ = std::fs::remove_file(p);
+            // Best-effort cleanup; surface failures (disk-full / read-only)
+            // in logs rather than leaking temp files silently.
+            if let Err(e) = std::fs::remove_file(p.as_path()) {
+                tracing::warn!(error = %e, path = ?p, "failed to remove transcode temp file");
+            }
         }
     }
 }
@@ -131,7 +136,7 @@ impl Drop for Wav16kPath {
 /// deletes any temp file when dropped. Mirrors [`load_audio_mono16k`] for the
 /// path-consuming case (samples vs file). On non-macOS only 16 kHz WAV input
 /// is supported (afconvert is macOS-only).
-pub fn ensure_wav16k(path: &Path) -> Result<Wav16kPath, AsrError> {
+pub(crate) fn ensure_wav16k(path: &Path) -> Result<Wav16kPath, AsrError> {
     if !path.exists() {
         return Err(AsrError::AudioNotFound(path.to_path_buf()));
     }

--- a/crates/panops-portable/src/sherpa_diarizer.rs
+++ b/crates/panops-portable/src/sherpa_diarizer.rs
@@ -35,8 +35,12 @@ impl Diarizer for SherpaDiarizer {
         // a ready 16 kHz WAV is read directly, anything else is transcoded to
         // a temp 16 kHz WAV first — same media path the ASR pipeline uses, so
         // diarization works on the same inputs transcription does.
-        let wav = crate::audio::ensure_wav16k(audio_path)
-            .map_err(|e| DiarError::InvalidAudio(e.to_string()))?;
+        // Map variants explicitly so a filesystem path only ever lands in the
+        // typed `AudioNotFound` (never expanded into a free-form error string).
+        let wav = crate::audio::ensure_wav16k(audio_path).map_err(|e| match e {
+            panops_core::asr::AsrError::AudioNotFound(p) => DiarError::AudioNotFound(p),
+            other => DiarError::InvalidAudio(other.to_string()),
+        })?;
 
         let (samples, sample_rate) = read_audio_file(
             wav.path()

--- a/crates/panops-portable/src/sherpa_diarizer.rs
+++ b/crates/panops-portable/src/sherpa_diarizer.rs
@@ -31,8 +31,15 @@ impl Diarizer for SherpaDiarizer {
             return Err(DiarError::AudioNotFound(audio_path.to_path_buf()));
         }
 
+        // Accept any CoreAudio-decodable container (WAV, MOV, MP4, M4A, …):
+        // a ready 16 kHz WAV is read directly, anything else is transcoded to
+        // a temp 16 kHz WAV first — same media path the ASR pipeline uses, so
+        // diarization works on the same inputs transcription does.
+        let wav = crate::audio::ensure_wav16k(audio_path)
+            .map_err(|e| DiarError::InvalidAudio(e.to_string()))?;
+
         let (samples, sample_rate) = read_audio_file(
-            audio_path
+            wav.path()
                 .to_str()
                 .ok_or_else(|| DiarError::InvalidAudio("non-UTF-8 audio path".to_string()))?,
         )


### PR DESCRIPTION
Lets the pipeline ingest any CoreAudio-decodable container, not just 16 kHz WAV. `load_audio_mono16k` reads a ready 16 kHz WAV directly, else transcodes (macOS `afconvert`) to a temp 16 kHz mono 16-bit WAV and loads that. Wired into both audio-load sites (CLI `transcribe_with_vad` + IPC `run_notes_pipeline`). macOS-gated test transcoding a 48 kHz WAV. Design: afconvert (built-in CoreAudio, zero dep) for v0.1 macOS; cross-platform decoder later. Enables real-meeting testing from video recordings. DRAFT until a posted ai-review clears.

---
Tracking: #167 (media-input feature). Follow-up debt: #168 (cross-platform decoder), #169 (afconvert hardening: timeout + private temp dir).