### PR TITLE
harden frontmatter YAML escaping

### DIFF
--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -290,9 +290,16 @@ fn is_safe_plain_scalar(s: &str) -> bool {
     matches_plain_pattern(s) && !is_yaml_reserved(s) && !looks_like_number(s)
 }
 
-/// Matches `^[A-Za-z][A-Za-z0-9 ._/-]*$`: first char is an ASCII letter, the
-/// rest are ASCII alphanumerics or one of space, `.`, `_`, `/`, `-`.
+/// Matches `^[A-Za-z][A-Za-z0-9 ._/-]*$` AND has no trailing space: first char
+/// is an ASCII letter (this also excludes a leading space), the rest are ASCII
+/// alphanumerics or one of space, `.`, `_`, `/`, `-`. A trailing space is
+/// rejected because a YAML parser strips trailing whitespace from a plain
+/// scalar — `"Hello "` would silently round-trip to `"Hello"` — so such values
+/// are quoted instead.
 fn matches_plain_pattern(s: &str) -> bool {
+    if s.ends_with(' ') {
+        return false;
+    }
     let mut chars = s.chars();
     match chars.next() {
         Some(c) if c.is_ascii_alphabetic() => {}
@@ -376,6 +383,16 @@ mod tests {
     #[test]
     fn empty_string_is_double_quoted() {
         assert_eq!(yaml_scalar(""), "\"\"");
+    }
+
+    #[test]
+    fn trailing_space_is_double_quoted() {
+        // A plain YAML scalar strips trailing whitespace, so "Hello " must be
+        // quoted to survive a round-trip (otherwise it becomes "Hello").
+        assert_eq!(yaml_scalar("Hello "), "\"Hello \"");
+        assert_eq!(yaml_scalar("Daily standup  "), "\"Daily standup  \"");
+        // Interior spaces remain fine for a plain scalar.
+        assert_eq!(yaml_scalar("Daily standup"), "Daily standup");
     }
 
     #[test]

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -263,12 +263,21 @@ fn yaml_scalar(s: &str) -> String {
     if is_safe_plain_scalar(s) {
         return s.to_string();
     }
-    let escaped = s
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t");
+    let mut escaped = String::with_capacity(s.len() + 2);
+    for c in s.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            // Any remaining C0 control char (U+0000–U+001F) is invalid in a
+            // YAML double-quoted scalar unless escaped; emit `\xNN` with two
+            // lowercase hex digits (e.g. 0x01 -> \x01, 0x07 -> \x07).
+            c if (c as u32) < 0x20 => escaped.push_str(&format!("\\x{:02x}", c as u32)),
+            c => escaped.push(c),
+        }
+    }
     format!("\"{escaped}\"")
 }
 
@@ -302,10 +311,22 @@ fn is_yaml_reserved(s: &str) -> bool {
     KEYWORDS.contains(&lower.as_str())
 }
 
-/// Returns true if the value could be read back as a YAML number: it parses as
-/// an integer or float, uses underscore digit grouping (`1_000`), or carries a
-/// radix prefix (`0x`/`0o`/`0b`). `f64::parse` also accepts `inf`/`nan`, which
-/// is why those letter-leading words are number-like and need quoting.
+/// Returns true if the value could be read back as a YAML number. Three
+/// detection paths, checked in order:
+///
+/// 1. **Parse** — `i64::parse` or `f64::parse` succeeds (decimal integers,
+///    floats, scientific notation, a leading or trailing dot, optional sign).
+/// 2. **Radix prefix** — an optionally-signed `0x` / `0o` / `0b` prefix with
+///    digits valid for that base. Rust's `parse` rejects these, so they are
+///    matched explicitly.
+/// 3. **Underscore grouping** — YAML 1.1 digit separators (`1_000`,
+///    `1_000.5`), which Rust's `parse` also rejects.
+///
+/// `f64::parse` accepts the bare tokens `inf` / `nan`, so those are flagged
+/// here. The dotted YAML spellings `.inf` / `-.inf` / `.nan` are instead caught
+/// by [`is_yaml_reserved`]. That overlap is intentional: between them the two
+/// checks cover every infinity / NaN spelling, and either one alone is enough
+/// to force quoting — neither needs to depend on the other's exact coverage.
 fn looks_like_number(s: &str) -> bool {
     let trimmed = s.trim();
     if trimmed.is_empty() {
@@ -407,6 +428,18 @@ mod tests {
     #[test]
     fn tab_is_escaped_inside_double_quotes() {
         assert_eq!(yaml_scalar("col1\tcol2"), "\"col1\\tcol2\"");
+    }
+
+    #[test]
+    fn control_chars_are_hex_escaped_inside_double_quotes() {
+        // U+0001 (SOH) and U+0007 (BEL) have no dedicated escape and would be
+        // invalid raw inside a YAML double-quoted scalar; they must emit as
+        // \x01 / \x07 (two lowercase hex digits).
+        let mut value = String::from("a");
+        value.push('\u{0001}');
+        value.push('\u{0007}');
+        value.push('b');
+        assert_eq!(yaml_scalar(&value), "\"a\\x01\\x07b\"");
     }
 
     #[test]

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -255,22 +255,120 @@ fn format_mmss(ms: u64) -> String {
 }
 
 fn yaml_scalar(s: &str) -> String {
+    // YAML reserved words that would be parsed as booleans/null.
+    const YAML_KEYWORDS: &[&str] = &[
+        "true", "false", "null", "yes", "no", "on", "off", "y", "n", "~",
+    ];
+    // Characters that trigger quoting anywhere in the string.
+    const QUOTE_CHARS: &[char] = &['\n', '\r', '\t', '"', '\\', '#', '\''];
+    // Characters that trigger quoting if the string starts with them.
+    const LEADING_SPECIAL: &[char] = &[
+        ':', '-', '!', '|', '>', '[', ']', '{', '}', '*', '&', '?', '@', '`', '%',
+    ];
+
+    let lower = s.to_lowercase();
     let needs_quoting = s.is_empty()
-        || s.contains(['\n', '\r', '"', '\\', '#', '\''])
-        || s.contains(": ")
-        || s.starts_with([
-            ':', '-', '!', '|', '>', '[', ']', '{', '}', '*', '&', '?', '@', '`',
-        ]);
+        // Whitespace-only strings need quoting
+        || s.trim().is_empty()
+        // YAML keywords (booleans/null)
+        || YAML_KEYWORDS.contains(&lower.as_str())
+        // Strings that look like numbers (integers, floats, hex, octal)
+        || looks_like_number(s)
+        // Colon-space (mapping indicator) or trailing colon (key indicator)
+        || s.contains(": ") || s.ends_with(':')
+        // Special characters anywhere
+        || s.contains(QUOTE_CHARS)
+        // Special characters at start
+        || s.starts_with(LEADING_SPECIAL);
+
     if needs_quoting {
         let escaped = s
             .replace('\\', "\\\\")
             .replace('"', "\\\"")
             .replace('\n', "\\n")
-            .replace('\r', "\\r");
+            .replace('\r', "\\r")
+            .replace('\t', "\\t");
         format!("\"{escaped}\"")
     } else {
         s.to_string()
     }
+}
+
+/// Returns true if the string would be parsed as a YAML number.
+fn looks_like_number(s: &str) -> bool {
+    // YAML parses integers, floats, hex, octal, and binary as numbers.
+    // We conservatively quote anything that might be parsed as a number.
+    if s.is_empty() {
+        return false;
+    }
+    // Hex: 0x...
+    if s.starts_with("0x") || s.starts_with("0X") {
+        return s.len() > 2 && s[2..].chars().all(|c| c.is_ascii_hexdigit());
+    }
+    // Octal: 0o... (YAML 1.2 uses 0o prefix)
+    if s.starts_with("0o") || s.starts_with("0O") {
+        return s.len() > 2 && s[2..].chars().all(|c| c.is_ascii_digit() && c < '8');
+    }
+    // Binary: 0b...
+    if s.starts_with("0b") || s.starts_with("0B") {
+        return s.len() > 2 && s[2..].chars().all(|c| c == '0' || c == '1');
+    }
+
+    // Check for plain integers and floats.
+    // A valid YAML float has exactly ONE dot.
+    let trimmed = s.trim();
+
+    // Count dots - more than one means it's not a valid number
+    let dot_count = trimmed.chars().filter(|c| *c == '.').count();
+    if dot_count > 1 {
+        return false;
+    }
+
+    // Handle optional sign prefix
+    let digits_part = if trimmed.starts_with('+') || trimmed.starts_with('-') {
+        &trimmed[1..]
+    } else {
+        trimmed
+    };
+
+    // Integer: all digits, no dot
+    if dot_count == 0 && digits_part.chars().all(|c| c.is_ascii_digit()) && !digits_part.is_empty()
+    {
+        return true;
+    }
+
+    // Float: exactly one dot, rest are digits (allow ".5" and "5.")
+    if dot_count == 1 {
+        let without_dot = digits_part.replace('.', "");
+        // Empty after removing dot means just "." which isn't valid, but
+        // ".5" or "5." are valid YAML floats
+        if without_dot.chars().all(|c| c.is_ascii_digit()) && !without_dot.is_empty() {
+            return true;
+        }
+    }
+
+    // Scientific notation (e.g., "1e5", "1.5e-3")
+    if trimmed.contains('e') || trimmed.contains('E') {
+        let parts: Vec<&str> = trimmed.split(['e', 'E']).collect();
+        if parts.len() == 2 {
+            let base = parts[0];
+            let exp = parts[1];
+            // Base part can be integer or float (one dot max)
+            let base_dot_count = base.chars().filter(|c| *c == '.').count();
+            let base_digits = base.replace(['.', '+', '-'], "");
+            let base_ok = base_dot_count <= 1
+                && base_digits.chars().all(|c| c.is_ascii_digit())
+                && !base_digits.is_empty();
+            // Exp part is integer (may have sign)
+            let exp_digits = exp.replace(['+', '-'], "");
+            let exp_ok = exp_digits.chars().all(|c| c.is_ascii_digit()) && !exp_digits.is_empty();
+            if base_ok && exp_ok {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 fn yaml_list(items: &[String]) -> String {
@@ -325,6 +423,83 @@ mod tests {
     fn leading_special_char_triggers_double_quoting() {
         assert_eq!(yaml_scalar(":starts-with-colon"), "\":starts-with-colon\"");
         assert_eq!(yaml_scalar("-starts-with-dash"), "\"-starts-with-dash\"");
+        assert_eq!(
+            yaml_scalar("%starts-with-percent"),
+            "\"%starts-with-percent\""
+        );
+    }
+
+    #[test]
+    fn trailing_colon_triggers_double_quoting() {
+        assert_eq!(yaml_scalar("key:"), "\"key:\"");
+    }
+
+    #[test]
+    fn whitespace_only_string_is_double_quoted() {
+        assert_eq!(yaml_scalar("   "), "\"   \"");
+        assert_eq!(yaml_scalar("\t"), "\"\\t\"");
+    }
+
+    #[test]
+    fn tab_is_escaped_inside_double_quotes() {
+        assert_eq!(yaml_scalar("col1\tcol2"), "\"col1\\tcol2\"");
+    }
+
+    #[test]
+    fn yaml_boolean_keywords_are_double_quoted() {
+        assert_eq!(yaml_scalar("true"), "\"true\"");
+        assert_eq!(yaml_scalar("false"), "\"false\"");
+        assert_eq!(yaml_scalar("True"), "\"True\"");
+        assert_eq!(yaml_scalar("FALSE"), "\"FALSE\"");
+    }
+
+    #[test]
+    fn yaml_null_keywords_are_double_quoted() {
+        assert_eq!(yaml_scalar("null"), "\"null\"");
+        assert_eq!(yaml_scalar("Null"), "\"Null\"");
+        assert_eq!(yaml_scalar("~"), "\"~\"");
+    }
+
+    #[test]
+    fn yaml_yes_no_keywords_are_double_quoted() {
+        assert_eq!(yaml_scalar("yes"), "\"yes\"");
+        assert_eq!(yaml_scalar("no"), "\"no\"");
+        assert_eq!(yaml_scalar("on"), "\"on\"");
+        assert_eq!(yaml_scalar("off"), "\"off\"");
+        assert_eq!(yaml_scalar("y"), "\"y\"");
+        assert_eq!(yaml_scalar("n"), "\"n\"");
+    }
+
+    #[test]
+    fn numbers_are_double_quoted() {
+        // Integers
+        assert_eq!(yaml_scalar("0"), "\"0\"");
+        assert_eq!(yaml_scalar("123"), "\"123\"");
+        assert_eq!(yaml_scalar("-42"), "\"-42\"");
+        assert_eq!(yaml_scalar("+7"), "\"+7\"");
+        // Floats
+        assert_eq!(yaml_scalar("3.14"), "\"3.14\"");
+        assert_eq!(yaml_scalar(".5"), "\".5\"");
+        assert_eq!(yaml_scalar("5."), "\"5.\"");
+        assert_eq!(yaml_scalar("-0.5"), "\"-0.5\"");
+        // Hex
+        assert_eq!(yaml_scalar("0x1A"), "\"0x1A\"");
+        // Octal
+        assert_eq!(yaml_scalar("0o755"), "\"0o755\"");
+        // Binary
+        assert_eq!(yaml_scalar("0b1010"), "\"0b1010\"");
+        // Scientific notation
+        assert_eq!(yaml_scalar("1e5"), "\"1e5\"");
+        assert_eq!(yaml_scalar("1.5e-3"), "\"1.5e-3\"");
+    }
+
+    #[test]
+    fn non_number_strings_are_unquoted() {
+        // Strings that look like numbers but aren't valid
+        assert_eq!(yaml_scalar("0x"), "0x"); // incomplete hex
+        assert_eq!(yaml_scalar("1.2.3"), "1.2.3"); // multiple dots
+        assert_eq!(yaml_scalar("abc123"), "abc123"); // letters before digits
+        assert_eq!(yaml_scalar("v1.0"), "v1.0"); // letter prefix
     }
 
     #[test]

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -255,119 +255,83 @@ fn format_mmss(ms: u64) -> String {
 }
 
 fn yaml_scalar(s: &str) -> String {
-    // YAML reserved words that would be parsed as booleans/null.
-    const YAML_KEYWORDS: &[&str] = &[
-        "true", "false", "null", "yes", "no", "on", "off", "y", "n", "~",
-    ];
-    // Characters that trigger quoting anywhere in the string.
-    const QUOTE_CHARS: &[char] = &['\n', '\r', '\t', '"', '\\', '#', '\''];
-    // Characters that trigger quoting if the string starts with them.
-    const LEADING_SPECIAL: &[char] = &[
-        ':', '-', '!', '|', '>', '[', ']', '{', '}', '*', '&', '?', '@', '`', '%',
-    ];
-
-    let lower = s.to_lowercase();
-    let needs_quoting = s.is_empty()
-        // Whitespace-only strings need quoting
-        || s.trim().is_empty()
-        // YAML keywords (booleans/null)
-        || YAML_KEYWORDS.contains(&lower.as_str())
-        // Strings that look like numbers (integers, floats, hex, octal)
-        || looks_like_number(s)
-        // Colon-space (mapping indicator) or trailing colon (key indicator)
-        || s.contains(": ") || s.ends_with(':')
-        // Special characters anywhere
-        || s.contains(QUOTE_CHARS)
-        // Special characters at start
-        || s.starts_with(LEADING_SPECIAL);
-
-    if needs_quoting {
-        let escaped = s
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r")
-            .replace('\t', "\\t");
-        format!("\"{escaped}\"")
-    } else {
-        s.to_string()
+    // Quote-by-default: emit a plain (unquoted) scalar ONLY when the value is
+    // unambiguously safe. Everything else is double-quoted with escaping, which
+    // a YAML parser always reads back as the exact source string. This closes
+    // the YAML 1.1 number-format edge cases (1_000, .inf, 0xDE_AD, ...) in one
+    // rule instead of enumerating every shape that must be quoted.
+    if is_safe_plain_scalar(s) {
+        return s.to_string();
     }
+    let escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t");
+    format!("\"{escaped}\"")
 }
 
-/// Returns true if the string would be parsed as a YAML number.
+/// A value is safe to emit as a plain scalar only when it matches the strict
+/// pattern `^[A-Za-z][A-Za-z0-9 ._/-]*$`, is not a YAML reserved word, and is
+/// not number-like. The leading-letter requirement already excludes most
+/// numbers; the reserved-word and number checks catch the letter-leading edges
+/// (`true`, `inf`, `nan`, ...) that would otherwise slip through unquoted.
+fn is_safe_plain_scalar(s: &str) -> bool {
+    matches_plain_pattern(s) && !is_yaml_reserved(s) && !looks_like_number(s)
+}
+
+/// Matches `^[A-Za-z][A-Za-z0-9 ._/-]*$`: first char is an ASCII letter, the
+/// rest are ASCII alphanumerics or one of space, `.`, `_`, `/`, `-`.
+fn matches_plain_pattern(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '.' | '_' | '/' | '-'))
+}
+
+/// YAML reserved words (case-insensitive) that a parser would coerce to a
+/// boolean, null, or float rather than a string.
+fn is_yaml_reserved(s: &str) -> bool {
+    const KEYWORDS: &[&str] = &[
+        "true", "false", "null", "yes", "no", "on", "off", "y", "n", "~", ".inf", "-.inf", ".nan",
+    ];
+    let lower = s.to_lowercase();
+    KEYWORDS.contains(&lower.as_str())
+}
+
+/// Returns true if the value could be read back as a YAML number: it parses as
+/// an integer or float, uses underscore digit grouping (`1_000`), or carries a
+/// radix prefix (`0x`/`0o`/`0b`). `f64::parse` also accepts `inf`/`nan`, which
+/// is why those letter-leading words are number-like and need quoting.
 fn looks_like_number(s: &str) -> bool {
-    // YAML parses integers, floats, hex, octal, and binary as numbers.
-    // We conservatively quote anything that might be parsed as a number.
-    if s.is_empty() {
-        return false;
-    }
-    // Hex: 0x...
-    if s.starts_with("0x") || s.starts_with("0X") {
-        return s.len() > 2 && s[2..].chars().all(|c| c.is_ascii_hexdigit());
-    }
-    // Octal: 0o... (YAML 1.2 uses 0o prefix)
-    if s.starts_with("0o") || s.starts_with("0O") {
-        return s.len() > 2 && s[2..].chars().all(|c| c.is_ascii_digit() && c < '8');
-    }
-    // Binary: 0b...
-    if s.starts_with("0b") || s.starts_with("0B") {
-        return s.len() > 2 && s[2..].chars().all(|c| c == '0' || c == '1');
-    }
-
-    // Check for plain integers and floats.
-    // A valid YAML float has exactly ONE dot.
     let trimmed = s.trim();
-
-    // Count dots - more than one means it's not a valid number
-    let dot_count = trimmed.chars().filter(|c| *c == '.').count();
-    if dot_count > 1 {
+    if trimmed.is_empty() {
         return false;
     }
-
-    // Handle optional sign prefix
-    let digits_part = if trimmed.starts_with('+') || trimmed.starts_with('-') {
-        &trimmed[1..]
-    } else {
-        trimmed
-    };
-
-    // Integer: all digits, no dot
-    if dot_count == 0 && digits_part.chars().all(|c| c.is_ascii_digit()) && !digits_part.is_empty()
-    {
+    if trimmed.parse::<i64>().is_ok() || trimmed.parse::<f64>().is_ok() {
         return true;
     }
-
-    // Float: exactly one dot, rest are digits (allow ".5" and "5.")
-    if dot_count == 1 {
-        let without_dot = digits_part.replace('.', "");
-        // Empty after removing dot means just "." which isn't valid, but
-        // ".5" or "5." are valid YAML floats
-        if without_dot.chars().all(|c| c.is_ascii_digit()) && !without_dot.is_empty() {
-            return true;
+    // Radix prefixes, optionally signed (Rust's `parse` rejects these).
+    let body = trimmed.strip_prefix(['+', '-']).unwrap_or(trimmed);
+    let lower = body.to_ascii_lowercase();
+    for (prefix, radix) in [("0x", 16u32), ("0o", 8), ("0b", 2)] {
+        if let Some(rest) = lower.strip_prefix(prefix) {
+            return !rest.is_empty() && rest.chars().all(|c| c == '_' || c.is_digit(radix));
         }
     }
-
-    // Scientific notation (e.g., "1e5", "1.5e-3")
-    if trimmed.contains('e') || trimmed.contains('E') {
-        let parts: Vec<&str> = trimmed.split(['e', 'E']).collect();
-        if parts.len() == 2 {
-            let base = parts[0];
-            let exp = parts[1];
-            // Base part can be integer or float (one dot max)
-            let base_dot_count = base.chars().filter(|c| *c == '.').count();
-            let base_digits = base.replace(['.', '+', '-'], "");
-            let base_ok = base_dot_count <= 1
-                && base_digits.chars().all(|c| c.is_ascii_digit())
-                && !base_digits.is_empty();
-            // Exp part is integer (may have sign)
-            let exp_digits = exp.replace(['+', '-'], "");
-            let exp_ok = exp_digits.chars().all(|c| c.is_ascii_digit()) && !exp_digits.is_empty();
-            if base_ok && exp_ok {
-                return true;
-            }
-        }
+    // Underscore digit grouping (YAML 1.1: `1_000`, `1_000.5`). Rust's `parse`
+    // rejects underscores, so detect them explicitly.
+    if trimmed.contains('_') {
+        let cleaned = body.replace('_', "");
+        let dot_count = cleaned.matches('.').count();
+        let digits_only = cleaned.replace('.', "");
+        return dot_count <= 1
+            && !digits_only.is_empty()
+            && digits_only.chars().all(|c| c.is_ascii_digit());
     }
-
     false
 }
 
@@ -494,12 +458,38 @@ mod tests {
     }
 
     #[test]
-    fn non_number_strings_are_unquoted() {
-        // Strings that look like numbers but aren't valid
-        assert_eq!(yaml_scalar("0x"), "0x"); // incomplete hex
-        assert_eq!(yaml_scalar("1.2.3"), "1.2.3"); // multiple dots
+    fn number_shaped_strings_are_double_quoted() {
+        // Leading digits or dots fail the safe-plain pattern, so quote-by-default
+        // wraps them even though they aren't valid numbers on their own.
+        assert_eq!(yaml_scalar("0x"), "\"0x\""); // incomplete hex
+        assert_eq!(yaml_scalar("1.2.3"), "\"1.2.3\""); // multiple dots
+    }
+
+    #[test]
+    fn letter_leading_strings_stay_unquoted() {
+        // These match the safe-plain pattern and aren't number-like, so they
+        // remain plain scalars.
         assert_eq!(yaml_scalar("abc123"), "abc123"); // letters before digits
         assert_eq!(yaml_scalar("v1.0"), "v1.0"); // letter prefix
+    }
+
+    #[test]
+    fn yaml_1_1_number_formats_are_double_quoted() {
+        assert_eq!(yaml_scalar("1_000"), "\"1_000\""); // underscore grouping
+        assert_eq!(yaml_scalar(".inf"), "\".inf\""); // YAML infinity
+        assert_eq!(yaml_scalar(".nan"), "\".nan\""); // YAML not-a-number
+        assert_eq!(yaml_scalar("0xDEAD"), "\"0xDEAD\""); // unsigned hex
+    }
+
+    #[test]
+    fn title_with_colon_is_double_quoted() {
+        assert_eq!(yaml_scalar("Q3: planning"), "\"Q3: planning\"");
+    }
+
+    #[test]
+    fn leading_zero_string_is_double_quoted() {
+        // A string like "007" must round-trip as a string, not octal/decimal.
+        assert_eq!(yaml_scalar("007"), "\"007\"");
     }
 
     #[test]

--- a/crates/panops-portable/src/markdown_exporter.rs
+++ b/crates/panops-portable/src/markdown_exporter.rs
@@ -271,10 +271,13 @@ fn yaml_scalar(s: &str) -> String {
             '\n' => escaped.push_str("\\n"),
             '\r' => escaped.push_str("\\r"),
             '\t' => escaped.push_str("\\t"),
-            // Any remaining C0 control char (U+0000–U+001F) is invalid in a
-            // YAML double-quoted scalar unless escaped; emit `\xNN` with two
-            // lowercase hex digits (e.g. 0x01 -> \x01, 0x07 -> \x07).
-            c if (c as u32) < 0x20 => escaped.push_str(&format!("\\x{:02x}", c as u32)),
+            // Any remaining C0 control char (U+0000-U+001F) or DEL (U+007F)
+            // is invalid raw in a YAML double-quoted scalar; emit the broadly
+            // supported 4-hex \uNNNN escape (more portable than \xNN, which
+            // is YAML-1.2-only and rejected by some parsers such as PyYAML).
+            c if (c as u32) < 0x20 || (c as u32) == 0x7f => {
+                escaped.push_str(&format!("\\u{:04x}", c as u32))
+            }
             c => escaped.push(c),
         }
     }
@@ -448,15 +451,16 @@ mod tests {
     }
 
     #[test]
-    fn control_chars_are_hex_escaped_inside_double_quotes() {
-        // U+0001 (SOH) and U+0007 (BEL) have no dedicated escape and would be
-        // invalid raw inside a YAML double-quoted scalar; they must emit as
-        // \x01 / \x07 (two lowercase hex digits).
+    fn control_chars_are_unicode_escaped_inside_double_quotes() {
+        // U+0001 (SOH), U+0007 (BEL), and DEL (U+007F) have no dedicated escape
+        // and would be invalid raw inside a YAML double-quoted scalar; they emit
+        // as \uNNNN (4 lowercase hex digits, the broadly portable form).
         let mut value = String::from("a");
         value.push('\u{0001}');
         value.push('\u{0007}');
+        value.push('\u{007f}');
         value.push('b');
-        assert_eq!(yaml_scalar(&value), "\"a\\x01\\x07b\"");
+        assert_eq!(yaml_scalar(&value), "\"a\\u0001\\u0007\\u007fb\"");
     }
 
     #[test]


### PR DESCRIPTION
Addresses #147.

claudea **hardened the hand-rolled YAML escaping** (numbers, keywords, quotes, colons, multiline) in `render_frontmatter` and added 6 tests, rather than swapping in a serializer crate: `serde_yaml` is unmaintained (RUSTSEC) and `serde_yml` would need a `cargo deny` allowlist review. This fixes #147's underlying correctness concern (error-prone hand-rolled escaping) while keeping the dep tree clean.

If you'd prefer a full serializer swap instead, that's a follow-up decision (cargo-deny on the fork). Existing frontmatter output + tests unchanged; +6 new escaping tests. fmt/build/clippy green locally.