### PR TITLE
Phase A backend: notes.json sidecar + richer MeetingSummary

### DIFF
--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -514,7 +514,10 @@ impl Storage for InMemoryStorage {
                 id: m.id.clone(),
                 title: m.title.clone(),
                 started_at: m.started_at.clone(),
+                ended_at: m.ended_at.clone(),
                 duration_ms: m.duration_ms.unwrap_or(0),
+                language: m.language.clone(),
+                has_notes: inner.notes.values().any(|n| n.meeting_id == m.id),
             })
             .collect();
         rows.sort_by(|a, b| b.started_at.cmp(&a.started_at));

--- a/crates/panops-core/src/conformance/storage.rs
+++ b/crates/panops-core/src/conformance/storage.rs
@@ -130,6 +130,21 @@ fn list_returns_started_at_desc<S: Storage>(adapter: &S) {
     let _ = adapter.create_meeting(draft("a", "A", "2026-05-01T10:00:00+00:00"));
     let _ = adapter.create_meeting(draft("b", "B", "2026-05-03T10:00:00+00:00"));
     let _ = adapter.create_meeting(draft("c", "C", "2026-05-02T10:00:00+00:00"));
+    adapter
+        .update_meeting_language("b", "es")
+        .expect("language update should succeed");
+    adapter
+        .update_meeting_ended("b", "2026-05-03T10:30:00+00:00", 1_800_000)
+        .expect("ended update should succeed");
+    adapter
+        .create_note(NoteDraft {
+            id: "n_list_b".into(),
+            meeting_id: "b".into(),
+            dialect: "basic".into(),
+            content_md: "# listed".into(),
+            primary_path: "/tmp/b/notes.md".into(),
+        })
+        .expect("note create should succeed");
 
     let rows = adapter.list_meetings().expect("list should succeed");
     let our: Vec<&str> = rows
@@ -142,6 +157,20 @@ fn list_returns_started_at_desc<S: Storage>(adapter: &S) {
         vec!["b", "c", "a"],
         "list_meetings should return started_at DESC; got {our:?}"
     );
+
+    let b = rows.iter().find(|r| r.id == "b").expect("b summary");
+    assert_eq!(b.title, "B");
+    assert_eq!(b.started_at, "2026-05-03T10:00:00+00:00");
+    assert_eq!(b.ended_at.as_deref(), Some("2026-05-03T10:30:00+00:00"));
+    assert_eq!(b.duration_ms, 1_800_000);
+    assert_eq!(b.language, "es");
+    assert!(b.has_notes, "summary should flag existing note row");
+
+    let a = rows.iter().find(|r| r.id == "a").expect("a summary");
+    assert!(a.ended_at.is_none());
+    assert_eq!(a.duration_ms, 0);
+    assert_eq!(a.language, "auto");
+    assert!(!a.has_notes, "summary should be false without note rows");
 }
 
 fn update_meeting_ended_writes_duration<S: Storage>(adapter: &S) {

--- a/crates/panops-core/src/storage.rs
+++ b/crates/panops-core/src/storage.rs
@@ -64,7 +64,10 @@ pub struct MeetingSummary {
     pub id: String,
     pub title: String,
     pub started_at: String,
+    pub ended_at: Option<String>,
     pub duration_ms: u64,
+    pub language: String,
+    pub has_notes: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -959,8 +959,13 @@ fn write_structured_notes_json(notes: &StructuredNotes, out_dir: &Path) -> Resul
     let json =
         serde_json::to_string_pretty(notes).map_err(|e| format!("serialize notes.json: {e}"))?;
     let notes_json_path = out_dir.join("notes.json");
-    std::fs::write(&notes_json_path, json)
-        .map_err(|e| format!("write {notes_json_path:?}: {e}"))?;
+    // Write to a temp sibling then rename, so a crash mid-write can't leave a
+    // partial notes.json a consumer fails to parse (notes.md is the primary
+    // artifact; same .partial+rename pattern as model downloads in model.rs).
+    let partial = out_dir.join("notes.json.partial");
+    std::fs::write(&partial, json).map_err(|e| format!("write {partial:?}: {e}"))?;
+    std::fs::rename(&partial, &notes_json_path)
+        .map_err(|e| format!("rename {partial:?} -> {notes_json_path:?}: {e}"))?;
     Ok(notes_json_path)
 }
 

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -11,7 +11,7 @@
 //! RPC boundary" section.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use jsonrpsee::PendingSubscriptionSink;
@@ -22,6 +22,7 @@ use panops_core::capture::CaptureSession;
 use panops_core::merge::merge_speaker_turns;
 use panops_core::notes::dialect::MarkdownDialect;
 use panops_core::notes::input::{MeetingMetadata, NotesInput};
+use panops_core::notes::ir::StructuredNotes;
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
@@ -216,18 +217,7 @@ impl IpcServer for IpcImpl {
             })?
             .map_err(|e| ipc_error_to_obj(e.into()))?;
 
-        // Convert from `panops_core::storage::MeetingSummary` to the
-        // wire-shape `panops_protocol::MeetingSummary`. Same field set
-        // today; the explicit map keeps us free to diverge later.
-        Ok(rows
-            .into_iter()
-            .map(|s| MeetingSummary {
-                id: s.id,
-                title: s.title,
-                started_at: s.started_at,
-                duration_ms: s.duration_ms,
-            })
-            .collect())
+        Ok(rows.into_iter().map(MeetingSummary::from).collect())
     }
 
     async fn meeting_start(&self, params: MeetingConfig) -> Result<String, ErrorObjectOwned> {
@@ -904,6 +894,10 @@ pub(super) fn run_notes_pipeline(
         IpcError::from(e)
     })?;
 
+    if let Err(e) = write_structured_notes_json(&notes, &out_dir) {
+        tracing::warn!(error = %e, "notes.generate: write notes.json failed; continuing");
+    }
+
     // Persist the note row. Genuinely best-effort: the markdown file
     // is already on disk at `artifact.primary_file`. If the registry
     // insert fails (e.g. FK violation because the meeting was
@@ -956,6 +950,18 @@ pub(super) fn run_notes_pipeline(
         meeting_id: resolved_meeting_id,
         transcript_txt_path,
     })
+}
+
+/// Additive structured-notes sidecar (`notes.json`): exposes the
+/// `StructuredNotes` IR to richer clients while `notes.md` remains the
+/// primary artifact.
+fn write_structured_notes_json(notes: &StructuredNotes, out_dir: &Path) -> Result<PathBuf, String> {
+    let json =
+        serde_json::to_string_pretty(notes).map_err(|e| format!("serialize notes.json: {e}"))?;
+    let notes_json_path = out_dir.join("notes.json");
+    std::fs::write(&notes_json_path, json)
+        .map_err(|e| format!("write {notes_json_path:?}: {e}"))?;
+    Ok(notes_json_path)
 }
 
 /// Map `IpcError` to a JSON-RPC server error (-32000) carrying the
@@ -1183,6 +1189,61 @@ mod readiness_tests {
             }
             other => panic!("expected Internal, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod notes_json_sidecar_tests {
+    use super::*;
+    use chrono::{NaiveDate, TimeZone, Utc};
+    use panops_core::notes::ir::{NotesFrontmatter, NotesSection};
+
+    fn sample_notes() -> StructuredNotes {
+        StructuredNotes {
+            schema_version: StructuredNotes::SCHEMA_VERSION,
+            frontmatter: NotesFrontmatter {
+                title: "Sidebar IR test".into(),
+                date: NaiveDate::from_ymd_opt(2026, 6, 7).unwrap(),
+                started_at: chrono::FixedOffset::east_opt(0)
+                    .unwrap()
+                    .with_ymd_and_hms(2026, 6, 7, 12, 0, 0)
+                    .unwrap(),
+                duration_ms: 60_000,
+                speakers: vec!["speaker_0".into()],
+                languages: vec!["en".into()],
+                tags: vec!["test".into()],
+                template: "default".into(),
+                dialect: MarkdownDialect::Basic,
+                panops_version: "0.1.0".into(),
+                source_audio: None,
+            },
+            sections: vec![NotesSection {
+                index: 1,
+                title: "Summary".into(),
+                time_range_ms: (0, 60_000),
+                narrative_md: "The generated sidecar round-trips.".into(),
+                key_points: vec!["Structured notes are preserved".into()],
+                action_items: Vec::new(),
+                screenshots: Vec::new(),
+            }],
+            language: "en".into(),
+            generated_at: Utc.with_ymd_and_hms(2026, 6, 7, 12, 1, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn write_structured_notes_json_creates_round_trippable_sidecar() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let notes = sample_notes();
+
+        let path = write_structured_notes_json(&notes, dir.path()).expect("write notes.json");
+
+        assert_eq!(path, dir.path().join("notes.json"));
+        assert!(path.exists(), "notes.json should exist at {path:?}");
+        let body = std::fs::read_to_string(&path).expect("read notes.json");
+        let back: StructuredNotes =
+            serde_json::from_str(&body).expect("notes.json parses as StructuredNotes");
+        assert_eq!(back, notes);
     }
 }
 

--- a/crates/panops-engine/tests/ipc_meeting_list_returns_inserted_rows.rs
+++ b/crates/panops-engine/tests/ipc_meeting_list_returns_inserted_rows.rs
@@ -13,7 +13,7 @@ use jsonrpsee::rpc_params;
 use panops_core::conformance::fakes::{
     FakeNotesExporter, KnownRegionsFake, KnownTurnsFake, MockLlm, TranscriptFileFake,
 };
-use panops_core::storage::MeetingDraft;
+use panops_core::storage::{MeetingDraft, NoteDraft};
 use panops_engine::server::{EngineServices, run_serve_in_process};
 use panops_protocol::MeetingSummary;
 use tempfile::tempdir;
@@ -45,8 +45,23 @@ async fn meeting_list_returns_rows_inserted_via_storage() {
             id: "b".into(),
             title: "B".into(),
             started_at: "2026-05-03T10:00:00+00:00".into(),
-            language: "en".into(),
+            language: "es".into(),
             dir_path: data_dir.join("meetings/b").to_string_lossy().into_owned(),
+        })
+        .unwrap();
+    storage
+        .update_meeting_ended("b", "2026-05-03T10:15:00+00:00", 900_000)
+        .unwrap();
+    storage
+        .create_note(NoteDraft {
+            id: "n_b".into(),
+            meeting_id: "b".into(),
+            dialect: "basic".into(),
+            content_md: "# Notes".into(),
+            primary_path: data_dir
+                .join("meetings/b/notes.md")
+                .to_string_lossy()
+                .into_owned(),
         })
         .unwrap();
 
@@ -81,8 +96,18 @@ async fn meeting_list_returns_rows_inserted_via_storage() {
     assert_eq!(result[0].title, "B");
     assert_eq!(result[1].id, "a");
     assert_eq!(result[1].title, "A");
+    assert_eq!(
+        result[0].ended_at.as_deref(),
+        Some("2026-05-03T10:15:00+00:00")
+    );
+    assert_eq!(result[0].duration_ms, 900_000);
+    assert_eq!(result[0].language, "es");
+    assert!(result[0].has_notes);
     // In-progress meetings render duration_ms as 0 (not Option<u64>).
-    assert_eq!(result[0].duration_ms, 0);
+    assert!(result[1].ended_at.is_none());
+    assert_eq!(result[1].duration_ms, 0);
+    assert_eq!(result[1].language, "en");
+    assert!(!result[1].has_notes);
 
     let _ = shutdown_tx.send(true);
     let _ = server.await;

--- a/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
+++ b/crates/panops-engine/tests/ipc_notes_generate_auto_creates_meeting.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
 use jsonrpsee::rpc_params;
+use panops_core::notes::ir::StructuredNotes;
 use panops_engine::server::run_serve_in_process;
 use panops_protocol::{Event, JobAccepted};
 use tempfile::tempdir;
@@ -117,6 +118,23 @@ async fn notes_generate_without_meeting_id_auto_creates_one() {
         primary_file.starts_with(data_dir.join("meetings").join(&meeting_id)),
         "primary_file {primary_file:?} should live under canonical meeting dir"
     );
+    let notes_json_path = primary_file
+        .parent()
+        .expect("notes primary file should have parent dir")
+        .join("notes.json");
+    assert!(
+        notes_json_path.exists(),
+        "structured notes sidecar should exist: {notes_json_path:?}"
+    );
+    let notes_json = std::fs::read_to_string(&notes_json_path).expect("read notes.json");
+    let structured: StructuredNotes =
+        serde_json::from_str(&notes_json).expect("notes.json round-trips to StructuredNotes");
+    assert_eq!(structured.schema_version, StructuredNotes::SCHEMA_VERSION);
+    assert_eq!(
+        structured.frontmatter.title,
+        "Quarterly budget review kickoff"
+    );
+    assert!(!structured.sections.is_empty());
 
     let _ = shutdown_tx.send(true);
     let _ = server.await;

--- a/crates/panops-portable/src/rusqlite_storage.rs
+++ b/crates/panops-portable/src/rusqlite_storage.rs
@@ -295,7 +295,14 @@ impl Storage for RusqliteStorage {
         let conn = lock(&self.conn)?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, title, started_at, COALESCE(duration_ms, 0)
+                "SELECT
+                     id,
+                     title,
+                     started_at,
+                     ended_at,
+                     COALESCE(duration_ms, 0),
+                     language,
+                     EXISTS (SELECT 1 FROM note WHERE note.meeting_id = meeting.id)
                  FROM meeting ORDER BY started_at DESC",
             )
             .map_err(StorageError::sql)?;
@@ -305,9 +312,12 @@ impl Storage for RusqliteStorage {
                     id: r.get(0)?,
                     title: r.get(1)?,
                     started_at: r.get(2)?,
+                    ended_at: r.get(3)?,
                     // Clamp negative durations to 0 (same defense as
                     // `map_meeting_row` — the DB file is not trusted).
-                    duration_ms: r.get::<_, i64>(3)?.max(0) as u64,
+                    duration_ms: r.get::<_, i64>(4)?.max(0) as u64,
+                    language: r.get(5)?,
+                    has_notes: r.get(6)?,
                 })
             })
             .map_err(StorageError::sql)?;

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -170,7 +170,13 @@ pub struct MeetingSummary {
     /// crate stays free of date-time deps; non-Rust consumers don't need
     /// a Rust-specific time crate to consume it.
     pub started_at: String,
+    /// RFC3339 when the meeting has ended; `None` for in-progress meetings.
+    pub ended_at: Option<String>,
     pub duration_ms: u64,
+    /// BCP-47 language hint, or "auto".
+    pub language: String,
+    /// Whether at least one note row exists for this meeting.
+    pub has_notes: bool,
 }
 
 /// Full meeting record returned by `meeting.get` / `meeting.start` /
@@ -189,6 +195,21 @@ pub struct Meeting {
     /// Absolute path to the meeting directory (where notes / future
     /// audio + screenshots live).
     pub dir_path: String,
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::storage::MeetingSummary> for MeetingSummary {
+    fn from(value: panops_core::storage::MeetingSummary) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            started_at: value.started_at,
+            ended_at: value.ended_at,
+            duration_ms: value.duration_ms,
+            language: value.language,
+            has_notes: value.has_notes,
+        }
+    }
 }
 
 /// Input shape for `meeting.start`. Both fields optional; server
@@ -499,7 +520,10 @@ mod tests {
             id: "m1".into(),
             title: "Test".into(),
             started_at: "2026-05-02T10:00:00Z".into(),
+            ended_at: Some("2026-05-02T10:01:00Z".into()),
             duration_ms: 60_000,
+            language: "en".into(),
+            has_notes: true,
         };
         let back: MeetingSummary =
             serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();

--- a/docs/proto/ipc.md
+++ b/docs/proto/ipc.md
@@ -47,8 +47,16 @@ The `ipc.` namespace + `.` separator are wired via jsonrpsee `#[rpc(server, name
 ### `Meeting` and `MeetingSummary`
 
 ```json
-// MeetingSummary (slice 05; shape unchanged)
-{ "id": "...", "title": "...", "started_at": "RFC3339", "duration_ms": 0 }
+// MeetingSummary (slice 05; +language/ended_at/has_notes for the workspace UI)
+{
+  "id": "...",
+  "title": "...",
+  "started_at": "RFC3339",
+  "duration_ms": 0,
+  "ended_at": null | "RFC3339",
+  "language": "en" | "es" | "auto" | ...,
+  "has_notes": false | true
+}
 
 // Meeting (slice 06; new)
 {
@@ -62,7 +70,7 @@ The `ipc.` namespace + `.` separator are wired via jsonrpsee `#[rpc(server, name
 }
 ```
 
-In-progress meetings render `ended_at: null` and `duration_ms: null` on `Meeting`; `MeetingSummary.duration_ms` defaults to `0` to keep the slice-05 wire shape stable.
+In-progress meetings render `ended_at: null` and `duration_ms: null` on `Meeting`; `MeetingSummary.duration_ms` defaults to `0`. The `language`/`ended_at`/`has_notes` additions to `MeetingSummary` (for the date-grouped sidebar + status pills) are **additive** — existing decoders ignore unknown fields, so the slice-05 four-field consumers keep working.
 
 ### `MeetingConfig` (input to `meeting.start`)
 


### PR DESCRIPTION
Foundation for the UX overhaul (Phase A).

## What
- **notes.json sidecar**: `run_notes_pipeline` now writes the `StructuredNotes` IR to `<meeting_dir>/notes.json` (best-effort, after a successful `exporter.export`, mirroring the transcript.json/txt writes). Lets the Mac app render structured notes (sections, key points, action items w/ owner/due, tags, speakers) with **no markdown re-parsing** — and supplies header metadata the `Meeting` wire type lacks.
- **MeetingSummary** gains `language`, `ended_at`, `has_notes` (wire + domain + Storage port + SQLite `meeting.list` via `EXISTS(note)` + conformance + conversion). Enables date-grouped sidebar rows with language + status pills.

## Verified locally
`cargo build/test/clippy --workspace --locked` all green (incl. the IPC socket-bind tests, which only fail in codex's sandbox). New tests: `notes_json_sidecar` round-trip + `meeting.list` returns the new fields.

Part of the Phase A UX plan; the Swift redesign that consumes these is a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)