### PR TITLE
Wire Mac RecordBar to live recording.* IPC

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -518,6 +518,11 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                 MeetingDetailView(
                     meeting: meeting,
                     recordingController: recordingController,
+                    onRecordingStarted: { id in
+                        await MainActor.run {
+                            vm.activeRecordingMeetingId = id
+                        }
+                    },
                     onRecordingStopped: { _ in
                         try await vm.finishActiveLiveRecording()
                     }

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -218,6 +218,24 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+    /// Create a meeting through the existing `ipc.meeting.start` path, start
+    /// live capture for it, select it in the sidebar, and refresh the list.
+    func startNewRecording<Controller: RecordingController>(using recordingController: Controller) async throws {
+        let meetingId = try await client.meetingStart()
+        do {
+            try await recordingController.start(meetingId: meetingId)
+        } catch {
+            await refreshMeetings()
+            throw error
+        }
+
+        selectedMeetingId = meetingId
+        selectedMeeting = nil
+        state = .idle(audio: nil)
+        await refreshMeetings()
+        await loadSelectedMeeting()
+    }
+
     /// Load meeting detail when selected.
     func loadSelectedMeeting() async {
         guard let id = selectedMeetingId else {
@@ -232,6 +250,17 @@ final class AppViewModel: ObservableObject {
         } catch {
             Self.logFullError("meeting.get", error)
             selectedMeeting = nil
+        }
+    }
+
+    /// Close the meeting row after a live recording stops, then refresh list
+    /// and detail so ended_at/duration_ms are visible immediately.
+    func finishLiveRecording(meetingId: String) async throws {
+        let stoppedMeeting = try await client.meetingStop(id: meetingId)
+        await refreshMeetings()
+        if selectedMeetingId == meetingId {
+            selectedMeeting = stoppedMeeting
+            state = .idle(audio: nil)
         }
     }
 
@@ -358,6 +387,8 @@ final class AppViewModel: ObservableObject {
 struct ContentView<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var vm: AppViewModel
     @ObservedObject var recordingController: Controller
+    @State private var isStartingNewRecording = false
+    @State private var toolbarRecordingError: String?
 
     var body: some View {
         NavigationSplitView {
@@ -378,18 +409,61 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         }
         .frame(minWidth: 720, minHeight: 480)
         .toolbar {
-            if vm.selectedMeeting != nil {
-                Button("New") {
-                    vm.startNewGenerationFlow()
+            ToolbarItemGroup {
+                if vm.selectedMeeting != nil {
+                    Button("New") {
+                        vm.startNewGenerationFlow()
+                    }
+                    .help("Start a new notes-generation flow")
                 }
-                .help("Start a new notes-generation flow")
+
+                Button("New Recording") {
+                    Task { @MainActor in
+                        await startNewRecording()
+                    }
+                }
+                .disabled(isStartingNewRecording || recordingController.isRecording || isEngineNotConnected)
+                .help("Create a meeting and start live recording")
             }
+        }
+        .alert("Recording error", isPresented: toolbarRecordingErrorPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(toolbarRecordingError ?? "")
         }
         .task {
             await vm.refreshMeetings()
         }
         .onChange(of: vm.selectedMeetingId) { _, _ in
             Task { await vm.loadSelectedMeeting() }
+        }
+    }
+
+    private var isEngineNotConnected: Bool {
+        if case .engineNotConnected = vm.state {
+            return true
+        }
+        return false
+    }
+
+    private var toolbarRecordingErrorPresented: Binding<Bool> {
+        Binding(
+            get: { toolbarRecordingError != nil },
+            set: { if !$0 { toolbarRecordingError = nil } }
+        )
+    }
+
+    private func startNewRecording() async {
+        guard !isStartingNewRecording else { return }
+        isStartingNewRecording = true
+        defer { isStartingNewRecording = false }
+
+        do {
+            toolbarRecordingError = nil
+            try await vm.startNewRecording(using: recordingController)
+        } catch {
+            AppViewModel.logFullError("recording.new", error)
+            toolbarRecordingError = "Couldn't start recording."
         }
     }
 
@@ -413,7 +487,13 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         VStack(spacing: 24) {
             // Show selected meeting detail if available
             if let meeting = vm.selectedMeeting {
-                MeetingDetailView(meeting: meeting, recordingController: recordingController)
+                MeetingDetailView(
+                    meeting: meeting,
+                    recordingController: recordingController,
+                    onRecordingStopped: { _ in
+                        try await vm.finishLiveRecording(meetingId: meeting.id)
+                    }
+                )
             } else {
                 VStack(spacing: 16) {
                     Text("Panops").font(.largeTitle)

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -13,6 +13,7 @@ final class AppViewModel: ObservableObject {
 
     @Published var state: State = .idle(audio: nil)
     @Published var selectedMeetingId: String?
+    @Published var activeRecordingMeetingId: String?
     @Published var meetings: [MeetingSummary] = []
     @Published var selectedMeeting: Meeting?
 
@@ -225,10 +226,19 @@ final class AppViewModel: ObservableObject {
         do {
             try await recordingController.start(meetingId: meetingId)
         } catch {
+            let recordingStartError = error
+            do {
+                // No recording was accepted, so remove the provisional row and
+                // meeting directory rather than leaving a bogus open meeting.
+                try await client.meetingDelete(id: meetingId)
+            } catch {
+                Self.logFullError("meeting.delete.cleanup", error)
+            }
             await refreshMeetings()
-            throw error
+            throw recordingStartError
         }
 
+        activeRecordingMeetingId = meetingId
         selectedMeetingId = meetingId
         selectedMeeting = nil
         state = .idle(audio: nil)
@@ -257,11 +267,21 @@ final class AppViewModel: ObservableObject {
     /// and detail so ended_at/duration_ms are visible immediately.
     func finishLiveRecording(meetingId: String) async throws {
         let stoppedMeeting = try await client.meetingStop(id: meetingId)
+        if activeRecordingMeetingId == meetingId {
+            activeRecordingMeetingId = nil
+        }
         await refreshMeetings()
         if selectedMeetingId == meetingId {
             selectedMeeting = stoppedMeeting
             state = .idle(audio: nil)
         }
+    }
+
+    /// Close whichever meeting owns the active recording, regardless of the
+    /// sidebar selection when the user presses Stop.
+    func finishActiveLiveRecording() async throws {
+        guard let meetingId = activeRecordingMeetingId else { return }
+        try await finishLiveRecording(meetingId: meetingId)
     }
 
     private func showSelectedMeetingAfterTerminalState() {
@@ -364,6 +384,7 @@ final class AppViewModel: ObservableObject {
         wsSubscriptionTask = nil
         Task { await eventStream.stop() }
         selectedMeetingId = nil
+        activeRecordingMeetingId = nil
         selectedMeeting = nil
         state = .idle(audio: nil)
     }
@@ -422,7 +443,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                         await startNewRecording()
                     }
                 }
-                .disabled(isStartingNewRecording || recordingController.isRecording || isEngineNotConnected)
+                .disabled(isStartingNewRecording || recordingController.isRecording || isEngineNotConnected || isGeneratingNotes)
                 .help("Create a meeting and start live recording")
             }
         }
@@ -441,6 +462,13 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
 
     private var isEngineNotConnected: Bool {
         if case .engineNotConnected = vm.state {
+            return true
+        }
+        return false
+    }
+
+    private var isGeneratingNotes: Bool {
+        if case .working = vm.state {
             return true
         }
         return false
@@ -491,7 +519,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                     meeting: meeting,
                     recordingController: recordingController,
                     onRecordingStopped: { _ in
-                        try await vm.finishLiveRecording(meetingId: meeting.id)
+                        try await vm.finishActiveLiveRecording()
                     }
                 )
             } else {

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -355,9 +355,9 @@ final class AppViewModel: ObservableObject {
     }
 }
 
-struct ContentView: View {
+struct ContentView<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var vm: AppViewModel
-    @StateObject private var recordingController = MockRecordingController()
+    @ObservedObject var recordingController: Controller
 
     var body: some View {
         NavigationSplitView {

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -586,6 +586,15 @@ actor IpcClient {
         )
     }
 
+    /// `ipc.meeting.stop(id)` — marks a meeting ended and returns the
+    /// updated Meeting row with `ended_at` / `duration_ms` populated.
+    func meetingStop(id: String) async throws -> Meeting {
+        return try await sendRequest(
+            method: "ipc.meeting.stop",
+            params: MeetingStopParams(id: id)
+        )
+    }
+
     /// `ipc.meeting.list` — fetches all meeting summaries.
     /// Slice 12: sidebar needs meeting list for navigation.
     func meetingList() async throws -> [MeetingSummary] {

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -595,6 +595,14 @@ actor IpcClient {
         )
     }
 
+    /// `ipc.meeting.delete(id)` — removes the meeting row and its directory.
+    func meetingDelete(id: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.meeting.delete",
+            params: MeetingDeleteParams(id: id)
+        )
+    }
+
     /// `ipc.meeting.list` — fetches all meeting summaries.
     /// Slice 12: sidebar needs meeting list for navigation.
     func meetingList() async throws -> [MeetingSummary] {
@@ -668,6 +676,39 @@ actor IpcClient {
         let envelope = JsonRpcRequest(id: id, method: method, param: params)
         let body = try JSONEncoder().encode(envelope)
         return try await sendRawRequest(body: body)
+    }
+
+    private func sendRawRequestVoid(
+        body: Data
+    ) async throws {
+        let request = Self.buildHttpRequest(body: body)
+        let conn = NWConnection(to: endpoint, using: .tcp)
+        try await Self.start(conn)
+        defer { conn.cancel() }
+        try await Self.send(conn, data: request)
+        let (status, responseBody) = try await Self.readHttpResponse(conn)
+        guard status == 200 else {
+            let bodyString = String(data: responseBody, encoding: .utf8) ?? ""
+            throw IpcClientError.httpError(status: status, body: bodyString)
+        }
+        let resp = try JSONDecoder().decode(JsonRpcVoidResponse.self, from: responseBody)
+        if let err = resp.error {
+            throw IpcClientError.rpcError(code: err.code, message: err.message)
+        }
+        guard resp.hasResult else {
+            throw IpcClientError.decode("response missing both result and error")
+        }
+    }
+
+    private func sendRequestVoid<P: Encodable>(
+        method: String,
+        params: P
+    ) async throws {
+        let id = nextId
+        nextId += 1
+        let envelope = JsonRpcRequest(id: id, method: method, param: params)
+        let body = try JSONEncoder().encode(envelope)
+        try await sendRawRequestVoid(body: body)
     }
 
     /// Send request for methods that take no parameters.

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -594,6 +594,36 @@ actor IpcClient {
         )
     }
 
+    /// `ipc.recording.start` — starts live capture for an existing meeting.
+    /// Returns the engine-issued recording session id used by
+    /// `ipc.recording.stop`.
+    func recordingStart(
+        meetingId: String,
+        audioSources: AudioSourcesWire = .systemAndMic,
+        screenshotIntervalMs: UInt64 = 500,
+        screenshotThreshold: Float = 0.15
+    ) async throws -> RecordingAccepted {
+        let params = RecordingStartParams(
+            meetingId: meetingId,
+            audioSources: audioSources,
+            screenshotIntervalMs: screenshotIntervalMs,
+            screenshotThreshold: screenshotThreshold
+        )
+        return try await sendRequest(
+            method: "ipc.recording.start",
+            params: params
+        )
+    }
+
+    /// `ipc.recording.stop` — stops a live capture session and returns
+    /// captured artifact paths.
+    func recordingStop(recordingId: String) async throws -> RecordingStopped {
+        return try await sendRequest(
+            method: "ipc.recording.stop",
+            params: RecordingStopParams(recordingId: recordingId)
+        )
+    }
+
     // MARK: - Private
 
     /// Core HTTP transport: sends encoded body, reads response, decodes result.

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Combine
+
+/// Live recording controller backed by the panops engine IPC.
+@MainActor
+final class LiveRecordingController: RecordingController, ObservableObject {
+    @Published private(set) var isRecording = false
+
+    private let ipcClient: IpcClient
+    private var recordingId: String?
+
+    init(ipcClient: IpcClient) {
+        self.ipcClient = ipcClient
+    }
+
+    func start(meetingId: String) async throws {
+        guard !isRecording else { return }
+
+        let accepted = try await ipcClient.recordingStart(
+            meetingId: meetingId,
+            audioSources: .systemAndMic,
+            screenshotIntervalMs: 500,
+            screenshotThreshold: 0.15
+        )
+        recordingId = accepted.recordingId
+        isRecording = true
+    }
+
+    func stop() async throws -> URL? {
+        guard let recordingId else { return nil }
+
+        let stopped = try await ipcClient.recordingStop(recordingId: recordingId)
+        self.recordingId = nil
+        isRecording = false
+
+        let audioPath = stopped.systemAudioPath ?? stopped.micAudioPath
+        return audioPath.map { URL(fileURLWithPath: $0) }
+    }
+}

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -1,39 +1,76 @@
 import Foundation
 import Combine
 
+protocol LiveRecordingIpcClient: Sendable {
+    func recordingStart(
+        meetingId: String,
+        audioSources: AudioSourcesWire,
+        screenshotIntervalMs: UInt64,
+        screenshotThreshold: Float
+    ) async throws -> RecordingAccepted
+
+    func recordingStop(recordingId: String) async throws -> RecordingStopped
+}
+
+extension IpcClient: LiveRecordingIpcClient {}
+
+enum RecordingPathValidationError: Error {
+    case unsafePath(String)
+}
+
 /// Live recording controller backed by the panops engine IPC.
 @MainActor
 final class LiveRecordingController: RecordingController, ObservableObject {
     @Published private(set) var isRecording = false
 
-    private let ipcClient: IpcClient
+    private let ipcClient: any LiveRecordingIpcClient
     private var recordingId: String?
 
-    init(ipcClient: IpcClient) {
+    init(ipcClient: any LiveRecordingIpcClient) {
         self.ipcClient = ipcClient
     }
 
     func start(meetingId: String) async throws {
         guard !isRecording else { return }
-
-        let accepted = try await ipcClient.recordingStart(
-            meetingId: meetingId,
-            audioSources: .systemAndMic,
-            screenshotIntervalMs: 500,
-            screenshotThreshold: 0.15
-        )
-        recordingId = accepted.recordingId
         isRecording = true
+        recordingId = nil
+
+        do {
+            let accepted = try await ipcClient.recordingStart(
+                meetingId: meetingId,
+                audioSources: .systemAndMic,
+                screenshotIntervalMs: 500,
+                screenshotThreshold: 0.15
+            )
+            recordingId = accepted.recordingId
+        } catch {
+            isRecording = false
+            recordingId = nil
+            throw error
+        }
     }
 
     func stop() async throws -> URL? {
-        guard let recordingId else { return nil }
+        guard let activeRecordingId = recordingId else { return nil }
+        defer {
+            recordingId = nil
+            isRecording = false
+        }
 
-        let stopped = try await ipcClient.recordingStop(recordingId: recordingId)
-        self.recordingId = nil
-        isRecording = false
+        let stopped = try await ipcClient.recordingStop(recordingId: activeRecordingId)
+        try validateArtifactPaths(stopped)
 
         let audioPath = stopped.systemAudioPath ?? stopped.micAudioPath
         return audioPath.map { URL(fileURLWithPath: $0) }
+    }
+
+    private func validateArtifactPaths(_ stopped: RecordingStopped) throws {
+        let paths = [stopped.systemAudioPath, stopped.micAudioPath].compactMap { $0 }
+            + stopped.screenshotPaths
+        for path in paths {
+            guard PathValidator.isUnderPanopsDataDir(path) else {
+                throw RecordingPathValidationError.unsafePath(path)
+            }
+        }
     }
 }

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -52,12 +52,16 @@ final class LiveRecordingController: RecordingController, ObservableObject {
 
     func stop() async throws -> URL? {
         guard let activeRecordingId = recordingId else { return nil }
-        defer {
-            recordingId = nil
-            isRecording = false
-        }
 
+        // Clear state only AFTER the engine confirms the stop. If
+        // `recordingStop` throws (transient/engine error), keep recordingId +
+        // isRecording so the user can retry Stop instead of orphaning the
+        // engine-side recording (the error is surfaced by the caller). On
+        // success we clear even if path validation then fails — the recording
+        // did stop.
         let stopped = try await ipcClient.recordingStop(recordingId: activeRecordingId)
+        recordingId = nil
+        isRecording = false
         try validateArtifactPaths(stopped)
 
         let audioPath = stopped.systemAudioPath ?? stopped.micAudioPath

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -237,6 +237,11 @@ struct MeetingGetParams: Encodable {
     let id: String
 }
 
+/// Outgoing params for `ipc.meeting.stop`.
+struct MeetingStopParams: Encodable {
+    let id: String
+}
+
 /// Response from `ipc.meeting.get`. Mirrors `panops-protocol::Meeting`.
 /// `dir_path` is where notes.md eventually lands; slice 09 polls
 /// `<dirPath>/notes.md` on disk to detect completion (the IPC's

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -96,6 +96,61 @@ enum IpcEvent: Decodable {
     }
 }
 
+/// Audio source selection for `ipc.recording.start`.
+enum AudioSourcesWire: String, Codable {
+    case systemOnly = "system_only"
+    case micOnly = "mic_only"
+    case systemAndMic = "system_and_mic"
+}
+
+/// Outgoing params for `ipc.recording.start`.
+struct RecordingStartParams: Encodable {
+    let meetingId: String
+    let audioSources: AudioSourcesWire
+    let screenshotIntervalMs: UInt64
+    let screenshotThreshold: Float
+
+    enum CodingKeys: String, CodingKey {
+        case meetingId = "meeting_id"
+        case audioSources = "audio_sources"
+        case screenshotIntervalMs = "screenshot_interval_ms"
+        case screenshotThreshold = "screenshot_threshold"
+    }
+}
+
+/// Synchronous response from `ipc.recording.start`.
+struct RecordingAccepted: Decodable {
+    let recordingId: String
+
+    enum CodingKeys: String, CodingKey {
+        case recordingId = "recording_id"
+    }
+}
+
+/// Outgoing params for `ipc.recording.stop`.
+struct RecordingStopParams: Encodable {
+    let recordingId: String
+
+    enum CodingKeys: String, CodingKey {
+        case recordingId = "recording_id"
+    }
+}
+
+/// Synchronous response from `ipc.recording.stop`.
+struct RecordingStopped: Decodable {
+    let systemAudioPath: String?
+    let micAudioPath: String?
+    let screenshotPaths: [String]
+    let durationMs: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case systemAudioPath = "system_audio_path"
+        case micAudioPath = "mic_audio_path"
+        case screenshotPaths = "screenshot_paths"
+        case durationMs = "duration_ms"
+    }
+}
+
 /// Minimal JSON-RPC 2.0 envelopes (request and response).
 /// jsonrpsee uses positional params: each method takes exactly one
 /// argument, wrapped in a 1-element array on the wire.

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -189,6 +189,28 @@ struct JsonRpcResponse<R: Decodable>: Decodable {
     let error: JsonRpcError?
 }
 
+struct JsonRpcVoidResponse: Decodable {
+    let jsonrpc: String
+    let id: UInt64
+    let hasResult: Bool
+    let error: JsonRpcError?
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case result
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decode(UInt64.self, forKey: .id)
+        hasResult = container.contains(.result)
+        error = try container.decodeIfPresent(JsonRpcError.self, forKey: .error)
+    }
+}
+
 struct JsonRpcError: Decodable {
     let code: Int
     let message: String
@@ -239,6 +261,11 @@ struct MeetingGetParams: Encodable {
 
 /// Outgoing params for `ipc.meeting.stop`.
 struct MeetingStopParams: Encodable {
+    let id: String
+}
+
+/// Outgoing params for `ipc.meeting.delete`.
+struct MeetingDeleteParams: Encodable {
     let id: String
 }
 

--- a/apps/Panops/Sources/Panops/PanopsApp.swift
+++ b/apps/Panops/Sources/Panops/PanopsApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct PanopsApp: App {
     @StateObject private var viewModel: AppViewModel
+    @StateObject private var recordingController: LiveRecordingController
     @State private var engine: EngineProcess?
     @State private var startupError: String?
     @State private var willTerminateObserver: NSObjectProtocol?
@@ -17,11 +18,14 @@ struct PanopsApp: App {
             .appendingPathComponent("Library/Application Support/panops/engine.sock")
         let client = IpcClient(socketPath: socketPath)
         self._viewModel = StateObject(wrappedValue: AppViewModel(client: client))
+        self._recordingController = StateObject(
+            wrappedValue: LiveRecordingController(ipcClient: client)
+        )
     }
 
     var body: some Scene {
         WindowGroup("Panops") {
-            ContentView(vm: viewModel)
+            ContentView(vm: viewModel, recordingController: recordingController)
                 .task { await bootstrap() }
                 .alert("Engine failed to start", isPresented: errorPresented) {
                     Button("Quit", role: .destructive) { NSApp.terminate(nil) }

--- a/apps/Panops/Sources/Panops/RecordingController.swift
+++ b/apps/Panops/Sources/Panops/RecordingController.swift
@@ -1,15 +1,17 @@
 import Foundation
+import Combine
 
-/// Protocol for recording control. Slice 12 provides MockRecordingController.
-/// Slice 11 will provide LiveRecordingController that calls IPC methods.
+/// Protocol for recording control.
+@MainActor
 protocol RecordingController: AnyObject {
     var isRecording: Bool { get }
     func start(meetingId: String) async throws
     func stop() async throws -> URL?  // Returns audio file path
 }
 
-/// Mock implementation for Slice 12. Placeholder until Slice 11.
-/// Toggles isRecording but shows alert indicating recording not implemented.
+/// Mock implementation for previews/tests.
+/// Toggles isRecording and can still surface the old placeholder alert.
+@MainActor
 final class MockRecordingController: RecordingController, ObservableObject {
     @Published private(set) var isRecording = false
     @Published var showPlaceholderAlert = false

--- a/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
@@ -6,14 +6,20 @@ import SwiftUI
 struct MeetingDetailView<Controller: RecordingController & ObservableObject>: View {
     let meeting: Meeting
     let recordingController: Controller?
+    let onRecordingStopped: (URL?) async throws -> Void
     @State private var transcript: Transcript?
     @State private var notesContent: String?
     @State private var screenshots: [URL]?
     @State private var isLoading = true
 
-    init(meeting: Meeting, recordingController: Controller? = nil) {
+    init(
+        meeting: Meeting,
+        recordingController: Controller? = nil,
+        onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
+    ) {
         self.meeting = meeting
         self.recordingController = recordingController
+        self.onRecordingStopped = onRecordingStopped
     }
 
     var body: some View {
@@ -23,7 +29,11 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
             Divider()
             // Record bar (if controller provided)
             if let controller = recordingController {
-                RecordBar(controller: controller, meetingId: meeting.id)
+                RecordBar(
+                    controller: controller,
+                    meetingId: meeting.id,
+                    onRecordingStopped: onRecordingStopped
+                )
                 Divider()
             }
             // Content sections
@@ -52,7 +62,11 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
                 }
             }
         }
-        .task(id: meeting.id) { await loadMeetingData() }
+        .task(id: loadToken) { await loadMeetingData() }
+    }
+
+    private var loadToken: String {
+        "\(meeting.id)|\(meeting.endedAt ?? "")|\(meeting.durationMs ?? 0)"
     }
 
     private var headerView: some View {

--- a/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
@@ -3,15 +3,15 @@ import SwiftUI
 /// Container view for a selected meeting's content.
 /// Reads transcript.json, notes.md, and enumerates screenshots/ directory.
 /// Missing files → placeholders (expected when Slice 11 data doesn't exist).
-struct MeetingDetailView: View {
+struct MeetingDetailView<Controller: RecordingController & ObservableObject>: View {
     let meeting: Meeting
-    let recordingController: MockRecordingController?
+    let recordingController: Controller?
     @State private var transcript: Transcript?
     @State private var notesContent: String?
     @State private var screenshots: [URL]?
     @State private var isLoading = true
 
-    init(meeting: Meeting, recordingController: MockRecordingController? = nil) {
+    init(meeting: Meeting, recordingController: Controller? = nil) {
         self.meeting = meeting
         self.recordingController = recordingController
     }
@@ -23,7 +23,7 @@ struct MeetingDetailView: View {
             Divider()
             // Record bar (if controller provided)
             if let controller = recordingController {
-                RecordBar(controller: controller)
+                RecordBar(controller: controller, meetingId: meeting.id)
                 Divider()
             }
             // Content sections

--- a/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct MeetingDetailView<Controller: RecordingController & ObservableObject>: View {
     let meeting: Meeting
     let recordingController: Controller?
+    let onRecordingStarted: (String) async throws -> Void
     let onRecordingStopped: (URL?) async throws -> Void
     @State private var transcript: Transcript?
     @State private var notesContent: String?
@@ -15,10 +16,12 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
     init(
         meeting: Meeting,
         recordingController: Controller? = nil,
+        onRecordingStarted: @escaping (String) async throws -> Void = { _ in },
         onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
     ) {
         self.meeting = meeting
         self.recordingController = recordingController
+        self.onRecordingStarted = onRecordingStarted
         self.onRecordingStopped = onRecordingStopped
     }
 
@@ -32,6 +35,7 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
                 RecordBar(
                     controller: controller,
                     meetingId: meeting.id,
+                    onRecordingStarted: onRecordingStarted,
                     onRecordingStopped: onRecordingStopped
                 )
                 Divider()

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -4,9 +4,20 @@ import SwiftUI
 struct RecordBar<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var controller: Controller
     let meetingId: String
+    let onRecordingStopped: (URL?) async throws -> Void
     @State private var isBusy = false
     @State private var errorMessage: String?
     @State private var lastAudioURL: URL?
+
+    init(
+        controller: Controller,
+        meetingId: String,
+        onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
+    ) {
+        self._controller = ObservedObject(wrappedValue: controller)
+        self.meetingId = meetingId
+        self.onRecordingStopped = onRecordingStopped
+    }
 
     var body: some View {
         HStack(spacing: 16) {
@@ -62,20 +73,28 @@ struct RecordBar<Controller: RecordingController & ObservableObject>: View {
     private func toggleRecording() async {
         guard !isBusy else { return }
         isBusy = true
+        let wasRecording = controller.isRecording
         defer { isBusy = false }
 
         do {
-            if controller.isRecording {
-                lastAudioURL = try await controller.stop()
+            if wasRecording {
+                let audioURL = try await controller.stop()
+                if let audioURL {
+                    guard PathValidator.isUnderPanopsDataDir(audioURL.path) else {
+                        throw RecordingPathValidationError.unsafePath(audioURL.path)
+                    }
+                    lastAudioURL = audioURL
+                } else {
+                    lastAudioURL = nil
+                }
+                try await onRecordingStopped(audioURL)
             } else {
                 lastAudioURL = nil
                 try await controller.start(meetingId: meetingId)
             }
-        } catch let IpcClientError.rpcError(_, message) {
-            errorMessage = message
         } catch {
-            AppViewModel.logFullError("recording.toggle", error)
-            errorMessage = "Could not reach the engine."
+            AppViewModel.logFullError(wasRecording ? "recording.stop" : "recording.start", error)
+            errorMessage = wasRecording ? "Couldn't stop recording." : "Couldn't start recording."
         }
     }
 }

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct RecordBar<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var controller: Controller
     let meetingId: String
+    let onRecordingStarted: (String) async throws -> Void
     let onRecordingStopped: (URL?) async throws -> Void
     @State private var isBusy = false
     @State private var errorMessage: String?
@@ -12,10 +13,12 @@ struct RecordBar<Controller: RecordingController & ObservableObject>: View {
     init(
         controller: Controller,
         meetingId: String,
+        onRecordingStarted: @escaping (String) async throws -> Void = { _ in },
         onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
     ) {
         self._controller = ObservedObject(wrappedValue: controller)
         self.meetingId = meetingId
+        self.onRecordingStarted = onRecordingStarted
         self.onRecordingStopped = onRecordingStopped
     }
 
@@ -78,19 +81,16 @@ struct RecordBar<Controller: RecordingController & ObservableObject>: View {
 
         do {
             if wasRecording {
+                // The controller already validates returned artifact paths
+                // (LiveRecordingController.validateArtifactPaths), so no
+                // duplicate PathValidator check here.
                 let audioURL = try await controller.stop()
-                if let audioURL {
-                    guard PathValidator.isUnderPanopsDataDir(audioURL.path) else {
-                        throw RecordingPathValidationError.unsafePath(audioURL.path)
-                    }
-                    lastAudioURL = audioURL
-                } else {
-                    lastAudioURL = nil
-                }
+                lastAudioURL = audioURL
                 try await onRecordingStopped(audioURL)
             } else {
                 lastAudioURL = nil
                 try await controller.start(meetingId: meetingId)
+                try await onRecordingStarted(meetingId)
             }
         } catch {
             AppViewModel.logFullError(wasRecording ? "recording.stop" : "recording.start", error)

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -1,39 +1,81 @@
 import SwiftUI
 
-/// Record/Stop control bar. DISABLED this slice with placeholder text.
-/// Injects RecordingController for future live capture.
-struct RecordBar: View {
-    @ObservedObject var controller: MockRecordingController
+/// Record/Stop control bar backed by an injected RecordingController.
+struct RecordBar<Controller: RecordingController & ObservableObject>: View {
+    @ObservedObject var controller: Controller
+    let meetingId: String
+    @State private var isBusy = false
+    @State private var errorMessage: String?
+    @State private var lastAudioURL: URL?
 
     var body: some View {
         HStack(spacing: 16) {
             Button(action: {
-                Task {
-                    // Disabled this slice - show placeholder
-                    controller.showPlaceholderAlert = true
+                Task { @MainActor in
+                    await toggleRecording()
                 }
             }) {
                 HStack(spacing: 4) {
-                    Image(systemName: "record.circle")
-                        .foregroundStyle(.red)
-                    Text("Record")
+                    Image(systemName: controller.isRecording ? "stop.circle" : "record.circle")
+                        .foregroundStyle(controller.isRecording ? Color.primary : Color.red)
+                    Text(controller.isRecording ? "Stop" : "Record")
                 }
             }
-            .disabled(true)  // Disabled per spec
-            .help("Live capture coming soon (Anchor B)")
+            .disabled(isBusy)
+            .help(controller.isRecording ? "Stop recording" : "Start recording")
 
             Spacer()
 
-            Text("Recording requires live capture (Anchor B)")
+            Text(statusText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
         .padding()
         .background(Color.secondary.opacity(0.05))
-        .alert("Recording not available", isPresented: $controller.showPlaceholderAlert) {
+        .alert("Recording error", isPresented: errorPresented) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Live capture is coming in a future update. This slice focuses on the UI framework.")
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var statusText: String {
+        if isBusy {
+            return controller.isRecording ? "Stopping recording…" : "Starting recording…"
+        }
+        if controller.isRecording {
+            return "Recording audio and screenshots"
+        }
+        if let lastAudioURL {
+            return "Last audio: \(lastAudioURL.lastPathComponent)"
+        }
+        return "Ready to record"
+    }
+
+    private var errorPresented: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private func toggleRecording() async {
+        guard !isBusy else { return }
+        isBusy = true
+        defer { isBusy = false }
+
+        do {
+            if controller.isRecording {
+                lastAudioURL = try await controller.stop()
+            } else {
+                lastAudioURL = nil
+                try await controller.start(meetingId: meetingId)
+            }
+        } catch let IpcClientError.rpcError(_, message) {
+            errorMessage = message
+        } catch {
+            AppViewModel.logFullError("recording.toggle", error)
+            errorMessage = "Could not reach the engine."
         }
     }
 }

--- a/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
+++ b/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("LiveRecordingController")
+@MainActor
+struct LiveRecordingControllerTests {
+    @Test("optimistic start prevents a double-start while IPC is in flight")
+    func optimisticStartPreventsDoubleStart() async throws {
+        let fake = FakeLiveRecordingIpcClient(startDelayNanoseconds: 50_000_000)
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        let firstStart = Task { @MainActor in
+            try await controller.start(meetingId: "meeting-1")
+        }
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        #expect(controller.isRecording)
+        try await controller.start(meetingId: "meeting-1")
+        try await firstStart.value
+
+        let startCalls = await fake.startCallCount()
+        #expect(startCalls == 1)
+        #expect(controller.isRecording)
+    }
+
+    @Test("start failure resets recording state")
+    func startFailureResetsRecordingState() async throws {
+        let fake = FakeLiveRecordingIpcClient(startError: TestRecordingError.startFailed)
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        do {
+            try await controller.start(meetingId: "meeting-1")
+            Issue.record("start should throw")
+        } catch {
+            #expect(controller.isRecording == false)
+            let startCalls = await fake.startCallCount()
+            #expect(startCalls == 1)
+        }
+    }
+
+    @Test("stop failure resets recording state")
+    func stopFailureResetsRecordingState() async throws {
+        let fake = FakeLiveRecordingIpcClient(stopError: TestRecordingError.stopFailed)
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        try await controller.start(meetingId: "meeting-1")
+        #expect(controller.isRecording)
+
+        do {
+            _ = try await controller.stop()
+            Issue.record("stop should throw")
+        } catch {
+            #expect(controller.isRecording == false)
+            let stopCalls = await fake.stopCallCount()
+            #expect(stopCalls == 1)
+        }
+
+        let secondStop = try await controller.stop()
+        let stopCalls = await fake.stopCallCount()
+        #expect(secondStop == nil)
+        #expect(stopCalls == 1)
+    }
+}
+
+private enum TestRecordingError: Error {
+    case startFailed
+    case stopFailed
+}
+
+private actor FakeLiveRecordingIpcClient: LiveRecordingIpcClient {
+    private var startCalls = 0
+    private var stopCalls = 0
+    private let startDelayNanoseconds: UInt64
+    private let startError: (any Error)?
+    private let stopError: (any Error)?
+    private let accepted: RecordingAccepted
+    private let stopped: RecordingStopped
+
+    init(
+        startDelayNanoseconds: UInt64 = 0,
+        startError: (any Error)? = nil,
+        stopError: (any Error)? = nil,
+        accepted: RecordingAccepted = RecordingAccepted(recordingId: "recording-1"),
+        stopped: RecordingStopped = RecordingStopped(
+            systemAudioPath: (PathValidator.panopsDataRoot as NSString)
+                .appendingPathComponent("meetings/meeting-1/system.wav"),
+            micAudioPath: nil,
+            screenshotPaths: [],
+            durationMs: 1_000
+        )
+    ) {
+        self.startDelayNanoseconds = startDelayNanoseconds
+        self.startError = startError
+        self.stopError = stopError
+        self.accepted = accepted
+        self.stopped = stopped
+    }
+
+    func recordingStart(
+        meetingId: String,
+        audioSources: AudioSourcesWire,
+        screenshotIntervalMs: UInt64,
+        screenshotThreshold: Float
+    ) async throws -> RecordingAccepted {
+        startCalls += 1
+        if startDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: startDelayNanoseconds)
+        }
+        if let startError {
+            throw startError
+        }
+        return accepted
+    }
+
+    func recordingStop(recordingId: String) async throws -> RecordingStopped {
+        stopCalls += 1
+        if let stopError {
+            throw stopError
+        }
+        return stopped
+    }
+
+    func startCallCount() -> Int {
+        startCalls
+    }
+
+    func stopCallCount() -> Int {
+        stopCalls
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
+++ b/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
@@ -39,8 +39,8 @@ struct LiveRecordingControllerTests {
         }
     }
 
-    @Test("stop failure resets recording state")
-    func stopFailureResetsRecordingState() async throws {
+    @Test("stop failure keeps recording state for retry")
+    func stopFailureKeepsRecordingStateForRetry() async throws {
         let fake = FakeLiveRecordingIpcClient(stopError: TestRecordingError.stopFailed)
         let controller = LiveRecordingController(ipcClient: fake)
 
@@ -51,15 +51,22 @@ struct LiveRecordingControllerTests {
             _ = try await controller.stop()
             Issue.record("stop should throw")
         } catch {
-            #expect(controller.isRecording == false)
+            // State is kept on IPC failure so the user can retry Stop rather
+            // than orphaning the engine-side recording.
+            #expect(controller.isRecording == true)
             let stopCalls = await fake.stopCallCount()
             #expect(stopCalls == 1)
         }
 
-        let secondStop = try await controller.stop()
-        let stopCalls = await fake.stopCallCount()
-        #expect(secondStop == nil)
-        #expect(stopCalls == 1)
+        // Preserved state means a retry actually re-attempts the stop.
+        do {
+            _ = try await controller.stop()
+            Issue.record("retry stop should throw again")
+        } catch {
+            let stopCalls = await fake.stopCallCount()
+            #expect(stopCalls == 2)
+        }
+        #expect(controller.isRecording == true)
     }
 }
 


### PR DESCRIPTION
Completes the WS-2 Mac UI loop now that slice 11's capture backend is on main.

## What this ships
- **`LiveRecordingController`** (`@MainActor`, `ObservableObject`): implements the `RecordingController` protocol by calling the engine's `ipc.recording.start` / `ipc.recording.stop` JSON-RPC methods (the placeholder `MockRecordingController` reserved this since slice 12). Guards double start/stop; defaults to `system_and_mic` / 500 ms / 0.15 (matching the capture sidecar); returns the system (else mic) audio path as a `URL`.
- **`IpcClient`**: `recordingStart`/`recordingStop` via the existing `sendRequest` transport, `ipc.recording.*` names matching the engine's `namespace = "ipc"`.
- **Wire DTOs** (`Models.swift`): `RecordingStartParams` / `RecordingAccepted` / `RecordingStopParams` / `RecordingStopped` with snake_case `CodingKeys` matching `panops-protocol`.
- **`PanopsApp` / `ContentView` / `MeetingDetailView` / `RecordBar`**: inject the live controller; Record/Stop UI enabled. `MockRecordingController` kept for previews/tests.

Tracking #138. `swift build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)