### PR TITLE
Notes LLM: local by default + visible provider chip

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -17,6 +17,7 @@ final class AppViewModel: ObservableObject {
     @Published var meetings: [MeetingSummary] = []
     @Published var selectedMeeting: Meeting?
     @Published var notesProgress: JobProgressEvent?
+    @Published var llmInfo: LlmInfo?
 
     private let client: IpcClient
     private var pollingTask: Task<Void, Never>?
@@ -39,6 +40,7 @@ final class AppViewModel: ObservableObject {
 
     func connect() async throws {
         try await client.connect()
+        await loadServerInfoBestEffort()
         await refreshMeetingsWithStartupRetry()
     }
 
@@ -47,6 +49,7 @@ final class AppViewModel: ObservableObject {
     func retryConnect() async {
         do {
             try await client.connect()
+            await loadServerInfoBestEffort()
             await refreshMeetingsWithStartupRetry()
             state = .idle(audio: nil)
         } catch {
@@ -200,6 +203,18 @@ final class AppViewModel: ObservableObject {
             return result
         }
         return .timedOut
+    }
+
+    /// Fetch engine status once after IPC connection. Best-effort: older or
+    /// unhealthy engines simply omit the chip instead of blocking the app.
+    private func loadServerInfoBestEffort() async {
+        do {
+            let info = try await client.serverInfo()
+            llmInfo = info.llm
+        } catch {
+            Self.logFullError("ipc.server.info", error)
+            llmInfo = nil
+        }
     }
 
     /// Fetch meeting list from engine. Called on app launch and refresh.
@@ -447,6 +462,37 @@ final class AppViewModel: ObservableObject {
     }
 }
 
+struct LlmProviderChip: View {
+    let info: LlmInfo
+
+    private var label: String {
+        if info.local {
+            return "Local · \(info.provider)/\(info.model)"
+        }
+        return "⚠︎ Cloud · \(info.provider)/\(info.model)"
+    }
+
+    private var tint: Color {
+        info.local ? Color.secondary : Color.orange
+    }
+
+    private var fill: Color {
+        info.local ? Color.secondary.opacity(0.12) : Color.orange.opacity(0.15)
+    }
+
+    var body: some View {
+        Text(label)
+            .font(.caption)
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(tint)
+            .background(Capsule().fill(fill))
+            .overlay(Capsule().stroke(tint.opacity(0.35), lineWidth: 1))
+            .help(label)
+    }
+}
+
 struct ContentView<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var vm: AppViewModel
     @ObservedObject var recordingController: Controller
@@ -473,6 +519,10 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         .frame(minWidth: 720, minHeight: 480)
         .toolbar {
             ToolbarItemGroup {
+                if let llmInfo = vm.llmInfo {
+                    LlmProviderChip(info: llmInfo)
+                }
+
                 if vm.selectedMeeting != nil {
                     Button("New") {
                         vm.startNewGenerationFlow()

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -533,6 +533,13 @@ actor IpcClient {
         }
     }
 
+    /// `ipc.server.info` — fetches active engine/provider status.
+    func serverInfo() async throws -> ServerInfo {
+        return try await sendRequestNoParams(
+            method: "ipc.server.info"
+        )
+    }
+
     /// `ipc.notes.generate` — synchronous response is the job_id.
     /// JobDone arrives later; slice 09 detects completion via polling
     /// `meeting.get(meetingId)` rather than WS events.

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// Response from `ipc.server.info`.
+struct ServerInfo: Decodable, Equatable {
+    let llm: LlmInfo
+}
+
+/// Active LLM provider advertised by the engine.
+struct LlmInfo: Decodable, Equatable {
+    let provider: String
+    let model: String
+    let local: Bool
+}
+
 /// Outgoing params for `ipc.notes.generate`.
 struct NotesGenerateParams: Encodable {
     let audio: String

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -39,6 +39,17 @@ struct IpcClientCodecTests {
         #expect(!json.contains("\"language\":"), "expected language field to be omitted: \(json)")
     }
 
+    @Test("ServerInfo decodes LLM provider chip payload")
+    func serverInfoDecodes() throws {
+        let json = #"""
+        {"llm":{"provider":"ollama","model":"gemma3:4b","local":true}}
+        """#
+        let info = try decoder.decode(ServerInfo.self, from: json.data(using: .utf8)!)
+        #expect(info.llm.provider == "ollama")
+        #expect(info.llm.model == "gemma3:4b")
+        #expect(info.llm.local == true)
+    }
+
     @Test("job.done event decodes")
     func jobDoneEvent_decodes() throws {
         let json = #"""

--- a/crates/panops-engine/src/llm_resolver.rs
+++ b/crates/panops-engine/src/llm_resolver.rs
@@ -3,7 +3,8 @@
 //! On macOS, if `PANOPS_LLM_SIDECAR_BIN` is set AND that path is an
 //! executable file, probe the FoundationModels sidecar (`panops_mac::FoundationLlm`).
 //! If `SystemLanguageModel.availability` reports available, use it;
-//! otherwise fall back to `GenaiLlm` (Ollama / provider env auto-detect).
+//! otherwise fall back to local Ollama via `GenaiLlm`. Cloud auto-detect is
+//! reserved for the explicit CLI `--llm-provider auto` path.
 //!
 //! Slice 15 design:
 //! `docs/superpowers/specs/2026-06-06-slice-15-foundationmodels-llm-sidecar-design.md`.
@@ -12,8 +13,9 @@ use std::sync::Arc;
 
 use panops_core::llm::LlmProvider;
 use panops_portable::genai_llm::GenaiLlm;
+use panops_protocol::LlmInfo;
 
-/// Resolve the LLM adapter as an `Arc<dyn LlmProvider + Send + Sync>`.
+/// Resolve the LLM adapter and its wire-facing description.
 ///
 /// `sidecar_path` is intentionally an explicit argument instead of a
 /// hidden read inside this function so `main.rs` owns the dev/CI-only
@@ -22,7 +24,7 @@ use panops_portable::genai_llm::GenaiLlm;
 pub fn pick_llm(
     handle: tokio::runtime::Handle,
     sidecar_path: Option<std::path::PathBuf>,
-) -> Arc<dyn LlmProvider + Send + Sync> {
+) -> (Arc<dyn LlmProvider + Send + Sync>, LlmInfo) {
     #[cfg(not(target_os = "macos"))]
     let _ = sidecar_path;
 
@@ -39,26 +41,26 @@ pub fn pick_llm(
                         sidecar = %sidecar.display(),
                         "selecting FoundationModels LLM sidecar"
                     );
-                    return Arc::new(llm);
+                    return (Arc::new(llm), LlmInfo::apple_foundation());
                 }
                 Ok(probe) => {
                     tracing::info!(
                         sidecar = %sidecar.display(),
                         reason = probe.reason.as_deref().unwrap_or("unavailable"),
-                        "FoundationModels unavailable; falling back to GenaiLlm"
+                        "FoundationModels unavailable; falling back to local Ollama"
                     );
                 }
                 Err(e) => {
                     tracing::warn!(
                         sidecar = %sidecar.display(),
                         error = %e,
-                        "FoundationModels sidecar probe failed; falling back to GenaiLlm"
+                        "FoundationModels sidecar probe failed; falling back to local Ollama"
                     );
                 }
             }
         }
     }
-    Arc::new(genai_with_handle(handle))
+    (Arc::new(genai_with_handle(handle)), LlmInfo::local_ollama())
 }
 
 /// Read the dev/CI-only `PANOPS_LLM_SIDECAR_BIN` gate. The returned
@@ -94,17 +96,11 @@ pub fn foundation_llm_explicit(
 }
 
 fn genai_with_handle(handle: tokio::runtime::Handle) -> GenaiLlm {
-    let model = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
-        "claude-haiku-4-5-20251001"
-    } else if std::env::var("OPENAI_API_KEY").is_ok() {
-        "gpt-4o-mini"
-    } else if std::env::var("OLLAMA_HOST").is_ok() {
-        "gemma3:4b"
-    } else {
-        // Last-resort default. Matches `GenaiLlm::auto` so the IPC
-        // server is no more restrictive than the CLI's auto mode.
-        "gemma3:4b"
-    };
+    let model = "gemma3:4b";
+    tracing::info!(
+        model = model,
+        "notes LLM: using local ollama (set --llm-provider auto for cloud)"
+    );
     GenaiLlm::with_handle(model, handle)
 }
 

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -28,7 +28,7 @@ use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
     AudioSourcesWire, Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent,
     Meeting, MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
-    RecordingAccepted, RecordingStartParams, RecordingStopParams, RecordingStopped,
+    RecordingAccepted, RecordingStartParams, RecordingStopParams, RecordingStopped, ServerInfo,
 };
 use tokio::sync::broadcast;
 
@@ -66,6 +66,9 @@ pub(super) trait Ipc {
 
     #[method(name = "meeting.list")]
     async fn meeting_list(&self) -> Result<Vec<MeetingSummary>, ErrorObjectOwned>;
+
+    #[method(name = "server.info")]
+    async fn server_info(&self) -> Result<ServerInfo, ErrorObjectOwned>;
 
     #[method(name = "meeting.start")]
     async fn meeting_start(&self, params: MeetingConfig) -> Result<String, ErrorObjectOwned>;
@@ -218,6 +221,12 @@ impl IpcServer for IpcImpl {
             .map_err(|e| ipc_error_to_obj(e.into()))?;
 
         Ok(rows.into_iter().map(MeetingSummary::from).collect())
+    }
+
+    async fn server_info(&self) -> Result<ServerInfo, ErrorObjectOwned> {
+        Ok(ServerInfo {
+            llm: self.services.llm_info.clone(),
+        })
     }
 
     async fn meeting_start(&self, params: MeetingConfig) -> Result<String, ErrorObjectOwned> {

--- a/crates/panops-engine/src/server/mod.rs
+++ b/crates/panops-engine/src/server/mod.rs
@@ -40,6 +40,7 @@ use panops_core::exporter::NotesExporter;
 use panops_core::llm::LlmProvider;
 use panops_core::storage::Storage;
 use panops_core::vad::Vad;
+use panops_protocol::LlmInfo;
 use tokio::sync::{Semaphore, watch};
 
 use crate::server::handlers::{IpcImpl, IpcServer};
@@ -85,6 +86,7 @@ pub(super) struct HeavyAdapters {
 /// in `run_notes_pipeline`.
 pub struct EngineServices {
     pub llm: Arc<dyn LlmProvider + Send + Sync>,
+    pub llm_info: LlmInfo,
     /// Storage port (slice 06). Cheap to open (SQLite file open is
     /// microseconds), so it lives in the **direct** lane next to
     /// `llm`, NOT in the `heavy` `OnceLock`.
@@ -119,6 +121,7 @@ impl EngineServices {
         }));
         Self {
             llm,
+            llm_info: LlmInfo::local_ollama(),
             storage,
             data_dir,
             heavy,
@@ -136,14 +139,25 @@ impl EngineServices {
     /// the pending shape. Integration tests use [`Self::ready`].
     /// `HeavyAdapters` stays `pub(super)` so it can't leak out of
     /// `server::*`.
+    #[cfg(test)]
     pub(crate) fn pending(
         llm: Arc<dyn LlmProvider + Send + Sync>,
+        storage: Arc<dyn Storage>,
+        data_dir: PathBuf,
+    ) -> (Self, Arc<OnceLock<Result<HeavyAdapters, String>>>) {
+        Self::pending_with_llm_info(llm, LlmInfo::local_ollama(), storage, data_dir)
+    }
+
+    pub(crate) fn pending_with_llm_info(
+        llm: Arc<dyn LlmProvider + Send + Sync>,
+        llm_info: LlmInfo,
         storage: Arc<dyn Storage>,
         data_dir: PathBuf,
     ) -> (Self, Arc<OnceLock<Result<HeavyAdapters, String>>>) {
         let heavy = Arc::new(OnceLock::new());
         let services = Self {
             llm,
+            llm_info,
             storage,
             data_dir,
             heavy: heavy.clone(),
@@ -205,8 +219,9 @@ pub fn run_serve(
         // with the accept loop, so the socket binds within the 5s
         // budget and `notes.generate` is gated with
         // `ProviderUnavailable` until the trio is ready.
-        let llm = crate::llm_resolver::pick_llm(llm_handle, llm_sidecar_path);
-        let (services, heavy_lock) = EngineServices::pending(llm, storage, data_dir);
+        let (llm, llm_info) = crate::llm_resolver::pick_llm(llm_handle, llm_sidecar_path);
+        let (services, heavy_lock) =
+            EngineServices::pending_with_llm_info(llm, llm_info, storage, data_dir);
         spawn_heavy_init(heavy_lock);
         run_serve_in_process(&path, services, None).await
     });

--- a/crates/panops-engine/tests/ipc_server_info_returns_llm.rs
+++ b/crates/panops-engine/tests/ipc_server_info_returns_llm.rs
@@ -1,0 +1,59 @@
+//! `ipc.server.info` exposes the resolved notes LLM provider for the Mac app.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownRegionsFake, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::{LlmInfo, ServerInfo};
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_info_returns_llm_description() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let result: ServerInfo = ClientT::request(&client, "ipc.server.info", rpc_params![])
+        .await
+        .expect("call server.info");
+    assert_eq!(
+        result,
+        ServerInfo {
+            llm: LlmInfo::local_ollama()
+        }
+    );
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-engine/tests/llm_resolver.rs
+++ b/crates/panops-engine/tests/llm_resolver.rs
@@ -35,7 +35,10 @@ done
 fn resolver_accepts_available_sidecar() -> TestResult {
     let (_dir, bin) = write_fake_sidecar(true)?;
     let rt = tokio::runtime::Runtime::new()?;
-    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    let (llm, info) = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    assert_eq!(info.provider, "apple-foundation");
+    assert_eq!(info.model, "on-device");
+    assert!(info.local);
     drop(llm);
     Ok(())
 }
@@ -44,7 +47,10 @@ fn resolver_accepts_available_sidecar() -> TestResult {
 fn resolver_falls_back_when_probe_unavailable() -> TestResult {
     let (_dir, bin) = write_fake_sidecar(false)?;
     let rt = tokio::runtime::Runtime::new()?;
-    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    let (llm, info) = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    assert_eq!(info.provider, "ollama");
+    assert_eq!(info.model, "gemma3:4b");
+    assert!(info.local);
     drop(llm);
     Ok(())
 }
@@ -55,7 +61,10 @@ fn resolver_falls_back_when_sidecar_is_not_executable() -> TestResult {
     let bin = dir.path().join("not-executable");
     std::fs::write(&bin, "#!/bin/sh\nexit 0\n")?;
     let rt = tokio::runtime::Runtime::new()?;
-    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    let (llm, info) = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(bin));
+    assert_eq!(info.provider, "ollama");
+    assert_eq!(info.model, "gemma3:4b");
+    assert!(info.local);
     drop(llm);
     Ok(())
 }
@@ -65,7 +74,10 @@ fn resolver_falls_back_when_sidecar_path_does_not_exist() -> TestResult {
     let dir = tempfile::tempdir()?;
     let missing = dir.path().join("missing-panops-llm-mac");
     let rt = tokio::runtime::Runtime::new()?;
-    let llm = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(missing));
+    let (llm, info) = panops_engine::llm_resolver::pick_llm(rt.handle().clone(), Some(missing));
+    assert_eq!(info.provider, "ollama");
+    assert_eq!(info.model, "gemma3:4b");
+    assert!(info.local);
     drop(llm);
     Ok(())
 }

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -14,8 +14,8 @@ pub mod methods;
 
 pub use error::IpcError;
 pub use methods::{
-    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, Meeting,
-    MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, LlmInfo,
+    Meeting, MeetingConfig, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
     RecordingAccepted, RecordingProgressEvent, RecordingStartParams, RecordingStopParams,
-    RecordingStopped, ScreenshotEvent,
+    RecordingStopped, ScreenshotEvent, ServerInfo,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -114,6 +114,36 @@ pub struct JobAccepted {
     pub job_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmInfo {
+    pub provider: String,
+    pub model: String,
+    pub local: bool,
+}
+
+impl LlmInfo {
+    pub fn local_ollama() -> Self {
+        Self {
+            provider: "ollama".into(),
+            model: "gemma3:4b".into(),
+            local: true,
+        }
+    }
+
+    pub fn apple_foundation() -> Self {
+        Self {
+            provider: "apple-foundation".into(),
+            model: "on-device".into(),
+            local: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerInfo {
+    pub llm: LlmInfo,
+}
+
 /// Params for `ipc.notes.generate`.
 ///
 /// Param structs intentionally do NOT carry `#[serde(deny_unknown_fields)]`
@@ -281,6 +311,20 @@ pub struct RecordingStopped {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn server_info_round_trips_with_llm_info() {
+        let info = ServerInfo {
+            llm: LlmInfo::local_ollama(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert_eq!(
+            json,
+            r#"{"llm":{"provider":"ollama","model":"gemma3:4b","local":true}}"#
+        );
+        let back: ServerInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, info);
+    }
 
     #[test]
     fn notes_generate_params_minimal_round_trip() {


### PR DESCRIPTION
Closes #204. Privacy hardening surfaced during the first real app run.

## Problem
With no FoundationModels sidecar, the LLM resolver fell back to `genai_with_handle`, which **silently picked a cloud model** (`claude-haiku` / `gpt-4o-mini`) whenever an Anthropic/OpenAI key was in the env — the app would have sent a private meeting transcript to a cloud API with no indication to the user.

## Engine
- `genai_with_handle` now **always resolves to local ollama (gemma3:4b)** — never silently cloud from a present key. Cloud remains available only via the explicit `--llm-provider auto` CLI (a deliberate choice). Logs the local resolution.
- `pick_llm` returns the resolved `LlmInfo { provider, model, local }`; stored in services and exposed via a new `ipc.server.info` method → `{ "llm": { "provider", "model", "local" } }`.

## App
- Decodes `server.info`; on connect, fetches it (best-effort) and shows a status chip: subtle `Local · ollama/gemma3:4b` when local, a prominent orange `⚠︎ Cloud · provider/model` when not — so cloud processing is unmistakable.

Verified locally: cargo build/clippy/fmt + `ipc.server.info` socket test green; `swift build` + `swift test` (30) green. (Full engine suite runs in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)