### PR TITLE
add mirror URL with upstream fallback for model downloads

### DIFF
--- a/Casks/panops.rb
+++ b/Casks/panops.rb
@@ -1,6 +1,8 @@
 cask "panops" do
+  # Version and sha256 are updated at release time per docs/release-v0.1.md.
+  # Run `scripts/package.sh v0.1.0` and use the output sha256.
   version "0.1.0"
-  sha256 "REPLACE_WITH_TARBALL_SHA256"
+  sha256 "REPLACE_WITH_TARBALL_SHA256_FROM_PACKAGE_SH_OUTPUT"  # e.g. "a1b2c3d4..."
 
   url "https://github.com/vfmatzkin/panops/releases/download/v#{version}/Panops-#{version}.tar.gz"
   name "Panops"

--- a/crates/panops-portable/src/model.rs
+++ b/crates/panops-portable/src/model.rs
@@ -10,30 +10,36 @@ use sha2::{Digest, Sha256};
 
 pub struct ModelInfo {
     pub name: &'static str,
+    /// Upstream download URL. The mirror URL is derived from this at runtime.
     pub url: &'static str,
     pub sha256: &'static str,
     pub approx_size_mb: u32,
 }
 
+/// Construct the mirror URL for a model by extracting its filename from the upstream URL.
+fn mirror_url_from_upstream(upstream_url: &str) -> String {
+    let filename = upstream_url.rsplit('/').next().unwrap_or("");
+    format!("https://github.com/vfmatzkin/panops/releases/download/models-v1/{filename}")
+}
+
 pub const MODELS: &[ModelInfo] = &[
     ModelInfo {
         name: "ggml-tiny-q5_1",
-        // Mirroring to a project-hosted models-v1 release is deferred to #8
-        // (needs the release created + an upstream runtime fallback first).
+        // Primary: upstream Hugging Face. Mirror: models-v1 release (fallback).
         url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin",
         sha256: "818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7",
         approx_size_mb: 31,
     },
     ModelInfo {
         name: "ggml-base-q5_1",
-        // Mirror to models-v1 release deferred — #8.
+        // Primary: upstream Hugging Face. Mirror: models-v1 release (fallback).
         url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
         sha256: "422f1ae452ade6f30a004d7e5c6a43195e4433bc370bf23fac9cc591f01a8898",
         approx_size_mb: 57,
     },
     ModelInfo {
         name: "ggml-large-v3-turbo-q5_0",
-        // Mirror to models-v1 release deferred — #8.
+        // Primary: upstream Hugging Face. Mirror: models-v1 release (fallback).
         url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
         sha256: "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2",
         approx_size_mb: 547,
@@ -43,14 +49,14 @@ pub const MODELS: &[ModelInfo] = &[
 pub const DIAR_MODELS: &[ModelInfo] = &[
     ModelInfo {
         name: "sherpa-onnx-pyannote-segmentation-3-0",
-        // Mirror to models-v1 release deferred — #8.
+        // Primary: upstream sherpa-onnx release. Mirror: models-v1 release (fallback).
         url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2",
         sha256: "24615ee884c897d9d2ba09bb4d30da6bb1b15e685065962db5b02e76e4996488",
         approx_size_mb: 7,
     },
     ModelInfo {
         name: "3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k",
-        // Mirror to models-v1 release deferred — #8.
+        // Primary: upstream sherpa-onnx release. Mirror: models-v1 release (fallback).
         url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx",
         sha256: "1a331345f04805badbb495c775a6ddffcdd1a732567d5ec8b3d5749e3c7a5e4b",
         approx_size_mb: 38,
@@ -59,7 +65,7 @@ pub const DIAR_MODELS: &[ModelInfo] = &[
 
 pub const VAD_MODELS: &[ModelInfo] = &[ModelInfo {
     name: "ggml-silero-v6.2.0",
-    // Mirror to models-v1 release deferred — #8.
+    // Primary: upstream Hugging Face. Mirror: models-v1 release (fallback).
     url: "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v6.2.0.bin",
     // SHA256 captured 2026-05-09 by `shasum -a 256` after manual download.
     sha256: "2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987",
@@ -495,6 +501,41 @@ fn download(client: &reqwest::blocking::Client, url: &str, dest: &Path) -> Resul
     Ok(bytes_written)
 }
 
+/// Download a model with mirror-first fallback.
+/// Tries the models-v1 mirror URL first; on any failure (HTTP error, network error),
+/// falls back to the upstream URL. This allows downloads to keep working before
+/// the models-v1 release exists, and automatically uses the mirror once it does.
+///
+/// Logs which source succeeded or if both failed.
+fn download_with_fallback(
+    client: &reqwest::blocking::Client,
+    upstream_url: &str,
+    dest: &Path,
+) -> Result<u64, AsrError> {
+    let mirror_url = mirror_url_from_upstream(upstream_url);
+
+    // Try mirror first.
+    tracing::debug!(mirror = %mirror_url, upstream = %upstream_url, "attempting mirror download");
+    match download(client, &mirror_url, dest) {
+        Ok(n) => {
+            tracing::info!(source = "mirror", url = %mirror_url, bytes = n, "download succeeded from mirror");
+            return Ok(n);
+        }
+        Err(e) => {
+            tracing::warn!(
+                mirror = %mirror_url,
+                error = %e,
+                "mirror download failed, falling back to upstream"
+            );
+        }
+    }
+
+    // Fallback to upstream.
+    let n = download(client, upstream_url, dest)?;
+    tracing::info!(source = "upstream", url = %upstream_url, bytes = n, "download succeeded from upstream");
+    Ok(n)
+}
+
 /// Ensure a registered model exists at `dest`. Verifies sha256 against the
 /// registered hash for `name`. Idempotent. Used for both Whisper `.bin`
 /// files and bare `.onnx` files (not for tarballs — see `ensure_diar_models`).
@@ -530,7 +571,7 @@ pub fn ensure_model(name: &str, dest: &Path) -> Result<PathBuf, AsrError> {
         "downloading model"
     );
     let client = http_client()?;
-    let n = download(&client, info.url, dest)?;
+    let n = download_with_fallback(&client, info.url, dest)?;
     if let Err(e) = verify_sha256(dest, info.sha256) {
         // Self-heal: a checksum mismatch means we have a poisoned cache.
         // Drop the file so a subsequent run re-downloads instead of looping.
@@ -568,7 +609,7 @@ pub fn ensure_diar_models() -> Result<(PathBuf, PathBuf), AsrError> {
             "downloading diar embedding model"
         );
         let client = http_client()?;
-        download(&client, emb_info.url, &emb)?;
+        download_with_fallback(&client, emb_info.url, &emb)?;
     }
     let skip_checksum = std::env::var("PANOPS_SKIP_MODEL_CHECKSUM").is_ok();
     let emb_user_override = std::env::var("PANOPS_DIAR_EMB").is_ok();
@@ -614,7 +655,7 @@ pub fn ensure_diar_models() -> Result<(PathBuf, PathBuf), AsrError> {
                 "downloading diar segmentation model"
             );
             let client = http_client()?;
-            download(&client, seg_info.url, &tar_path)?;
+            download_with_fallback(&client, seg_info.url, &tar_path)?;
         }
         if !skip_checksum {
             // Same `.verified` cache: skip re-hashing the tarball when a valid
@@ -681,7 +722,7 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
         "downloading vad model"
     );
     let client = http_client()?;
-    let n = download(&client, info.url, dest)?;
+    let n = download_with_fallback(&client, info.url, dest)?;
     if let Err(e) = verify_sha256(dest, info.sha256) {
         let _ = fs::remove_file(dest);
         return Err(e);
@@ -695,6 +736,44 @@ pub fn ensure_vad_model(dest: &Path) -> Result<PathBuf, AsrError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mirror_url_extracts_filename_from_upstream() {
+        // Whisper models
+        assert_eq!(
+            mirror_url_from_upstream(
+                "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin"
+            ),
+            "https://github.com/vfmatzkin/panops/releases/download/models-v1/ggml-tiny-q5_1.bin"
+        );
+        assert_eq!(
+            mirror_url_from_upstream(
+                "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin"
+            ),
+            "https://github.com/vfmatzkin/panops/releases/download/models-v1/ggml-large-v3-turbo-q5_0.bin"
+        );
+        // Diar segmentation tarball
+        assert_eq!(
+            mirror_url_from_upstream(
+                "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+            ),
+            "https://github.com/vfmatzkin/panops/releases/download/models-v1/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+        );
+        // Diar embedding model
+        assert_eq!(
+            mirror_url_from_upstream(
+                "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
+            ),
+            "https://github.com/vfmatzkin/panops/releases/download/models-v1/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
+        );
+        // VAD model
+        assert_eq!(
+            mirror_url_from_upstream(
+                "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v6.2.0.bin"
+            ),
+            "https://github.com/vfmatzkin/panops/releases/download/models-v1/ggml-silero-v6.2.0.bin"
+        );
+    }
 
     #[cfg(unix)]
     fn set_file_mtime(path: &Path, secs: std::ffi::c_long, nanos: std::ffi::c_long) {

--- a/docs/release-v0.1.md
+++ b/docs/release-v0.1.md
@@ -1,0 +1,123 @@
+# v0.1 Release Checklist
+
+Prerequisites: merged PR for this slice, clean working tree on `main`.
+
+## 1. Build + ad-hoc-sign Panops.app
+
+```bash
+git checkout main
+git pull
+scripts/package.sh v0.1.0
+```
+
+Output: `dist/Panops-v0.1.0.tar.gz` + `dist/Panops-v0.1.0.tar.gz.sha256`.
+
+## 2. Compute tarball sha256
+
+```bash
+cat dist/Panops-v0.1.0.tar.gz.sha256
+```
+
+Copy this hex digest for the cask update.
+
+## 3. Create models-v1 release + upload model assets
+
+Create a GitHub release tagged `models-v1` with all model files as assets.
+
+### Model assets (with sha256 from `crates/panops-portable/src/model.rs`)
+
+| Asset | sha256 |
+|---|---|
+| `ggml-tiny-q5_1.bin` | `818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7` |
+| `ggml-base-q5_1.bin` | `422f1ae452ade6f30a004d7e5c6a43195e4433bc370bf23fac9cc591f01a8898` |
+| `ggml-large-v3-turbo-q5_0.bin` | `394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2` |
+| `sherpa-onnx-pyannote-segmentation-3-0.tar.bz2` | `24615ee884c897d9d2ba09bb4d30da6bb1b15e685065962db5b02e76e4996488` |
+| `3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx` | `1a331345f04805badbb495c775a6ddffcdd1a732567d5ec8b3d5749e3c7a5e4b` |
+| `ggml-silero-v6.2.0.bin` | `2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987` |
+
+```bash
+# Upload each asset to the models-v1 release
+gh release create models-v1 \
+  --repo vfmatzkin/panops \
+  --title "Model assets for v0.1" \
+  --notes "Model files for Panops v0.1. Mirror URLs in panops-portable use this release as primary, upstream as fallback." \
+  path/to/ggml-tiny-q5_1.bin \
+  path/to/ggml-base-q5_1.bin \
+  path/to/ggml-large-v3-turbo-q5_0.bin \
+  path/to/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2 \
+  path/to/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx \
+  path/to/ggml-silero-v6.2.0.bin
+```
+
+Model files must already exist locally (from CI cache or manual download). Obtain from upstream URLs documented in `model.rs` if needed.
+
+## 4. Update Casks/panops.rb
+
+```ruby
+cask "panops" do
+  version "0.1.0"
+  sha256 "<TARBALL_SHA256_FROM_STEP_2>"  # e.g. "a1b2c3..."
+
+  url "https://github.com/vfmatzkin/panops/releases/download/v#{version}/Panops-#{version}.tar.gz"
+  # ... rest unchanged
+end
+```
+
+Commit: `update cask for v0.1.0 release`
+
+## 5. Tag v0.1.0
+
+```bash
+git tag -a v0.1.0 -m "v0.1.0 release"
+git push origin v0.1.0
+```
+
+## 6. Create GitHub Release v0.1.0
+
+```bash
+gh release create v0.1.0 \
+  --repo vfmatzkin/panops \
+  --title "v0.1.0" \
+  --notes-file RELEASE_NOTES.md \
+  dist/Panops-v0.1.0.tar.gz \
+  dist/Panops-v0.1.0.tar.gz.sha256
+```
+
+### Release notes draft (v0.1.0)
+
+First public release of Panops — a local-first macOS recorder with screenshot-anchored meeting notes.
+
+Features:
+
+- Headless CLI for transcription + diarization + note generation
+- SwiftUI Mac app with WhisperKit ASR sidecar
+- SQLite per-meeting storage + cross-meeting registry
+- JSON-RPC + WebSocket IPC over Unix domain socket
+- VAD-aware multilingual ASR (per-region language detection)
+- Markdown notes output (NotionEnhanced dialect)
+
+Known limitations:
+
+- Ad-hoc signed (not Apple-notarized). Requires quarantine flag bypass on first launch.
+- No live capture yet (planned for post-v0.1).
+
+Install via Homebrew:
+
+```bash
+brew tap vfmatzkin/panops
+brew install --cask panops
+```
+
+## 7. Verify brew install
+
+```bash
+brew install --cask panops
+xattr -dr com.apple.quarantine "$(brew --prefix)/Caskroom/panops/0.1.0/Panops.app"
+open "$(brew --prefix)/Caskroom/panops/0.1.0/Panops.app"
+```
+
+Confirm app launches, UI renders, sidecars start.
+
+---
+
+Post-release: close v0.1 milestone on project board, run slice-boundary alignment audit per AGENTS.md.


### PR DESCRIPTION
Closes #8 (mirror w/ upstream fallback); preps #163 (release checklist + cask). Maintainer creates models-v1 release + tag.