### PR TITLE
Pin notes output language

### DIFF
--- a/crates/panops-core/src/notes/prompts.rs
+++ b/crates/panops-core/src/notes/prompts.rs
@@ -67,7 +67,9 @@ pub fn build_section_narrative_prompt(
          {transcript}\n\
          Markdown dialect for `narrative_md`:\n\
          {cheat}\n\
-         Output language: {language}\n\n\
+         CRITICAL: write the ENTIRE output (title, narrative_md, key_points,\n\
+         action_items) in {language}. Do NOT translate to English; keep the\n\
+         speakers' original language.\n\n\
          Speaker attribution rule (STRICT): never attribute a quote to a speaker_id\n\
          that does not appear in the transcript. When in doubt, use passive voice.\n\n\
          Non-duplication rule (STRICT): `narrative_md`, `key_points`, and `action_items`\n\
@@ -111,10 +113,11 @@ pub fn build_frontmatter_prompt(
     let user = format!(
         "Section summaries:\n\n\
          {s}\n\
-         Meeting language: {language}\n\
+         CRITICAL: write the title in {language}. Do NOT translate to English;\n\
+         keep the speakers' original language.\n\
          Meeting duration: {duration_ms} ms\n\n\
          Return JSON matching exactly:\n\
-         {{\n  \"title\": \"string (<=80 chars, descriptive)\",\n  \"tags\": [\"lowercase-kebab-case\", ...] (max 10)\n}}"
+         {{\n  \"title\": \"string (<=80 chars, descriptive, in {language})\",\n  \"tags\": [\"lowercase-kebab-case\", ...] (max 10)\n}}"
     );
     LlmRequest {
         system: Some(FRONTMATTER_SYSTEM.to_string()),
@@ -286,7 +289,9 @@ pub fn build_merge_section_prompt(
          {summaries_text}\n\
          Markdown dialect for `narrative_md`:\n\
          {cheat}\n\
-         Output language: {language}\n\n\
+         CRITICAL: write the ENTIRE output (title, narrative_md, key_points,\n\
+         action_items) in {language}. Do NOT translate to English; keep the\n\
+         speakers' original language.\n\n\
          Merge these sub-chunks into a single unified section summary.\n\
          - Combine narratives into flowing prose (no bullet lists).\n\
          - Deduplicate key_points: keep distinct facts, merge overlapping.\n\
@@ -395,6 +400,38 @@ mod tests {
         assert!(p.user.contains("must NOT restate the same facts"));
         assert!(p.user.contains("NO bullet lists"));
         assert!(p.user.contains("NOT in narrative_md"));
+    }
+
+    #[test]
+    fn section_narrative_prompt_pins_output_language() {
+        let segs = vec![seg(0, 5000, Some(0), "hola")];
+        let p = build_section_narrative_prompt(&segs, MarkdownDialect::NotionEnhanced, "es");
+        assert!(p.user.contains("CRITICAL: write the ENTIRE output"));
+        assert!(p.user.contains("in es."));
+        assert!(p.user.contains("Do NOT translate to English"));
+    }
+
+    #[test]
+    fn frontmatter_prompt_pins_output_language() {
+        let summaries = vec![SectionSummary {
+            title: "Intro".into(),
+            key_points: vec![],
+        }];
+        let p = build_frontmatter_prompt(&summaries, "es", 60_000);
+        assert!(p.user.contains("CRITICAL: write the title in es."));
+        assert!(p.user.contains("Do NOT translate to English"));
+        assert!(p.user.contains("descriptive, in es)"));
+    }
+
+    #[test]
+    fn merge_section_prompt_pins_output_language() {
+        let summaries = vec![serde_json::json!({
+            "title": "Parte 1", "narrative_md": "primera parte", "key_points": [], "action_items": []
+        })];
+        let p = build_merge_section_prompt(&summaries, MarkdownDialect::Basic, "es");
+        assert!(p.user.contains("CRITICAL: write the ENTIRE output"));
+        assert!(p.user.contains("in es."));
+        assert!(p.user.contains("Do NOT translate to English"));
     }
 
     #[test]

--- a/tests/fixtures/prompts/frontmatter.golden.txt
+++ b/tests/fixtures/prompts/frontmatter.golden.txt
@@ -12,12 +12,13 @@ Section 1: Quarterly budget review kickoff
   - Budget scoped to next quarter
   - Review sequence: marketing, engineering
 
-Meeting language: en
+CRITICAL: write the title in en. Do NOT translate to English;
+keep the speakers' original language.
 Meeting duration: 60000 ms
 
 Return JSON matching exactly:
 {
-  "title": "string (<=80 chars, descriptive)",
+  "title": "string (<=80 chars, descriptive, in en)",
   "tags": ["lowercase-kebab-case", ...] (max 10)
 }
 

--- a/tests/fixtures/prompts/merge_section_basic.golden.txt
+++ b/tests/fixtures/prompts/merge_section_basic.golden.txt
@@ -34,7 +34,9 @@ You are emitting strict CommonMark. Allowed constructs:
 NEVER emit HTML tags, callouts, color attributes, or Notion-specific extensions.
 This is for Obsidian / GitHub / vanilla CommonMark viewers.
 
-Output language: en
+CRITICAL: write the ENTIRE output (title, narrative_md, key_points,
+action_items) in en. Do NOT translate to English; keep the
+speakers' original language.
 
 Merge these sub-chunks into a single unified section summary.
 - Combine narratives into flowing prose (no bullet lists).

--- a/tests/fixtures/prompts/merge_section_notion-enhanced.golden.txt
+++ b/tests/fixtures/prompts/merge_section_notion-enhanced.golden.txt
@@ -33,7 +33,9 @@ You are emitting Notion-flavored markdown. Allowed constructs:
 - Inline mentions: @user, @date.
 NEVER emit raw HTML beyond the listed tags. NEVER nest callouts.
 
-Output language: en
+CRITICAL: write the ENTIRE output (title, narrative_md, key_points,
+action_items) in en. Do NOT translate to English; keep the
+speakers' original language.
 
 Merge these sub-chunks into a single unified section summary.
 - Combine narratives into flowing prose (no bullet lists).

--- a/tests/fixtures/prompts/section_narrative_basic.golden.txt
+++ b/tests/fixtures/prompts/section_narrative_basic.golden.txt
@@ -24,7 +24,9 @@ You are emitting strict CommonMark. Allowed constructs:
 NEVER emit HTML tags, callouts, color attributes, or Notion-specific extensions.
 This is for Obsidian / GitHub / vanilla CommonMark viewers.
 
-Output language: en
+CRITICAL: write the ENTIRE output (title, narrative_md, key_points,
+action_items) in en. Do NOT translate to English; keep the
+speakers' original language.
 
 Speaker attribution rule (STRICT): never attribute a quote to a speaker_id
 that does not appear in the transcript. When in doubt, use passive voice.

--- a/tests/fixtures/prompts/section_narrative_notion-enhanced.golden.txt
+++ b/tests/fixtures/prompts/section_narrative_notion-enhanced.golden.txt
@@ -23,7 +23,9 @@ You are emitting Notion-flavored markdown. Allowed constructs:
 - Inline mentions: @user, @date.
 NEVER emit raw HTML beyond the listed tags. NEVER nest callouts.
 
-Output language: en
+CRITICAL: write the ENTIRE output (title, narrative_md, key_points,
+action_items) in en. Do NOT translate to English; keep the
+speakers' original language.
 
 Speaker attribution rule (STRICT): never attribute a quote to a speaker_id
 that does not appear in the transcript. When in doubt, use passive voice.


### PR DESCRIPTION
Closes #185: pin notes output language strongly (was drifting to English on a Spanish meeting). Model-agnostic.