### PR TITLE
Live notes-generation progress (#80) + no-progress timeout watchdog

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -16,12 +16,14 @@ final class AppViewModel: ObservableObject {
     @Published var activeRecordingMeetingId: String?
     @Published var meetings: [MeetingSummary] = []
     @Published var selectedMeeting: Meeting?
+    @Published var notesProgress: JobProgressEvent?
 
     private let client: IpcClient
     private var pollingTask: Task<Void, Never>?
     private let eventStream: EventStreamActor
     private var wsSubscriptionTask: Task<Void, Never>?
-    nonisolated private static let pollingDeadlineSeconds: TimeInterval = 5 * 60
+    private var notesLastProgressAt: Date?
+    nonisolated private static let progressSilenceTimeoutSeconds: TimeInterval = 5 * 60
     nonisolated private static let wsSetupTimeoutNanoseconds: UInt64 = 3_000_000_000
 
     private enum WsSetupResult: Sendable {
@@ -75,6 +77,9 @@ final class AppViewModel: ObservableObject {
     func generate() async {
         guard case .idle(let audio?) = state else { return }
         do {
+            notesProgress = nil
+            notesLastProgressAt = Date()
+
             // Ensure WebSocket subscription is active (lazy)
             // If WebSocket fails, fall back to filesystem polling (fix #5)
             let wsOk = await ensureWsSubscription()
@@ -97,12 +102,15 @@ final class AppViewModel: ObservableObject {
                                 notesPath: result.primaryFile
                             )
                         case .jobError(_, let payload):
+                            self?.recordNotesProgressHeartbeat()
                             self?.finishGenerationError(
                                 meetingId: meetingId,
                                 jobId: jobId,
                                 kind: payload.kind,
                                 message: payload.message
                             )
+                        case .jobProgress(let progress):
+                            self?.updateNotesProgress(progress)
                         case .unknown:
                             break
                         }
@@ -113,9 +121,13 @@ final class AppViewModel: ObservableObject {
             // cancelled by the terminal WebSocket callback when one arrives.
             startPolling(meetingId: meetingId, jobId: wsOk ? jobId : nil)
         } catch let IpcClientError.rpcError(_, message) {
+            notesProgress = nil
+            notesLastProgressAt = nil
             state = .error(kind: "rpc_error", message: message)
         } catch {
             Self.logFullError("notes.generate", error)
+            notesProgress = nil
+            notesLastProgressAt = nil
             state = .error(kind: "internal", message: "Could not reach the engine.")
         }
     }
@@ -301,29 +313,50 @@ final class AppViewModel: ObservableObject {
 
     private func finishGenerationDone(meetingId: String, jobId: String? = nil, notesPath: String) {
         guard case .working(let currentMeetingId, _) = state, currentMeetingId == meetingId else { return }
+        recordNotesProgressHeartbeat()
         pollingTask?.cancel()
         pollingTask = nil
         if let jobId {
             Task { await eventStream.unregisterCallback(jobId: jobId) }
         }
+        notesProgress = nil
+        notesLastProgressAt = nil
         state = .done(notesPath: notesPath)
         Task { await refreshMeetings() }
     }
 
     private func finishGenerationError(meetingId: String, jobId: String? = nil, kind: String, message: String) {
         guard case .working(let currentMeetingId, _) = state, currentMeetingId == meetingId else { return }
+        recordNotesProgressHeartbeat()
         pollingTask?.cancel()
         pollingTask = nil
         if let jobId {
             Task { await eventStream.unregisterCallback(jobId: jobId) }
         }
+        notesProgress = nil
+        notesLastProgressAt = nil
         state = .error(kind: kind, message: message)
+    }
+
+    private func updateNotesProgress(_ progress: JobProgressEvent) {
+        notesProgress = progress
+        recordNotesProgressHeartbeat()
+    }
+
+    private func recordNotesProgressHeartbeat() {
+        notesLastProgressAt = Date()
+    }
+
+    private func notesProgressStalledMessage() -> String {
+        let minutes = Int(Self.progressSilenceTimeoutSeconds / 60)
+        return "notes.generate stalled: no progress for \(minutes) minutes"
     }
 
     private func startPolling(meetingId: String, jobId: String? = nil) {
         // Fallback polling if WebSocket isn't available, and safety-net polling
         // if WebSocket disconnects before a terminal event is delivered.
         pollingTask?.cancel()
+        notesLastProgressAt = Date()
         let client = self.client
         pollingTask = Task.detached { [weak self] in
             let mainActorRef = self
@@ -343,8 +376,7 @@ final class AppViewModel: ObservableObject {
                 return
             }
             let notesPath = (meeting.dirPath as NSString).appendingPathComponent("notes.md")
-            let deadline = Date().addingTimeInterval(Self.pollingDeadlineSeconds)
-            while !Task.isCancelled, Date() < deadline {
+            while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 if FileManager.default.fileExists(atPath: notesPath) {
                     await MainActor.run {
@@ -356,14 +388,22 @@ final class AppViewModel: ObservableObject {
                     }
                     return
                 }
-            }
-            await MainActor.run {
-                mainActorRef?.finishGenerationError(
-                    meetingId: meetingId,
-                    jobId: jobId,
-                    kind: "timeout",
-                    message: "notes.generate did not complete within \(Int(Self.pollingDeadlineSeconds / 60)) minutes"
-                )
+                let hasStalled = await MainActor.run { () -> Bool in
+                    let lastProgressAt = mainActorRef?.notesLastProgressAt ?? Date()
+                    return Date().timeIntervalSince(lastProgressAt) >= Self.progressSilenceTimeoutSeconds
+                }
+                if hasStalled {
+                    await MainActor.run {
+                        mainActorRef?.finishGenerationError(
+                            meetingId: meetingId,
+                            jobId: jobId,
+                            kind: "timeout",
+                            message: mainActorRef?.notesProgressStalledMessage()
+                                ?? "notes.generate stalled: no progress"
+                        )
+                    }
+                    return
+                }
             }
         }
     }
@@ -386,6 +426,8 @@ final class AppViewModel: ObservableObject {
         selectedMeetingId = nil
         activeRecordingMeetingId = nil
         selectedMeeting = nil
+        notesProgress = nil
+        notesLastProgressAt = nil
         state = .idle(audio: nil)
     }
 
@@ -561,15 +603,52 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
 
     @ViewBuilder
     private func workingView(audioName: String) -> some View {
+        let progress = vm.notesProgress
         VStack(spacing: 16) {
-            HStack(spacing: 12) {
-                ProgressView()
-                Text("Generating notes…").font(.headline)
+            VStack(spacing: 8) {
+                if let progress,
+                   let current = progress.current,
+                   let total = progress.total,
+                   total > 0 {
+                    ProgressView(value: max(0.0, min(Double(current) / Double(total), 1.0)))
+                        .frame(maxWidth: 280)
+                } else {
+                    ProgressView()
+                }
+
+                Text(notesProgressLabel(progress)).font(.headline)
+                if let message = progress?.message, !message.isEmpty {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
             }
             Text(audioName).foregroundStyle(.secondary)
             Spacer()
         }
         .padding()
+    }
+
+    private func notesProgressLabel(_ progress: JobProgressEvent?) -> String {
+        guard let progress else { return "Generating notes…" }
+
+        switch progress.stage {
+        case "loading":
+            return "Loading audio…"
+        case "transcribing":
+            if let current = progress.current, let total = progress.total {
+                return "Transcribing \(current)/\(total)…"
+            }
+            return "Transcribing…"
+        case "diarizing":
+            return "Identifying speakers…"
+        case "generating_notes":
+            return "Writing notes…"
+        case "exporting":
+            return "Saving…"
+        default:
+            return "Generating notes…"
+        }
     }
 
     @ViewBuilder

--- a/apps/Panops/Sources/Panops/EventStreamActor.swift
+++ b/apps/Panops/Sources/Panops/EventStreamActor.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Central dispatcher for IPC events from WebSocket subscription.
-/// Routes `job.done`/`job.error` to registered callbacks keyed by `job_id`.
+/// Routes `job.progress`/`job.done`/`job.error` to registered callbacks keyed by `job_id`.
 /// Buffers recent events to prevent lost-wakeup race: if a job.done/job.error
 /// arrives before registerCallback is called, the event is replayed on register.
 /// Slice 12 implementation per spec D7.
@@ -11,7 +11,7 @@ actor EventStreamActor {
     /// the spawned Task outlives `stop()` and keeps routing until the stream ends.
     private var loopTask: Task<Void, Never>?
     private var callbacks: [String: @Sendable (IpcEvent) -> Void] = [:]
-    /// Buffer of recent job.done/job.error events, stored in insertion order.
+    /// Buffer of recent terminal job.done/job.error events, stored in insertion order.
     /// Bounded to prevent unbounded growth if callbacks are never registered.
     private var eventBuffer: [(jobId: String, event: IpcEvent)] = []
     private static let maxBufferSize = 64
@@ -30,8 +30,9 @@ actor EventStreamActor {
     }
 
     /// Register a callback for a specific job_id.
-    /// The callback is invoked when `job.done` or `job.error` arrives for that job.
-    /// If the event was already received (lost-wakeup race), replay immediately.
+    /// The callback is invoked when `job.progress`, `job.done`, or `job.error`
+    /// arrives for that job. If a terminal event was already received
+    /// (lost-wakeup race), replay immediately.
     func registerCallback(jobId: String, handler: @escaping @Sendable (IpcEvent) -> Void) {
         // Replay buffered event if already received (lost-wakeup race fix)
         if let idx = eventBuffer.firstIndex(where: { $0.jobId == jobId }) {
@@ -59,7 +60,8 @@ actor EventStreamActor {
     }
 
     /// Route an event to its registered callback (if any).
-    /// If no callback is registered yet, buffer the event for replay.
+    /// If no callback is registered yet, buffer terminal events for replay.
+    /// Progress events are non-terminal and are only delivered live.
     private func route(event: IpcEvent) {
         switch event {
         case .jobDone(let jobId, _), .jobError(let jobId, _):
@@ -75,6 +77,8 @@ actor EventStreamActor {
                 }
                 eventBuffer.append((jobId: jobId, event: event))
             }
+        case .jobProgress(let progress):
+            callbacks[progress.jobId]?(event)
         case .unknown:
             // Ignore unknown events
             break

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -65,10 +65,28 @@ struct JobErrorPayload: Decodable {
     }
 }
 
+/// `job.progress` event payload.
+struct JobProgressEvent: Decodable, Equatable {
+    let jobId: String
+    let stage: String
+    let current: Int?
+    let total: Int?
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case jobId = "job_id"
+        case stage
+        case current
+        case total
+        case message
+    }
+}
+
 /// Tagged union over the event types we consume.
 enum IpcEvent: Decodable {
     case jobDone(jobId: String, result: JobDoneResult)
     case jobError(jobId: String, error: JobErrorPayload)
+    case jobProgress(JobProgressEvent)
     case unknown(type: String)
 
     private enum CodingKeys: String, CodingKey {
@@ -90,6 +108,8 @@ enum IpcEvent: Decodable {
             let jobId = try c.decode(String.self, forKey: .jobId)
             let error = try c.decode(JobErrorPayload.self, forKey: .error)
             self = .jobError(jobId: jobId, error: error)
+        case "job.progress":
+            self = .jobProgress(try JobProgressEvent(from: decoder))
         default:
             self = .unknown(type: type)
         }

--- a/apps/Panops/Tests/PanopsTests/EventStreamTests.swift
+++ b/apps/Panops/Tests/PanopsTests/EventStreamTests.swift
@@ -62,6 +62,47 @@ struct EventStreamTests {
         #expect(jobId == "error-job-456")
     }
 
+    @Test("EventStreamActor_routes_jobProgress_then_terminal_done_to_callback")
+    func routesJobProgressThenTerminalDoneToCallback() async throws {
+        let actor = EventStreamActor()
+        let state = TestState<[IpcEvent]>()
+        state.value = []
+
+        await actor.registerCallback(jobId: "progress-job-789", handler: { event in
+            state.value?.append(event)
+        })
+
+        await actor.testRoute(event: .jobProgress(JobProgressEvent(
+            jobId: "progress-job-789",
+            stage: "transcribing",
+            current: 1,
+            total: 3,
+            message: "mic track"
+        )))
+        await actor.testRoute(event: .jobDone(
+            jobId: "progress-job-789",
+            result: JobDoneResult(
+                primaryFile: "/tmp/notes.md",
+                assets: [],
+                meetingId: "meeting-1"
+            )
+        ))
+
+        #expect(state.value?.count == 2, "progress should not unregister terminal callback")
+        guard case .jobProgress(let progress) = state.value?.first else {
+            Issue.record("expected first event to be .jobProgress, got \(String(describing: state.value?.first))")
+            return
+        }
+        #expect(progress.jobId == "progress-job-789")
+        #expect(progress.stage == "transcribing")
+
+        guard case .jobDone(let jobId, _) = state.value?.last else {
+            Issue.record("expected last event to be .jobDone, got \(String(describing: state.value?.last))")
+            return
+        }
+        #expect(jobId == "progress-job-789")
+    }
+
     @Test("EventStreamActor_ignores_unknown_events")
     func ignoresUnknownEvents() async throws {
         let actor = EventStreamActor()

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -63,6 +63,82 @@ struct IpcClientCodecTests {
         #expect(result.meetingId == "m1")
     }
 
+    @Test("job.progress event decodes")
+    func jobProgressEvent_decodes() throws {
+        let json = #"""
+        {
+          "type": "job.progress",
+          "job_id": "abc-123",
+          "stage": "transcribing",
+          "current": 1,
+          "total": 3,
+          "message": "mic track"
+        }
+        """#
+        let event = try decoder.decode(IpcEvent.self, from: json.data(using: .utf8)!)
+        guard case .jobProgress(let progress) = event else {
+            Issue.record("expected .jobProgress, got \(event)")
+            return
+        }
+        #expect(progress == JobProgressEvent(
+            jobId: "abc-123",
+            stage: "transcribing",
+            current: 1,
+            total: 3,
+            message: "mic track"
+        ))
+    }
+
+    @Test("job.progress event decodes with optional fields omitted")
+    func jobProgressEvent_decodesWithOptionalFieldsOmitted() throws {
+        let json = #"""
+        {
+          "type": "job.progress",
+          "job_id": "abc-123",
+          "stage": "generating_notes"
+        }
+        """#
+        let event = try decoder.decode(IpcEvent.self, from: json.data(using: .utf8)!)
+        guard case .jobProgress(let progress) = event else {
+            Issue.record("expected .jobProgress, got \(event)")
+            return
+        }
+        #expect(progress.jobId == "abc-123")
+        #expect(progress.stage == "generating_notes")
+        #expect(progress.current == nil)
+        #expect(progress.total == nil)
+        #expect(progress.message == nil)
+    }
+
+    @Test("job.progress notification decodes")
+    func jobProgressNotification_decodes() throws {
+        let json = #"""
+        {
+          "jsonrpc": "2.0",
+          "method": "events",
+          "params": {
+            "subscription": 1,
+            "result": {
+              "type": "job.progress",
+              "job_id": "j",
+              "stage": "exporting",
+              "message": "notes.md"
+            }
+          }
+        }
+        """#
+        let notification = try decoder.decode(JsonRpcNotification.self, from: json.data(using: .utf8)!)
+        guard case .jobProgress(let progress) = notification.params.result else {
+            Issue.record("expected .jobProgress, got \(notification.params.result)")
+            return
+        }
+        #expect(progress.jobId == "j")
+        #expect(progress.stage == "exporting")
+        #expect(progress.current == nil)
+        #expect(progress.total == nil)
+        #expect(progress.message == "notes.md")
+    }
+
     @Test("job.error event decodes all kinds", arguments: [
         "input_not_found", "invalid_input", "provider_unavailable", "internal", "cancelled"
     ])

--- a/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientLiveSmokeTest.swift
@@ -130,7 +130,7 @@ struct IpcClientLiveSmokeTest {
                         return .done(jobId: jId, meetingId: result.meetingId)
                     case .jobError(let jId, let payload) where jId == jobId:
                         return .error(jobId: jId, kind: payload.kind, message: payload.message)
-                    case .jobDone, .jobError, .unknown:
+                    case .jobDone, .jobError, .jobProgress, .unknown:
                         break
                     }
                 }

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -25,8 +25,8 @@ use panops_core::notes::input::{MeetingMetadata, NotesInput};
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
-    AudioSourcesWire, Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting,
-    MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    AudioSourcesWire, Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent,
+    Meeting, MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
     RecordingAccepted, RecordingStartParams, RecordingStopParams, RecordingStopped,
 };
 use tokio::sync::broadcast;
@@ -164,7 +164,7 @@ impl IpcServer for IpcImpl {
             let events_tx_for_panic = events_tx.clone();
             let join_handle = tokio::task::spawn_blocking(move || {
                 let _notes_job_permit = notes_job_permit;
-                let outcome = run_notes_pipeline(&services, &params);
+                let outcome = run_notes_pipeline(&services, &params, &events_tx, &job_id_owned);
                 match outcome {
                     Ok(result) => {
                         let _ = events_tx.send(Event::JobDone(JobDoneEvent {
@@ -460,6 +460,23 @@ impl IpcServer for IpcImpl {
     }
 }
 
+fn emit_job_progress(
+    events_tx: &broadcast::Sender<Event>,
+    job_id: &str,
+    stage: &str,
+    current: Option<u32>,
+    total: Option<u32>,
+    message: Option<&str>,
+) {
+    let _ = events_tx.send(Event::JobProgress(JobProgressEvent {
+        job_id: job_id.to_string(),
+        stage: stage.to_string(),
+        current,
+        total,
+        message: message.map(str::to_string),
+    }));
+}
+
 /// Run VAD + recursive ASR over one already-loaded track, returning its
 /// stitched segments (absolute timestamps) and the model name. Mirrors the
 /// legacy single-track loop so both the file-import path and the slice-11
@@ -469,6 +486,28 @@ fn transcribe_track(
     samples: &[f32],
     sample_rate: u32,
     language: Option<&str>,
+    events_tx: &broadcast::Sender<Event>,
+    job_id: &str,
+) -> Result<(Vec<panops_core::Segment>, Option<String>), IpcError> {
+    transcribe_track_labeled(
+        heavy,
+        samples,
+        sample_rate,
+        language,
+        events_tx,
+        job_id,
+        None,
+    )
+}
+
+fn transcribe_track_labeled(
+    heavy: &crate::server::HeavyAdapters,
+    samples: &[f32],
+    sample_rate: u32,
+    language: Option<&str>,
+    events_tx: &broadcast::Sender<Event>,
+    job_id: &str,
+    message: Option<&str>,
 ) -> Result<(Vec<panops_core::Segment>, Option<String>), IpcError> {
     let regions = heavy.vad.detect_speech(samples, sample_rate).map_err(|e| {
         tracing::error!(error = %e, "vad detect_speech failed");
@@ -478,11 +517,20 @@ fn transcribe_track(
     let total_audio_ms = (samples.len() as u64 * 1000) / u64::from(sample_rate);
     let mut segments = Vec::new();
     let mut model = None;
-    for region in merged.iter() {
+    let total = merged.len() as u32;
+    for (idx, region) in merged.iter().enumerate() {
         let clamped = region.clamp_to(total_audio_ms);
         if clamped.start_ms >= clamped.end_ms {
             continue;
         }
+        emit_job_progress(
+            events_tx,
+            job_id,
+            "transcribing",
+            Some((idx + 1) as u32),
+            Some(total),
+            message,
+        );
         let result = panops_portable::recursive_asr::transcribe_recursive(
             heavy.asr.as_ref(),
             samples,
@@ -513,6 +561,8 @@ fn transcribe_two_track(
     mic_wav: Option<&std::path::Path>,
     language: Option<&str>,
     no_diarize: bool,
+    events_tx: &broadcast::Sender<Event>,
+    job_id: &str,
 ) -> Result<panops_core::Transcript, IpcError> {
     if system_wav.is_none() && mic_wav.is_none() {
         return Err(IpcError::InvalidInput {
@@ -530,7 +580,15 @@ fn transcribe_two_track(
         let (samples, sr) =
             panops_portable::audio::load_audio_mono16k(mic).map_err(IpcError::from)?;
         duration_ms = duration_ms.max((samples.len() as u64 * 1000) / u64::from(sr));
-        let (segs, m) = transcribe_track(heavy, &samples, sr, language)?;
+        let (segs, m) = transcribe_track_labeled(
+            heavy,
+            &samples,
+            sr,
+            language,
+            events_tx,
+            job_id,
+            Some("mic track"),
+        )?;
         if model.is_none() {
             model = m;
         }
@@ -540,12 +598,21 @@ fn transcribe_two_track(
         let (samples, sr) =
             panops_portable::audio::load_audio_mono16k(system).map_err(IpcError::from)?;
         duration_ms = duration_ms.max((samples.len() as u64 * 1000) / u64::from(sr));
-        let (segs, m) = transcribe_track(heavy, &samples, sr, language)?;
+        let (segs, m) = transcribe_track_labeled(
+            heavy,
+            &samples,
+            sr,
+            language,
+            events_tx,
+            job_id,
+            Some("system track"),
+        )?;
         if model.is_none() {
             model = m;
         }
         system_segments = segs;
         if !no_diarize {
+            emit_job_progress(events_tx, job_id, "diarizing", None, None, None);
             system_turns = heavy.diar.diarize(system).map_err(IpcError::from)?;
         }
     }
@@ -581,6 +648,8 @@ fn transcribe_two_track(
 pub(super) fn run_notes_pipeline(
     services: &crate::server::EngineServices,
     params: &NotesGenerateParams,
+    events_tx: &broadcast::Sender<Event>,
+    job_id: &str,
 ) -> Result<NotesGenerateResult, IpcError> {
     // Warmup gate first. The CLI `serve` path uses
     // `EngineServices::pending(llm)` and fills `heavy` from a
@@ -640,6 +709,7 @@ pub(super) fn run_notes_pipeline(
             path: params.audio.clone(),
         }
     })?;
+    emit_job_progress(events_tx, job_id, "loading", None, None, None);
 
     // Slice 06: resolve `meeting_id`. If the caller passed one, verify
     // it exists (NotFound -> InputNotFound surfaces synchronously).
@@ -705,13 +775,21 @@ pub(super) fn run_notes_pipeline(
             mic_wav.exists().then_some(mic_wav.as_path()),
             params.language.as_deref(),
             params.no_diarize.unwrap_or(false),
+            events_tx,
+            job_id,
         )?
     } else {
         let (samples, sample_rate) =
             panops_portable::audio::load_audio_mono16k(&audio_path).map_err(IpcError::from)?;
         let total_audio_ms = (samples.len() as u64 * 1000) / u64::from(sample_rate);
-        let (segments, model) =
-            transcribe_track(heavy, &samples, sample_rate, params.language.as_deref())?;
+        let (segments, model) = transcribe_track(
+            heavy,
+            &samples,
+            sample_rate,
+            params.language.as_deref(),
+            events_tx,
+            job_id,
+        )?;
 
         let mut transcript = panops_core::Transcript {
             schema_version: panops_core::Transcript::SCHEMA_VERSION,
@@ -724,6 +802,7 @@ pub(super) fn run_notes_pipeline(
 
         let no_diarize = params.no_diarize.unwrap_or(false);
         if !no_diarize {
+            emit_job_progress(events_tx, job_id, "diarizing", None, None, None);
             let turns = heavy.diar.diarize(&audio_path).map_err(IpcError::from)?;
             transcript.segments = merge_speaker_turns(transcript.segments, &turns);
             transcript.diarized = true;
@@ -807,6 +886,7 @@ pub(super) fn run_notes_pipeline(
         },
     };
 
+    emit_job_progress(events_tx, job_id, "generating_notes", None, None, None);
     let generator = NotesGenerator {
         llm: services.llm.as_ref(),
         dialect,
@@ -814,6 +894,7 @@ pub(super) fn run_notes_pipeline(
     let notes = generator.generate(input).map_err(IpcError::from)?;
     let exporter = heavy.exporter.clone();
 
+    emit_job_progress(events_tx, job_id, "exporting", None, None, None);
     let artifact = exporter.export(&notes, &out_dir).map_err(|e| {
         // Domain-to-wire mapping lives in `panops-protocol` (gated by
         // `domain-conversions`); we still log the full error here so
@@ -1060,7 +1141,9 @@ mod readiness_tests {
             Arc::new(panops_core::conformance::fakes::InMemoryStorage::new());
         let (services, _heavy_lock) =
             crate::server::EngineServices::pending(llm, storage, std::path::PathBuf::from("/tmp"));
-        let err = run_notes_pipeline(&services, &dummy_params()).expect_err("warmup must error");
+        let (events_tx, _) = broadcast::channel(16);
+        let err = run_notes_pipeline(&services, &dummy_params(), &events_tx, "test-job")
+            .expect_err("warmup must error");
         match err {
             IpcError::ProviderUnavailable { message } => {
                 assert!(
@@ -1084,8 +1167,9 @@ mod readiness_tests {
             .set(Err("simulated whisper init failure".to_string()))
             .map_err(|_| ())
             .expect("set OnceLock");
-        let err =
-            run_notes_pipeline(&services, &dummy_params()).expect_err("init failure must surface");
+        let (events_tx, _) = broadcast::channel(16);
+        let err = run_notes_pipeline(&services, &dummy_params(), &events_tx, "test-job")
+            .expect_err("init failure must surface");
         match err {
             IpcError::Internal { message } => {
                 assert!(
@@ -1302,7 +1386,7 @@ mod notes_generate_concurrency_tests {
                     Event::JobDone(_) => done += 1,
                     Event::JobError(e) => panic!("notes job errored: {:?}", e.error),
                     Event::Unknown(v) => panic!("unexpected unknown event: {v}"),
-                    Event::Screenshot(_) | Event::RecordingProgress(_) => {}
+                    Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {}
                 }
             }
         })

--- a/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
+++ b/crates/panops-engine/tests/ipc_job_error_carries_kind.rs
@@ -85,7 +85,9 @@ async fn notes_generate_emits_job_error_with_input_not_found_kind() {
                 Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_late_subscriber_no_prior_events.rs
+++ b/crates/panops-engine/tests/ipc_late_subscriber_no_prior_events.rs
@@ -86,7 +86,9 @@ async fn late_subscriber_does_not_receive_prior_events() {
                 Event::JobDone(d) => panic!("expected JobError, got JobDone: {:?}", d),
                 Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
                 // Ignore screenshot/recording progress from concurrent tests.
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })
@@ -135,7 +137,12 @@ async fn late_subscriber_does_not_receive_prior_events() {
         Ok(Event::JobDone(d)) => {
             panic!("late subscriber received prior JobDone: {:?}", d);
         }
-        Ok(Event::Screenshot(_) | Event::RecordingProgress(_) | Event::Unknown(_)) => {
+        Ok(
+            Event::Screenshot(_)
+            | Event::RecordingProgress(_)
+            | Event::JobProgress(_)
+            | Event::Unknown(_),
+        ) => {
             // Spurious event from concurrent test — acceptable, but NOT the
             // prior JobError. The test still proves broadcast semantics hold.
         }

--- a/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
@@ -81,7 +81,9 @@ async fn notes_generate_without_meeting_id_auto_creates_one() {
                 Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_round_trip.rs
@@ -84,7 +84,9 @@ async fn notes_generate_round_trip_emits_job_done() {
                 Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_notes_generate_two_track.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_two_track.rs
@@ -124,7 +124,9 @@ async fn two_track_capture_splits_local_and_remote_speakers() {
                 Event::JobError(e) => panic!("expected JobDone, got JobError: {:?}", e.error),
                 Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
                 // Other events may arrive from concurrent tests; ignore them.
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_existing_meeting_id.rs
@@ -87,7 +87,9 @@ async fn notes_generate_with_existing_meeting_id_attaches_note() {
                 Event::Unknown(v) => panic!("expected JobDone, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_with_unknown_meeting_id.rs
@@ -88,7 +88,9 @@ async fn notes_generate_with_unknown_meeting_id_returns_input_not_found() {
                 Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_pipeline_panic_emits_joberror.rs
+++ b/crates/panops-engine/tests/ipc_pipeline_panic_emits_joberror.rs
@@ -118,7 +118,9 @@ async fn pipeline_panic_emits_job_error_internal() {
                 Event::Unknown(v) => panic!("expected JobError, got Unknown: {v}"),
                 // Slice 11 adds Screenshot and RecordingProgress events; ignore them
                 // in this notes pipeline test (they may arrive from concurrent tests).
-                Event::Screenshot(_) | Event::RecordingProgress(_) => continue,
+                Event::Screenshot(_) | Event::RecordingProgress(_) | Event::JobProgress(_) => {
+                    continue;
+                }
             }
         }
     })

--- a/crates/panops-engine/tests/ipc_sigterm_during_inflight_notes.rs
+++ b/crates/panops-engine/tests/ipc_sigterm_during_inflight_notes.rs
@@ -182,7 +182,9 @@ async fn shutdown_during_inflight_notes_drains_without_hanging() {
         match next {
             // Drained terminal events are fine (the issue leaves the
             // drain-vs-cancel race unspecified); keep going until close.
-            Some(Ok(Event::JobDone(_))) | Some(Ok(Event::JobError(_))) => continue,
+            Some(Ok(Event::JobDone(_)))
+            | Some(Ok(Event::JobError(_)))
+            | Some(Ok(Event::JobProgress(_))) => continue,
             // Ignore non-terminal noise (screenshot / progress events
             // that may arrive from concurrent tests) and Unknown.
             Some(Ok(_)) => continue,

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -14,8 +14,8 @@ pub mod methods;
 
 pub use error::IpcError;
 pub use methods::{
-    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, Meeting, MeetingConfig,
-    MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
-    RecordingProgressEvent, RecordingStartParams, RecordingStopParams, RecordingStopped,
-    ScreenshotEvent,
+    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, Meeting,
+    MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    RecordingAccepted, RecordingProgressEvent, RecordingStartParams, RecordingStopParams,
+    RecordingStopped, ScreenshotEvent,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -23,6 +23,8 @@ pub enum Event {
     JobDone(JobDoneEvent),
     #[serde(rename = "job.error")]
     JobError(JobErrorEvent),
+    #[serde(rename = "job.progress")]
+    JobProgress(JobProgressEvent),
     /// Screenshot captured during recording (slice 11).
     #[serde(rename = "screenshot")]
     Screenshot(ScreenshotEvent),
@@ -51,6 +53,9 @@ impl<'de> Deserialize<'de> for Event {
             "job.error" => serde_json::from_value::<JobErrorEvent>(value)
                 .map(Event::JobError)
                 .map_err(serde::de::Error::custom),
+            "job.progress" => serde_json::from_value::<JobProgressEvent>(value)
+                .map(Event::JobProgress)
+                .map_err(serde::de::Error::custom),
             "screenshot" => serde_json::from_value::<ScreenshotEvent>(value)
                 .map(Event::Screenshot)
                 .map_err(serde::de::Error::custom),
@@ -72,6 +77,18 @@ pub struct JobDoneEvent {
 pub struct JobErrorEvent {
     pub job_id: String,
     pub error: crate::IpcError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JobProgressEvent {
+    pub job_id: String,
+    pub stage: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 /// Screenshot captured during a recording session. Emitted via WebSocket
@@ -455,6 +472,23 @@ mod tests {
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains(r#""type":"job.error""#));
         assert!(json.contains(r#""kind":"input_not_found""#));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn job_progress_event_round_trips_with_type_tag() {
+        let e = Event::JobProgress(JobProgressEvent {
+            job_id: "abc".into(),
+            stage: "transcribing".into(),
+            current: Some(1),
+            total: Some(3),
+            message: Some("mic track".into()),
+        });
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains(r#""type":"job.progress""#));
+        assert!(json.contains(r#""job_id":"abc""#));
+        assert!(json.contains(r#""stage":"transcribing""#));
         let back: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(back, e);
     }


### PR DESCRIPTION
Closes #80. Makes `notes.generate` legible and fixes the false 5-minute timeout on long meetings.

## Engine (Rust)
- New `Event::JobProgress` (`job.progress`): `{ job_id, stage, current?, total?, message? }`.
- `run_notes_pipeline` + `transcribe_track`/`transcribe_two_track` emit progress through the existing `events_tx` broadcast at each stage (`loading`, per-region `transcribing` with current/total, `diarizing`, `generating_notes`, `exporting`).

## App (Swift)
- Decodes `job.progress`; `EventStreamActor` routes it **live** (non-terminal) while still buffering terminal `job.done`/`job.error`.
- The 'Generating notes…' view shows a friendly stage label + a determinate `ProgressView` (e.g. 'Transcribing 4/11…').
- **Replaces the fixed 5-min `pollingDeadlineSeconds` with a no-progress watchdog**: resets on every progress event, errors only after 5 min of *silence*. A long active job no longer falsely times out (the exact bug hit on a real meeting `.mov`); a genuinely stuck job still errors.

Verified locally: `cargo build/test/clippy` (incl. socket tests), `swift build`, `swift test` (29 tests). Follow-up filed for per-section LLM-phase progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)