### PR TITLE
Phase A UX: native meeting workspace (tabs, rendered notes, grouped sidebar, trust strip)

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -18,6 +18,14 @@ final class AppViewModel: ObservableObject {
     @Published var selectedMeeting: Meeting?
     @Published var notesProgress: JobProgressEvent?
     @Published var llmInfo: LlmInfo?
+    /// Which meeting the current/last notes generation targets. Lets the meeting
+    /// workspace show processing/error inline for the right meeting (the audio-
+    /// file flow targets a freshly-created meeting that isn't selected, so its
+    /// states render in the no-selection area instead).
+    @Published var notesGenMeetingId: String?
+    /// Bumped when notes generation completes so the open meeting workspace
+    /// re-reads `notes.json` from disk.
+    @Published private(set) var notesReloadTick: Int = 0
 
     private let client: IpcClient
     private var pollingTask: Task<Void, Never>?
@@ -77,17 +85,54 @@ final class AppViewModel: ObservableObject {
         state = .idle(audio: url)
     }
 
+    /// Audio-file flow: create a fresh meeting from a picked file and generate.
     func generate() async {
         guard case .idle(let audio?) = state else { return }
         do {
+            let meetingId = try await client.meetingStart()
+            await beginNotesGeneration(meetingId: meetingId, audio: audio)
+        } catch let IpcClientError.rpcError(_, message) {
+            failNotesStart(kind: "rpc_error", message: message)
+        } catch {
+            Self.logFullError("meeting.start", error)
+            failNotesStart(kind: "internal", message: "Could not reach the engine.")
+        }
+    }
+
+    /// Selected-meeting flow: generate (or retry) notes for an existing meeting
+    /// using audio already captured in its directory. Targets the meeting's own
+    /// id rather than creating a new one.
+    func generateNotes(for meeting: Meeting) async {
+        // Only one notes job is tracked at a time (notesGenMeetingId + state).
+        // Starting a second while one runs would clobber the first's progress
+        // and completion tracking, so refuse while any job is in flight.
+        guard !isNotesJobActive else { return }
+        guard let audio = locateAudio(in: meeting.dirPath) else {
+            notesGenMeetingId = meeting.id
+            notesProgress = nil
+            notesLastProgressAt = nil
+            state = .error(
+                kind: "no_audio",
+                message: "No recorded audio was found for this meeting."
+            )
+            return
+        }
+        await beginNotesGeneration(meetingId: meeting.id, audio: audio)
+    }
+
+    /// Shared notes-generation machinery used by both entry points: subscribe
+    /// (or fall back to polling), kick off `notes.generate`, register the
+    /// completion callback, and arm the polling safety net.
+    private func beginNotesGeneration(meetingId: String, audio: URL) async {
+        do {
             notesProgress = nil
             notesLastProgressAt = Date()
+            notesGenMeetingId = meetingId
 
-            // Ensure WebSocket subscription is active (lazy)
-            // If WebSocket fails, fall back to filesystem polling (fix #5)
+            // Ensure WebSocket subscription is active (lazy).
+            // If WebSocket fails, fall back to filesystem polling (fix #5).
             let wsOk = await ensureWsSubscription()
 
-            let meetingId = try await client.meetingStart()
             let jobId = try await client.notesGenerate(audio: audio, meetingId: meetingId)
             state = .working(meetingId: meetingId, audioName: audio.lastPathComponent)
 
@@ -124,15 +169,92 @@ final class AppViewModel: ObservableObject {
             // cancelled by the terminal WebSocket callback when one arrives.
             startPolling(meetingId: meetingId, jobId: wsOk ? jobId : nil)
         } catch let IpcClientError.rpcError(_, message) {
-            notesProgress = nil
-            notesLastProgressAt = nil
-            state = .error(kind: "rpc_error", message: message)
+            failNotesStart(kind: "rpc_error", message: message)
         } catch {
             Self.logFullError("notes.generate", error)
-            notesProgress = nil
-            notesLastProgressAt = nil
-            state = .error(kind: "internal", message: "Could not reach the engine.")
+            failNotesStart(kind: "internal", message: "Could not reach the engine.")
         }
+    }
+
+    private func failNotesStart(kind: String, message: String) {
+        notesProgress = nil
+        notesLastProgressAt = nil
+        // Keep notesGenMeetingId so the workspace can show the error inline.
+        state = .error(kind: kind, message: message)
+    }
+
+    /// Find captured audio in a meeting directory. Live capture writes
+    /// `system.wav` / `mic.wav`; prefer those, then any audio-like file.
+    private func locateAudio(in dirPath: String) -> URL? {
+        let fm = FileManager.default
+        let preferred = ["system.wav", "mic.wav", "audio.wav"]
+        for name in preferred {
+            let path = (dirPath as NSString).appendingPathComponent(name)
+            if PathValidator.isPath(path, under: dirPath), fm.fileExists(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        }
+        let audioExtensions: Set<String> = ["wav", "m4a", "mp3", "mov"]
+        if let contents = try? fm.contentsOfDirectory(atPath: dirPath) {
+            for name in contents.sorted()
+            where audioExtensions.contains((name as NSString).pathExtension.lowercased()) {
+                let path = (dirPath as NSString).appendingPathComponent(name)
+                if PathValidator.isPath(path, under: dirPath) {
+                    return URL(fileURLWithPath: path)
+                }
+            }
+        }
+        return nil
+    }
+
+    /// True while any notes-generation job is in flight. Only one job is tracked
+    /// at a time, so callers must not start a second while this is true.
+    var isNotesJobActive: Bool {
+        if case .working = state { return true }
+        return false
+    }
+
+    /// Lifecycle status for a meeting summary, used by the sidebar status pill.
+    func status(for summary: MeetingSummary) -> MeetingStatus {
+        if activeRecordingMeetingId == summary.id { return .recording }
+        if notesGenMeetingId == summary.id, case .working = state { return .processing }
+        if summary.hasNotes { return .ready }
+        if summary.endedAt != nil { return .needsNotes }
+        // Older payloads (pre ended_at) decode endedAt as nil; a positive
+        // recorded duration still means the meeting ended and needs notes.
+        if summary.durationMs > 0 { return .needsNotes }
+        return .draft
+    }
+
+    /// Delete a meeting via the existing `meeting.delete` path; clear selection
+    /// if it was the open one, then refresh the list.
+    func deleteMeeting(id: String) async {
+        do {
+            try await client.meetingDelete(id: id)
+            // Only clear the selection / empty the workspace once the delete
+            // actually succeeded; a failed delete must leave the meeting open.
+            if selectedMeetingId == id {
+                selectedMeetingId = nil
+                selectedMeeting = nil
+                state = .idle(audio: nil)
+            }
+        } catch {
+            Self.logFullError("meeting.delete", error)
+        }
+        await refreshMeetings()
+    }
+
+    /// Open a path (typically a meeting directory) in Finder, guarded to the
+    /// panops data dir.
+    func openInFinder(path: String) {
+        guard PathValidator.isUnderPanopsDataDir(path) else {
+            Self.logFullError(
+                "openInFinder",
+                NSError(domain: "PanopsShell", code: 1, userInfo: [NSLocalizedDescriptionKey: "refusing to open path outside panops data dir: \(path)"])
+            )
+            return
+        }
+        NSWorkspace.shared.open(URL(fileURLWithPath: path).standardizedFileURL)
     }
 
     /// Ensure WebSocket subscription is active. Lazy per spec decision.
@@ -336,6 +458,9 @@ final class AppViewModel: ObservableObject {
         }
         notesProgress = nil
         notesLastProgressAt = nil
+        notesGenMeetingId = nil
+        // Signal the open meeting workspace to re-read notes.json from disk.
+        notesReloadTick += 1
         state = .done(notesPath: notesPath)
         Task { await refreshMeetings() }
     }
@@ -443,6 +568,7 @@ final class AppViewModel: ObservableObject {
         selectedMeeting = nil
         notesProgress = nil
         notesLastProgressAt = nil
+        notesGenMeetingId = nil
         state = .idle(audio: nil)
     }
 
@@ -503,17 +629,36 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         NavigationSplitView {
             MeetingListView(vm: vm)
         } detail: {
-            switch vm.state {
-            case .engineNotConnected:
-                engineNotConnectedView()
-            case .idle(let audio):
-                detailPlaceholder(audio: audio)
-            case .working(_, let audioName):
-                workingView(audioName: audioName)
-            case .done(let path):
-                doneView(path: path)
-            case .error(let kind, let message):
-                errorView(kind: kind, message: message)
+            // A selected meeting owns its own Notes/Transcript/Info workspace,
+            // including per-meeting processing/error states. The audio-file
+            // flow (no selection) renders its working/done/error here instead.
+            if let meeting = vm.selectedMeeting {
+                MeetingDetailView(
+                    meeting: meeting,
+                    vm: vm,
+                    recordingController: recordingController,
+                    onRecordingStarted: { id in
+                        await MainActor.run {
+                            vm.activeRecordingMeetingId = id
+                        }
+                    },
+                    onRecordingStopped: { _ in
+                        try await vm.finishActiveLiveRecording()
+                    }
+                )
+            } else {
+                switch vm.state {
+                case .engineNotConnected:
+                    engineNotConnectedView()
+                case .idle(let audio):
+                    emptyState(audio: audio)
+                case .working(_, let audioName):
+                    workingView(audioName: audioName)
+                case .done(let path):
+                    doneView(path: path)
+                case .error(let kind, let message):
+                    errorView(kind: kind, message: message)
+                }
             }
         }
         .frame(minWidth: 720, minHeight: 480)
@@ -602,53 +747,56 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         .padding()
     }
 
+    /// No meeting selected: product blurb, the primary New Recording CTA, the
+    /// honest trust strip, and a secondary audio-file generation path.
     @ViewBuilder
-    private func detailPlaceholder(audio: URL?) -> some View {
-        VStack(spacing: 24) {
-            // Show selected meeting detail if available
-            if let meeting = vm.selectedMeeting {
-                MeetingDetailView(
-                    meeting: meeting,
-                    recordingController: recordingController,
-                    onRecordingStarted: { id in
-                        await MainActor.run {
-                            vm.activeRecordingMeetingId = id
-                        }
-                    },
-                    onRecordingStopped: { _ in
-                        try await vm.finishActiveLiveRecording()
-                    }
-                )
-            } else {
-                VStack(spacing: 16) {
-                    Text("Panops").font(.largeTitle)
-                    Text("Select a meeting from the sidebar or generate notes from an audio file.")
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+    private func emptyState(audio: URL?) -> some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "waveform.and.mic")
+                .font(.system(size: 44))
+                .foregroundStyle(Color.accentColor)
+            Text("Panops").font(.largeTitle.weight(.semibold))
+            Text("Record a meeting and get private, screenshot-anchored notes —\nall processed on this Mac.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
 
-                    Divider()
-
-                    // Notes generation flow preserved here
-                    HStack {
-                        Button("Open audio…") { vm.pickAudio() }
-                        if let audio {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text(audio.lastPathComponent).font(.body)
-                                Button("Generate notes") {
-                                    Task { await vm.generate() }
-                                }
-                                .keyboardShortcut(.return, modifiers: [])
-                            }
-                        } else {
-                            Text("No file selected").foregroundStyle(.secondary)
-                        }
-                    }
-
-                    Spacer()
-                }
-                .padding()
+            Button {
+                Task { @MainActor in await startNewRecording() }
+            } label: {
+                Label("New Recording", systemImage: "record.circle")
+                    .padding(.horizontal, 8)
             }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(isStartingNewRecording || recordingController.isRecording || isEngineNotConnected)
+
+            // Secondary path: generate notes from an existing audio file.
+            VStack(spacing: 8) {
+                Divider().frame(maxWidth: 280)
+                HStack(spacing: 12) {
+                    Button("Open audio file…") { vm.pickAudio() }
+                    if let audio {
+                        Text(audio.lastPathComponent)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Button("Generate notes") {
+                            Task { await vm.generate() }
+                        }
+                        .keyboardShortcut(.return, modifiers: [])
+                    }
+                }
+            }
+            .padding(.top, 4)
+
+            Spacer()
+            TrustStrip()
+                .padding(.bottom, 12)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
     }
 
     @ViewBuilder
@@ -680,25 +828,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
     }
 
     private func notesProgressLabel(_ progress: JobProgressEvent?) -> String {
-        guard let progress else { return "Generating notes…" }
-
-        switch progress.stage {
-        case "loading":
-            return "Loading audio…"
-        case "transcribing":
-            if let current = progress.current, let total = progress.total {
-                return "Transcribing \(current)/\(total)…"
-            }
-            return "Transcribing…"
-        case "diarizing":
-            return "Identifying speakers…"
-        case "generating_notes":
-            return "Writing notes…"
-        case "exporting":
-            return "Saving…"
-        default:
-            return "Generating notes…"
-        }
+        progress?.stageLabel ?? "Generating notes…"
     }
 
     @ViewBuilder

--- a/apps/Panops/Sources/Panops/DateFormatting.swift
+++ b/apps/Panops/Sources/Panops/DateFormatting.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Date/time/duration formatting for meeting timestamps. Engine timestamps are
+/// RFC3339 strings ("2026-06-05T10:00:00Z" or with an offset / fractional
+/// seconds); these helpers parse leniently and format for display.
+enum MeetingDate {
+    // Cached formatters, only touched from the main thread. ISO8601DateFormatter
+    // is non-Sendable, so its shared statics need nonisolated(unsafe); plain
+    // DateFormatter is Sendable in this SDK, so day/time need no annotation.
+    nonisolated(unsafe) private static let isoBasic: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    nonisolated(unsafe) private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d, yyyy"
+        return f
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
+    static func parse(_ iso: String) -> Date? {
+        guard !iso.isEmpty else { return nil }
+        if let d = isoBasic.date(from: iso) { return d }
+        if let d = isoFractional.date(from: iso) { return d }
+        return nil
+    }
+
+    /// "Today" / "Yesterday" / "Jun 5, 2026" for date-grouped sidebar sections.
+    static func dayLabel(_ date: Date) -> String {
+        let cal = Calendar.current
+        if cal.isDateInToday(date) { return "Today" }
+        if cal.isDateInYesterday(date) { return "Yesterday" }
+        return dayFormatter.string(from: date)
+    }
+
+    static func shortDate(_ date: Date) -> String {
+        dayFormatter.string(from: date)
+    }
+
+    static func shortTime(_ date: Date) -> String {
+        timeFormatter.string(from: date)
+    }
+
+    /// Human duration: "1h 30m", "30m 12s", "45s".
+    static func duration(ms: UInt64) -> String {
+        let totalSec = ms / 1000
+        let hours = totalSec / 3600
+        let minutes = (totalSec % 3600) / 60
+        let seconds = totalSec % 60
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        if minutes > 0 { return "\(minutes)m \(seconds)s" }
+        return "\(seconds)s"
+    }
+}

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -326,17 +326,58 @@ struct Meeting: Decodable {
 }
 
 /// Summary item from `ipc.meeting.list`. Mirrors `panops-protocol::MeetingSummary`.
-/// Wire contract: ONLY 4 fields (id, title, started_at, duration_ms) — all required.
+///
+/// Base wire contract: id, title, started_at, duration_ms (all required).
+/// `language`, `ended_at`, and `has_notes` are decode-if-present: the engine
+/// change that adds them lands separately, so older payloads (and the existing
+/// codec test) still decode — `language` defaults to "", `endedAt` to nil,
+/// `hasNotes` to false.
 struct MeetingSummary: Decodable {
     let id: String
     let title: String
     let startedAt: String
     let durationMs: UInt64
+    let language: String
+    let endedAt: String?
+    let hasNotes: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
         case title
         case startedAt = "started_at"
         case durationMs = "duration_ms"
+        case language
+        case endedAt = "ended_at"
+        case hasNotes = "has_notes"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        title = try c.decode(String.self, forKey: .title)
+        startedAt = try c.decode(String.self, forKey: .startedAt)
+        durationMs = try c.decode(UInt64.self, forKey: .durationMs)
+        language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
+        endedAt = try c.decodeIfPresent(String.self, forKey: .endedAt)
+        hasNotes = try c.decodeIfPresent(Bool.self, forKey: .hasNotes) ?? false
+    }
+
+    // Memberwise init retained for tests/previews constructing summaries directly.
+    init(
+        id: String,
+        title: String,
+        startedAt: String,
+        durationMs: UInt64,
+        language: String = "",
+        endedAt: String? = nil,
+        hasNotes: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.startedAt = startedAt
+        self.durationMs = durationMs
+        self.language = language
+        self.endedAt = endedAt
+        self.hasNotes = hasNotes
     }
 }

--- a/apps/Panops/Sources/Panops/StructuredNotes.swift
+++ b/apps/Panops/Sources/Panops/StructuredNotes.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Swift mirror of `panops_core::notes::ir::StructuredNotes` — the structured
+/// notes IR written to `notes.json` next to `notes.md` in each meeting dir.
+///
+/// Keep field names/types in sync with `crates/panops-core/src/notes/ir.rs`.
+/// Decoding is lenient on purpose: the engine writes `notes.json` from a
+/// separately-landing change, so fields the engine may add later (or omit on
+/// older files) must not break decode. Date/time fields arrive as RFC3339 /
+/// `YYYY-MM-DD` strings (serde serializes chrono types as strings); they are
+/// decoded as `String` and parsed for display only.
+struct StructuredNotes: Decodable {
+    let schemaVersion: UInt32
+    let frontmatter: NotesFrontmatter
+    let sections: [NotesSection]
+    let language: String
+    let generatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case frontmatter
+        case sections
+        case language
+        case generatedAt = "generated_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try c.decodeIfPresent(UInt32.self, forKey: .schemaVersion) ?? 0
+        frontmatter = try c.decode(NotesFrontmatter.self, forKey: .frontmatter)
+        sections = try c.decodeIfPresent([NotesSection].self, forKey: .sections) ?? []
+        language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
+        generatedAt = try c.decodeIfPresent(String.self, forKey: .generatedAt) ?? ""
+    }
+}
+
+struct NotesFrontmatter: Decodable {
+    let title: String
+    let date: String
+    let startedAt: String
+    let durationMs: UInt64
+    let speakers: [String]
+    let languages: [String]
+    let tags: [String]
+    let template: String
+    let dialect: String
+    let panopsVersion: String
+    let sourceAudio: String?
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case date
+        case startedAt = "started_at"
+        case durationMs = "duration_ms"
+        case speakers
+        case languages
+        case tags
+        case template
+        case dialect
+        case panopsVersion = "panops_version"
+        case sourceAudio = "source_audio"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+        date = try c.decodeIfPresent(String.self, forKey: .date) ?? ""
+        startedAt = try c.decodeIfPresent(String.self, forKey: .startedAt) ?? ""
+        durationMs = try c.decodeIfPresent(UInt64.self, forKey: .durationMs) ?? 0
+        speakers = try c.decodeIfPresent([String].self, forKey: .speakers) ?? []
+        languages = try c.decodeIfPresent([String].self, forKey: .languages) ?? []
+        tags = try c.decodeIfPresent([String].self, forKey: .tags) ?? []
+        template = try c.decodeIfPresent(String.self, forKey: .template) ?? ""
+        // `dialect` serializes kebab-case ("notion-enhanced"); decode as a plain
+        // string and present it humanized rather than mapping a Swift enum.
+        dialect = try c.decodeIfPresent(String.self, forKey: .dialect) ?? ""
+        panopsVersion = try c.decodeIfPresent(String.self, forKey: .panopsVersion) ?? ""
+        sourceAudio = try c.decodeIfPresent(String.self, forKey: .sourceAudio)
+    }
+}
+
+struct NotesSection: Decodable, Identifiable {
+    let index: UInt32
+    let title: String
+    /// `time_range_ms` is a serde 2-tuple → encoded as a JSON array `[start, end]`.
+    let timeRangeMs: [UInt64]
+    let narrativeMd: String
+    let keyPoints: [String]
+    let actionItems: [ActionItem]
+    let screenshots: [Screenshot]
+
+    var id: UInt32 { index }
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case title
+        case timeRangeMs = "time_range_ms"
+        case narrativeMd = "narrative_md"
+        case keyPoints = "key_points"
+        case actionItems = "action_items"
+        case screenshots
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        index = try c.decodeIfPresent(UInt32.self, forKey: .index) ?? 0
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+        timeRangeMs = try c.decodeIfPresent([UInt64].self, forKey: .timeRangeMs) ?? []
+        narrativeMd = try c.decodeIfPresent(String.self, forKey: .narrativeMd) ?? ""
+        keyPoints = try c.decodeIfPresent([String].self, forKey: .keyPoints) ?? []
+        actionItems = try c.decodeIfPresent([ActionItem].self, forKey: .actionItems) ?? []
+        screenshots = try c.decodeIfPresent([Screenshot].self, forKey: .screenshots) ?? []
+    }
+}
+
+struct ActionItem: Decodable, Identifiable {
+    let description: String
+    let owner: String?
+    let due: String?
+
+    let id = UUID()
+
+    enum CodingKeys: String, CodingKey {
+        case description
+        case owner
+        case due
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        description = try c.decodeIfPresent(String.self, forKey: .description) ?? ""
+        owner = try c.decodeIfPresent(String.self, forKey: .owner)
+        due = try c.decodeIfPresent(String.self, forKey: .due)
+    }
+}
+
+struct Screenshot: Decodable, Identifiable {
+    let msSinceStart: UInt64
+    let path: String
+    let caption: String?
+
+    var id: String { "\(msSinceStart)-\(path)" }
+
+    enum CodingKeys: String, CodingKey {
+        case msSinceStart = "ms_since_start"
+        case path
+        case caption
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        msSinceStart = try c.decodeIfPresent(UInt64.self, forKey: .msSinceStart) ?? 0
+        path = try c.decodeIfPresent(String.self, forKey: .path) ?? ""
+        caption = try c.decodeIfPresent(String.self, forKey: .caption)
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/Chips.swift
+++ b/apps/Panops/Sources/Panops/Views/Chips.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Lifecycle status of a meeting, derived in `AppViewModel.status(for:)`.
+enum MeetingStatus: Equatable {
+    case recording
+    case processing
+    case ready
+    case needsNotes
+    case draft
+
+    var label: String {
+        switch self {
+        case .recording: return "Recording"
+        case .processing: return "Processing"
+        case .ready: return "Ready"
+        case .needsNotes: return "Needs notes"
+        case .draft: return "Draft"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .recording: return .red
+        case .processing: return .orange
+        case .ready: return .green
+        case .needsNotes: return .blue
+        case .draft: return .secondary
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .recording: return "record.circle"
+        case .processing: return "gearshape"
+        case .ready: return "checkmark.circle"
+        case .needsNotes: return "doc.badge.ellipsis"
+        case .draft: return "circle.dashed"
+        }
+    }
+
+    /// Whether deleting this meeting is safe. Recording and processing meetings
+    /// have active capture / notes work that owns the row and directory, so
+    /// removing them out from under that work is blocked.
+    var isDeletable: Bool {
+        switch self {
+        case .recording, .processing: return false
+        case .ready, .needsNotes, .draft: return true
+        }
+    }
+}
+
+/// Small colored status pill for sidebar rows.
+struct StatusPill: View {
+    let status: MeetingStatus
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: status.systemImage)
+                .imageScale(.small)
+            Text(status.label)
+        }
+        .font(.caption2.weight(.medium))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(status.color.opacity(0.15))
+        .foregroundStyle(status.color)
+        .clipShape(Capsule())
+    }
+}
+
+/// A trust/metadata chip: icon + label in a subtle pill. Used in the meeting
+/// header to convey on-device, private processing honestly.
+struct TrustChip: View {
+    let systemImage: String
+    let label: String
+    var tint: Color = .secondary
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage).imageScale(.small)
+            Text(label)
+        }
+        .font(.caption)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(tint.opacity(0.12))
+        .foregroundStyle(tint)
+        .clipShape(Capsule())
+    }
+}
+
+/// The honest local-first trust strip: "Local · Private · your data stays on
+/// this Mac".
+struct TrustStrip: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "lock.shield")
+            Text("Local · Private · your data stays on this Mac")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/FlowLayout.swift
+++ b/apps/Panops/Sources/Panops/Views/FlowLayout.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Wrapping flow layout: lays children left-to-right and wraps to a new row
+/// when the next child would overflow the available width. Used for tag pills
+/// and trust chips so a long list wraps instead of clipping.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    var lineSpacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = resolvedWidth(proposal.width, subviews: subviews)
+        let rows = computeRows(maxWidth: maxWidth, subviews: subviews)
+        let width: CGFloat
+        if let proposed = proposal.width, proposed.isFinite {
+            width = proposed
+        } else {
+            width = rows.map(\.width).max() ?? 0
+        }
+        let height = rows.reduce(0) { $0 + $1.height } + lineSpacing * CGFloat(max(0, rows.count - 1))
+        return CGSize(width: width, height: height)
+    }
+
+    /// Resolve a finite wrapping width. When the parent offers an unconstrained
+    /// (nil or infinite) width, fall back to the widest subview so rows still
+    /// wrap instead of laying every child on one unbounded line.
+    private func resolvedWidth(_ proposed: CGFloat?, subviews: Subviews) -> CGFloat {
+        if let proposed, proposed.isFinite { return proposed }
+        return subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let rows = computeRows(maxWidth: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func computeRows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let needed = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            if needed > maxWidth, !current.indices.isEmpty {
+                rows.append(current)
+                current = Row()
+                current.indices = [index]
+                current.width = size.width
+                current.height = size.height
+            } else {
+                current.indices.append(index)
+                current.width = current.indices.count == 1 ? size.width : current.width + spacing + size.width
+                current.height = max(current.height, size.height)
+            }
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/MarkdownText.swift
+++ b/apps/Panops/Sources/Panops/Views/MarkdownText.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// A parsed markdown block. Block-level structure (headings, lists, quotes,
+/// code) is parsed here; inline formatting (**bold**, *italic*, `code`) is
+/// rendered per line via `AttributedString(markdown:)` at display time.
+enum MarkdownBlock: Equatable {
+    case heading(level: Int, text: String)
+    case bullet(text: String)
+    case ordered(number: Int, text: String)
+    case paragraph(text: String)
+    case code(text: String)
+    case quote(text: String)
+}
+
+enum Markdown {
+    /// Strip a leading YAML frontmatter block delimited by a `---` line at the
+    /// very start and the next `---` line. Returns the body unchanged when no
+    /// frontmatter is present. Mirrors what the engine writes into `notes.md`.
+    static func stripFrontmatter(_ source: String) -> String {
+        let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.components(separatedBy: "\n")
+        guard let first = lines.first, first.trimmingCharacters(in: .whitespaces) == "---" else {
+            return source
+        }
+        // Find the closing fence after line 0.
+        for index in 1..<lines.count where lines[index].trimmingCharacters(in: .whitespaces) == "---" {
+            let body = lines[(index + 1)...].joined(separator: "\n")
+            return body.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        // Unterminated frontmatter: return original rather than eating the doc.
+        return source
+    }
+
+    /// Parse markdown text into block-level structure. Consecutive plain lines
+    /// coalesce into a single paragraph; blank lines separate blocks.
+    static func parseBlocks(_ source: String) -> [MarkdownBlock] {
+        let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.components(separatedBy: "\n")
+        var blocks: [MarkdownBlock] = []
+        var paragraph: [String] = []
+        var codeLines: [String] = []
+        var inCode = false
+
+        func flushParagraph() {
+            if !paragraph.isEmpty {
+                blocks.append(.paragraph(text: paragraph.joined(separator: " ")))
+                paragraph.removeAll()
+            }
+        }
+
+        for rawLine in lines {
+            let line = rawLine
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("```") {
+                if inCode {
+                    blocks.append(.code(text: codeLines.joined(separator: "\n")))
+                    codeLines.removeAll()
+                    inCode = false
+                } else {
+                    flushParagraph()
+                    inCode = true
+                }
+                continue
+            }
+            if inCode {
+                codeLines.append(line)
+                continue
+            }
+
+            if trimmed.isEmpty {
+                flushParagraph()
+                continue
+            }
+
+            if let heading = parseHeading(trimmed) {
+                flushParagraph()
+                blocks.append(heading)
+                continue
+            }
+            if let (number, text) = parseOrdered(trimmed) {
+                flushParagraph()
+                blocks.append(.ordered(number: number, text: text))
+                continue
+            }
+            if let bullet = parseBullet(trimmed) {
+                flushParagraph()
+                blocks.append(.bullet(text: bullet))
+                continue
+            }
+            if trimmed.hasPrefix(">") {
+                flushParagraph()
+                let text = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+                blocks.append(.quote(text: text))
+                continue
+            }
+
+            paragraph.append(trimmed)
+        }
+        if inCode, !codeLines.isEmpty {
+            blocks.append(.code(text: codeLines.joined(separator: "\n")))
+        }
+        flushParagraph()
+        return blocks
+    }
+
+    private static func parseHeading(_ trimmed: String) -> MarkdownBlock? {
+        var level = 0
+        for ch in trimmed {
+            if ch == "#" { level += 1 } else { break }
+        }
+        guard level >= 1, level <= 6 else { return nil }
+        let rest = trimmed.dropFirst(level)
+        guard rest.first == " " else { return nil }
+        let text = rest.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return nil }
+        return .heading(level: level, text: text)
+    }
+
+    private static func parseBullet(_ trimmed: String) -> String? {
+        for marker in ["- ", "* ", "+ "] where trimmed.hasPrefix(marker) {
+            return String(trimmed.dropFirst(marker.count)).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    private static func parseOrdered(_ trimmed: String) -> (Int, String)? {
+        var digits = ""
+        var idx = trimmed.startIndex
+        while idx < trimmed.endIndex, trimmed[idx].isNumber {
+            digits.append(trimmed[idx])
+            idx = trimmed.index(after: idx)
+        }
+        guard !digits.isEmpty, let number = Int(digits), idx < trimmed.endIndex else { return nil }
+        let sep = trimmed[idx]
+        guard sep == "." || sep == ")" else { return nil }
+        let afterSep = trimmed.index(after: idx)
+        guard afterSep < trimmed.endIndex, trimmed[afterSep] == " " else { return nil }
+        let text = String(trimmed[trimmed.index(after: afterSep)...]).trimmingCharacters(in: .whitespaces)
+        return (number, text)
+    }
+
+    /// Render a single line of inline markdown, falling back to plain text.
+    static func inlineAttributed(_ source: String) -> AttributedString {
+        if let parsed = try? AttributedString(
+            markdown: source,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        ) {
+            return parsed
+        }
+        return AttributedString(source)
+    }
+}
+
+/// Renders block-structured markdown: headings as styled titles, lists with
+/// bullets/numbers, paragraphs and quotes with inline formatting, code in a
+/// monospaced block. No literal `##` or list markers leak through.
+struct MarkdownBlocksView: View {
+    let markdown: String
+
+    var body: some View {
+        let blocks = Markdown.parseBlocks(markdown)
+        VStack(alignment: .leading, spacing: 8) {
+            // Positional identity: two blocks with identical text must stay
+            // distinct rows, so key on the parse order rather than the content.
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                switch block {
+                case .heading(let level, let text):
+                    Text(text)
+                        .font(headingFont(level))
+                        .fontWeight(.semibold)
+                        .padding(.top, level <= 2 ? 4 : 0)
+                case .bullet(let text):
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("•").foregroundStyle(.secondary)
+                        Text(Markdown.inlineAttributed(text))
+                    }
+                case .ordered(let number, let text):
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("\(number).").foregroundStyle(.secondary).monospacedDigit()
+                        Text(Markdown.inlineAttributed(text))
+                    }
+                case .paragraph(let text):
+                    Text(Markdown.inlineAttributed(text))
+                        .fixedSize(horizontal: false, vertical: true)
+                case .quote(let text):
+                    HStack(spacing: 8) {
+                        Rectangle().fill(Color.secondary.opacity(0.4)).frame(width: 3)
+                        Text(Markdown.inlineAttributed(text))
+                            .italic()
+                            .foregroundStyle(.secondary)
+                    }
+                case .code(let text):
+                    Text(text)
+                        .font(.system(.callout, design: .monospaced))
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.secondary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+        }
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title2
+        case 2: return .title3
+        default: return .headline
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
@@ -1,25 +1,46 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
-/// Container view for a selected meeting's content.
-/// Reads transcript.json, notes.md, and enumerates screenshots/ directory.
-/// Missing files → placeholders (expected when Slice 11 data doesn't exist).
+/// The meeting workspace: a notes-primary, tabbed review experience.
+///
+/// Loads `notes.json` (structured IR, preferred), `notes.md` (markdown
+/// fallback), `transcript.json`, and the `screenshots/` directory for the
+/// selected meeting. A segmented control switches between Notes, Transcript,
+/// and Info. The Notes tab also hosts this meeting's processing / error /
+/// no-notes states, driven by the shared `AppViewModel` notes flow.
 struct MeetingDetailView<Controller: RecordingController & ObservableObject>: View {
     let meeting: Meeting
+    @ObservedObject var vm: AppViewModel
     let recordingController: Controller?
     let onRecordingStarted: (String) async throws -> Void
     let onRecordingStopped: (URL?) async throws -> Void
+
     @State private var transcript: Transcript?
     @State private var notesContent: String?
+    @State private var structuredNotes: StructuredNotes?
     @State private var screenshots: [URL]?
     @State private var isLoading = true
+    @State private var selectedTab: DetailTab = .notes
+    @State private var editedTitle: String = ""
+    @State private var showErrorDetails = false
+    @State private var exportError: String?
+
+    enum DetailTab: String, CaseIterable, Identifiable {
+        case notes = "Notes"
+        case transcript = "Transcript"
+        case info = "Info"
+        var id: String { rawValue }
+    }
 
     init(
         meeting: Meeting,
+        vm: AppViewModel,
         recordingController: Controller? = nil,
         onRecordingStarted: @escaping (String) async throws -> Void = { _ in },
         onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
     ) {
         self.meeting = meeting
+        self.vm = vm
         self.recordingController = recordingController
         self.onRecordingStarted = onRecordingStarted
         self.onRecordingStopped = onRecordingStopped
@@ -27,89 +48,425 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header with meeting info
-            headerView
-            Divider()
-            // Record bar (if controller provided)
-            if let controller = recordingController {
+            header
+            if let controller = recordingController, meeting.endedAt == nil {
+                Divider()
                 RecordBar(
                     controller: controller,
                     meetingId: meeting.id,
                     onRecordingStarted: onRecordingStarted,
                     onRecordingStopped: onRecordingStopped
                 )
-                Divider()
             }
-            // Content sections
-            if isLoading {
-                ProgressView("Loading…")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
-                        // Transcript section
-                        SectionView(title: "Transcript") {
-                            TranscriptView(transcript: transcript)
-                        }
-                        Divider()
-                        // Notes section
-                        SectionView(title: "Notes") {
-                            NotesView(content: notesContent)
-                        }
-                        Divider()
-                        // Screenshots section
-                        SectionView(title: "Screenshots") {
-                            ScreenshotsStripView(urls: screenshots)
-                        }
-                    }
-                    .padding()
+            Divider()
+            Picker("View", selection: $selectedTab) {
+                ForEach(DetailTab.allCases) { tab in
+                    Text(tab.rawValue).tag(tab)
                 }
             }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            Divider()
+
+            switch selectedTab {
+            case .notes: notesTab
+            case .transcript: TranscriptView(transcript: transcript)
+            case .info: infoTab
+            }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task(id: loadToken) { await loadMeetingData() }
+        .onChange(of: meeting.id, initial: true) { _, _ in
+            editedTitle = meeting.title
+        }
+        .alert("Export failed", isPresented: exportErrorPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(exportError ?? "")
+        }
+    }
+
+    private var exportErrorPresented: Binding<Bool> {
+        Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )
     }
 
     private var loadToken: String {
-        "\(meeting.id)|\(meeting.endedAt ?? "")|\(meeting.durationMs ?? 0)"
+        "\(meeting.id)|\(meeting.endedAt ?? "")|\(meeting.durationMs ?? 0)|\(vm.notesReloadTick)"
     }
 
-    private var headerView: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(meeting.title).font(.headline)
-                Text(meeting.startedAt).font(.caption).foregroundStyle(.secondary)
-                if let duration = meeting.durationMs {
-                    Text("Duration: \(formatDuration(duration))")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top) {
+                // Inline-editable title. No rename IPC exists yet, so edits are
+                // local to this session.
+                TextField("Meeting title", text: $editedTitle)
+                    .textFieldStyle(.plain)
+                    .font(.title2.weight(.semibold))
+                    .onSubmit { /* local only until meeting.rename lands */ }
+
+                Spacer(minLength: 12)
+                headerActions
+            }
+
+            Text(metadataLine)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            FlowLayout(spacing: 6, lineSpacing: 6) {
+                ForEach(trustChips) { chip in
+                    TrustChip(systemImage: chip.icon, label: chip.label, tint: chip.tint)
                 }
             }
-            Spacer()
-            Text(meeting.language.uppercased())
-                .font(.caption)
-                .padding(4)
-                .background(Color.secondary.opacity(0.2))
-                .cornerRadius(4)
         }
+        .padding(16)
+    }
+
+    private var headerActions: some View {
+        HStack(spacing: 8) {
+            Button {
+                exportNotes()
+            } label: {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+            .disabled(!hasNotes)
+            .help("Export notes as Markdown")
+
+            Button {
+                vm.openInFinder(path: meeting.dirPath)
+            } label: {
+                Label("Reveal", systemImage: "folder")
+            }
+            .help("Reveal meeting folder in Finder")
+
+            Button {
+                // Sharing is a future, opt-in, local-first feature (post-v0.1); disabled for now.
+            } label: {
+                Label("Share", systemImage: "person.crop.circle.badge.plus")
+            }
+            .disabled(true)
+            .help("Sharing isn't available yet")
+        }
+        .labelStyle(.iconOnly)
+        .buttonStyle(.bordered)
+    }
+
+    // MARK: - Notes tab + states
+
+    @ViewBuilder
+    private var notesTab: some View {
+        if isProcessingThisMeeting {
+            processingView
+        } else if let detail = errorDetailForThisMeeting {
+            errorStateView(kind: detail.kind, message: detail.message)
+        } else if isLoading {
+            ProgressView("Loading…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if hasNotes {
+            NotesView(
+                notes: structuredNotes,
+                markdownFallback: notesContent,
+                meetingDir: meeting.dirPath
+            )
+        } else {
+            noNotesView
+        }
+    }
+
+    private var processingView: some View {
+        let progress = vm.notesProgress
+        return VStack(spacing: 16) {
+            Spacer()
+            if let progress, let current = progress.current, let total = progress.total, total > 0 {
+                ProgressView(value: max(0.0, min(Double(current) / Double(total), 1.0)))
+                    .frame(maxWidth: 320)
+            } else {
+                ProgressView()
+            }
+            Text(progress?.stageLabel ?? "Generating notes…").font(.headline)
+            if let message = progress?.message, !message.isEmpty {
+                Text(message).font(.subheadline).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
     }
 
-    /// Load transcript.json, notes.md, and screenshots from meeting directory.
+    private func errorStateView(kind: String, message: String) -> some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+            Text("Notes generation failed").font(.headline)
+            Text(friendlyError(kind: kind, message: message))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            HStack(spacing: 12) {
+                Button("Retry") {
+                    Task { await vm.generateNotes(for: meeting) }
+                }
+                .buttonStyle(.borderedProminent)
+                Button(showErrorDetails ? "Hide details" : "Show details") {
+                    showErrorDetails.toggle()
+                }
+            }
+            if showErrorDetails {
+                Text("\(kind): \(message)")
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .frame(maxWidth: 420)
+                    .background(Color.secondary.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var noNotesView: some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "doc.text")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+            Text("No notes yet").font(.headline)
+            Text("Generate structured notes from this meeting's audio.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button {
+                Task { await vm.generateNotes(for: meeting) }
+            } label: {
+                Label("Generate Notes", systemImage: "sparkles")
+                    .padding(.horizontal, 6)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            // Only one notes job is tracked at a time; block a second start
+            // (e.g. from another meeting) while one is in flight.
+            .disabled(vm.isNotesJobActive)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Info tab
+
+    private var infoTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                infoRow("Model", transcript?.model)
+                infoRow("Audio file", audioFileName)
+                infoRow("Duration", durationMs.map { MeetingDate.duration(ms: $0) })
+                infoRow("Speakers", speakerSummary)
+                infoRow("Languages", languageSummary)
+                infoRow("Tags", structuredNotes?.frontmatter.tags.isEmpty == false
+                    ? structuredNotes?.frontmatter.tags.joined(separator: ", ")
+                    : nil)
+                infoRow("Template", nonEmpty(structuredNotes?.frontmatter.template))
+                infoRow("Dialect", humanizedDialect)
+                infoRow("Started", startedDate.map { "\(MeetingDate.shortDate($0)) · \(MeetingDate.shortTime($0))" })
+                infoRow("Ended", endedDate.map { "\(MeetingDate.shortDate($0)) · \(MeetingDate.shortTime($0))" })
+                infoRow("panops", nonEmpty(structuredNotes?.frontmatter.panopsVersion))
+            }
+            .padding(16)
+        }
+    }
+
+    @ViewBuilder
+    private func infoRow(_ label: String, _ value: String?) -> some View {
+        if let value, !value.isEmpty {
+            HStack(alignment: .top) {
+                Text(label)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 110, alignment: .leading)
+                Text(value)
+                    .font(.subheadline)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.vertical, 6)
+            Divider()
+        }
+    }
+
+    // MARK: - Derived values
+
+    private var hasNotes: Bool {
+        if structuredNotes != nil { return true }
+        if let md = notesContent, !md.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        return false
+    }
+
+    private var isProcessingThisMeeting: Bool {
+        guard vm.notesGenMeetingId == meeting.id else { return false }
+        if case .working = vm.state { return true }
+        return false
+    }
+
+    private var errorDetailForThisMeeting: (kind: String, message: String)? {
+        guard vm.notesGenMeetingId == meeting.id, case .error(let kind, let message) = vm.state else {
+            return nil
+        }
+        return (kind, message)
+    }
+
+    private var durationMs: UInt64? {
+        if let d = structuredNotes?.frontmatter.durationMs, d > 0 { return d }
+        return meeting.durationMs
+    }
+
+    private var startedDate: Date? {
+        MeetingDate.parse(structuredNotes?.frontmatter.startedAt ?? "")
+            ?? MeetingDate.parse(meeting.startedAt)
+    }
+
+    private var endedDate: Date? {
+        meeting.endedAt.flatMap { MeetingDate.parse($0) }
+    }
+
+    private var speakerCount: Int? {
+        if let speakers = structuredNotes?.frontmatter.speakers, !speakers.isEmpty {
+            return speakers.count
+        }
+        if let segments = transcript?.segments {
+            let ids = Set(segments.compactMap { $0.speakerId })
+            return ids.isEmpty ? nil : ids.count
+        }
+        return nil
+    }
+
+    private var speakerSummary: String? {
+        if let speakers = structuredNotes?.frontmatter.speakers, !speakers.isEmpty {
+            return speakers.joined(separator: ", ")
+        }
+        if let count = speakerCount { return "\(count)" }
+        return nil
+    }
+
+    private var languageSummary: String? {
+        if let langs = structuredNotes?.frontmatter.languages, !langs.isEmpty {
+            return langs.map { $0.uppercased() }.joined(separator: ", ")
+        }
+        return nonEmpty(meeting.language).map { $0.uppercased() }
+    }
+
+    private var audioFileName: String? {
+        if let path = transcript?.audioPath, !path.isEmpty {
+            return (path as NSString).lastPathComponent
+        }
+        return structuredNotes?.frontmatter.sourceAudio.map { ($0 as NSString).lastPathComponent }
+    }
+
+    private var humanizedDialect: String? {
+        guard let dialect = structuredNotes?.frontmatter.dialect, !dialect.isEmpty else { return nil }
+        return dialect
+            .split(separator: "-")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    private var metadataLine: String {
+        var parts: [String] = []
+        if let date = startedDate {
+            parts.append(MeetingDate.shortDate(date))
+            parts.append(MeetingDate.shortTime(date))
+        }
+        if let ms = durationMs, ms > 0 { parts.append(MeetingDate.duration(ms: ms)) }
+        if let lang = languageSummary { parts.append(lang) }
+        if let count = speakerCount { parts.append(count == 1 ? "1 speaker" : "\(count) speakers") }
+        return parts.isEmpty ? "Meeting" : parts.joined(separator: " · ")
+    }
+
+    private struct ChipData: Identifiable {
+        let id = UUID()
+        let icon: String
+        let label: String
+        let tint: Color
+    }
+
+    private var trustChips: [ChipData] {
+        var chips: [ChipData] = [
+            ChipData(icon: "cpu", label: "Local", tint: .green),
+            ChipData(icon: "lock", label: "Private", tint: .green),
+        ]
+        if transcript != nil || audioFileName != nil {
+            chips.append(ChipData(icon: "waveform", label: "Audio", tint: .secondary))
+        }
+        if let count = screenshots?.count, count > 0 {
+            chips.append(ChipData(icon: "photo", label: count == 1 ? "1 screenshot" : "\(count) screenshots", tint: .secondary))
+        }
+        if let lang = languageSummary {
+            chips.append(ChipData(icon: "globe", label: lang, tint: .secondary))
+        }
+        return chips
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        return value
+    }
+
+    private func friendlyError(kind: String, message: String) -> String {
+        if kind == "no_audio" { return message }
+        return "Something went wrong while generating notes. You can retry or check the details."
+    }
+
+    // MARK: - Export
+
+    private func exportNotes() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "\(editedTitle.isEmpty ? meeting.title : editedTitle).md"
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        guard panel.runModal() == .OK, let dest = panel.url else { return }
+
+        // Prefer the already-loaded markdown; otherwise read notes.md from disk.
+        var data = notesContent.map { Data($0.utf8) }
+        if data == nil {
+            let src = (meeting.dirPath as NSString).appendingPathComponent("notes.md")
+            if PathValidator.isPath(src, under: meeting.dirPath) {
+                data = FileManager.default.contents(atPath: src)
+            }
+        }
+        guard let data else { return }
+        do {
+            try data.write(to: dest)
+        } catch {
+            AppViewModel.logFullError("notes.export", error)
+            exportError = "Couldn't save notes to \(dest.lastPathComponent). \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Loading
+
     private func loadMeetingData() async {
-        // Reset all detail state at start to avoid stale data on meeting switch
         transcript = nil
         notesContent = nil
+        structuredNotes = nil
         screenshots = nil
         isLoading = true
 
         let dirPath = meeting.dirPath
 
-        // Read + JSON-decode off the MainActor: transcript.json can be large for
-        // long meetings, and a sync read+decode on the main thread hitches the UI
-        // on every meeting selection (same hazard as ThumbnailView.loadImage).
-        let loaded = await Task.detached(priority: .utility) { () -> (Transcript?, String?, [URL]?) in
+        // Read + decode off the MainActor: transcript.json / notes.json can be
+        // large, and a sync read+decode on the main thread hitches the UI on
+        // every meeting switch.
+        let loaded = await Task.detached(priority: .utility) {
+            () -> (Transcript?, String?, StructuredNotes?, [URL]?) in
             var t: Transcript?
-            var notes: String?
+            var notesMd: String?
+            var notesJson: StructuredNotes?
             var shots: [URL]?
 
             let transcriptPath = (dirPath as NSString).appendingPathComponent("transcript.json")
@@ -119,10 +476,17 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
                 t = try? JSONDecoder().decode(Transcript.self, from: data)
             }
 
-            let notesPath = (dirPath as NSString).appendingPathComponent("notes.md")
-            if PathValidator.isPath(notesPath, under: dirPath),
-               FileManager.default.fileExists(atPath: notesPath) {
-                notes = try? String(contentsOfFile: notesPath, encoding: .utf8)
+            let notesJsonPath = (dirPath as NSString).appendingPathComponent("notes.json")
+            if PathValidator.isPath(notesJsonPath, under: dirPath),
+               FileManager.default.fileExists(atPath: notesJsonPath),
+               let data = FileManager.default.contents(atPath: notesJsonPath) {
+                notesJson = try? JSONDecoder().decode(StructuredNotes.self, from: data)
+            }
+
+            let notesMdPath = (dirPath as NSString).appendingPathComponent("notes.md")
+            if PathValidator.isPath(notesMdPath, under: dirPath),
+               FileManager.default.fileExists(atPath: notesMdPath) {
+                notesMd = try? String(contentsOfFile: notesMdPath, encoding: .utf8)
             }
 
             let screenshotsPath = (dirPath as NSString).appendingPathComponent("screenshots")
@@ -138,39 +502,38 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
                     }
                     .sorted { $0.lastPathComponent < $1.lastPathComponent }
             }
-            return (t, notes, shots)
+            return (t, notesMd, notesJson, shots)
         }.value
 
-        // The .task(id:) cancels on meeting switch, but the detached read still
-        // returns — bail so a slow load for the previous meeting can't overwrite
-        // the newly-selected one's detail.
         guard !Task.isCancelled else { return }
 
         transcript = loaded.0
         notesContent = loaded.1
-        screenshots = loaded.2
+        structuredNotes = loaded.2
+        screenshots = loaded.3
         isLoading = false
-    }
-
-    private func formatDuration(_ ms: UInt64) -> String {
-        let totalSec = ms / 1000
-        let min = totalSec / 60
-        let sec = totalSec % 60
-        return "\(min)m \(sec)s"
     }
 }
 
-/// Section wrapper with title header.
-struct SectionView<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: () -> Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.headline)
-                .foregroundStyle(.primary)
-            content()
+extension JobProgressEvent {
+    /// Human-facing label for a notes-generation stage.
+    var stageLabel: String {
+        switch stage {
+        case "loading":
+            return "Loading audio…"
+        case "transcribing":
+            if let current, let total {
+                return "Transcribing \(current)/\(total)…"
+            }
+            return "Transcribing…"
+        case "diarizing":
+            return "Identifying speakers…"
+        case "generating_notes":
+            return "Writing notes…"
+        case "exporting":
+            return "Saving…"
+        default:
+            return "Generating notes…"
         }
     }
 }

--- a/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingDetailView.swift
@@ -396,9 +396,19 @@ struct MeetingDetailView<Controller: RecordingController & ObservableObject>: Vi
         let tint: Color
     }
 
+    /// The Processing chip reflects the engine's resolved LLM provider so the
+    /// trust strip never claims "Local" when the engine actually resolved to a
+    /// cloud model. Mirrors the toolbar's LlmProviderChip (both read llmInfo).
+    private var processingChip: ChipData {
+        if let info = vm.llmInfo, !info.local {
+            return ChipData(icon: "cloud", label: "Cloud", tint: .orange)
+        }
+        return ChipData(icon: "cpu", label: "Local", tint: .green)
+    }
+
     private var trustChips: [ChipData] {
         var chips: [ChipData] = [
-            ChipData(icon: "cpu", label: "Local", tint: .green),
+            processingChip,
             ChipData(icon: "lock", label: "Private", tint: .green),
         ]
         if transcript != nil || audioFileName != nil {

--- a/apps/Panops/Sources/Panops/Views/MeetingListView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingListView.swift
@@ -1,33 +1,187 @@
 import SwiftUI
 
-/// Sidebar showing meetings from meeting.list.
-/// Slice 12 implementation per spec D1.
+/// Sidebar: meetings grouped by day (Today / Yesterday / dated), with rich rows
+/// (title, time, duration, language badge, status pill), a search field, and a
+/// context-menu delete. Selection drives the detail workspace.
 struct MeetingListView: View {
     @ObservedObject var vm: AppViewModel
+    @State private var searchText = ""
 
     var body: some View {
-        List(selection: $vm.selectedMeetingId) {
-            if vm.meetings.isEmpty {
-                Text("No meetings yet").foregroundStyle(.secondary)
-            } else {
-                ForEach(vm.meetings, id: \.id) { meeting in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(meeting.title).font(.headline)
-                        Text(meeting.startedAt).font(.caption).foregroundStyle(.secondary)
-                    }
-                    .tag(meeting.id)
-                }
-            }
+        VStack(spacing: 0) {
+            searchBar
+            Divider()
+            content
         }
         .toolbar {
             ToolbarItem {
-                Button("Refresh") {
+                Button {
                     Task { await vm.refreshMeetings() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
                 }
+                .help("Refresh meetings")
             }
         }
         .task {
             await vm.refreshMeetings()
         }
+    }
+
+    private var searchBar: some View {
+        SearchField(placeholder: "Search meetings", text: $searchText)
+            .padding(8)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if vm.meetings.isEmpty {
+            placeholder("No meetings yet")
+        } else {
+            let sections = groupedSections
+            if sections.isEmpty {
+                placeholder("No matches")
+            } else {
+                List(selection: $vm.selectedMeetingId) {
+                    ForEach(sections) { section in
+                        Section(section.title) {
+                            ForEach(section.meetings, id: \.id) { meeting in
+                                let status = vm.status(for: meeting)
+                                MeetingRow(meeting: meeting, status: status)
+                                    .tag(meeting.id)
+                                    .contextMenu {
+                                        Button(role: .destructive) {
+                                            Task { await vm.deleteMeeting(id: meeting.id) }
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                        // Don't delete a meeting whose capture or
+                                        // notes work is still in flight.
+                                        .disabled(!status.isDeletable)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func placeholder(_ text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text).foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Filtering / grouping
+
+    private var filteredMeetings: [MeetingSummary] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return vm.meetings }
+        return vm.meetings.filter { meeting in
+            if meeting.title.lowercased().contains(query) { return true }
+            if meeting.language.lowercased().contains(query) { return true }
+            if meeting.startedAt.lowercased().contains(query) { return true }
+            if let date = MeetingDate.parse(meeting.startedAt),
+               MeetingDate.shortDate(date).lowercased().contains(query) { return true }
+            return false
+        }
+    }
+
+    private struct MeetingSection: Identifiable {
+        let id: String
+        let title: String
+        let sortKey: Date
+        let meetings: [MeetingSummary]
+    }
+
+    private var groupedSections: [MeetingSection] {
+        let calendar = Calendar.current
+        var buckets: [Date: [MeetingSummary]] = [:]
+        var undated: [MeetingSummary] = []
+
+        for meeting in filteredMeetings {
+            if let date = MeetingDate.parse(meeting.startedAt) {
+                buckets[calendar.startOfDay(for: date), default: []].append(meeting)
+            } else {
+                undated.append(meeting)
+            }
+        }
+
+        func sortedByStartDescending(_ items: [MeetingSummary]) -> [MeetingSummary] {
+            items.sorted { lhs, rhs in
+                let l = MeetingDate.parse(lhs.startedAt) ?? .distantPast
+                let r = MeetingDate.parse(rhs.startedAt) ?? .distantPast
+                return l > r
+            }
+        }
+
+        var sections = buckets.map { day, items in
+            MeetingSection(
+                id: ISO8601DateFormatter().string(from: day),
+                title: MeetingDate.dayLabel(day),
+                sortKey: day,
+                meetings: sortedByStartDescending(items)
+            )
+        }
+        sections.sort { $0.sortKey > $1.sortKey }
+
+        if !undated.isEmpty {
+            sections.append(
+                MeetingSection(
+                    id: "undated",
+                    title: "Earlier",
+                    sortKey: .distantPast,
+                    meetings: undated
+                )
+            )
+        }
+        return sections
+    }
+}
+
+/// A rich sidebar row: title + status pill, then time · duration · language.
+struct MeetingRow: View {
+    let meeting: MeetingSummary
+    let status: MeetingStatus
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(meeting.title.isEmpty ? "Untitled meeting" : meeting.title)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                StatusPill(status: status)
+            }
+            HStack(spacing: 6) {
+                Text(metaLine)
+                if !meeting.language.isEmpty {
+                    Text(meeting.language.uppercased())
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var metaLine: String {
+        var parts: [String] = []
+        if let date = MeetingDate.parse(meeting.startedAt) {
+            parts.append(MeetingDate.shortTime(date))
+        }
+        if meeting.durationMs > 0 {
+            parts.append(MeetingDate.duration(ms: meeting.durationMs))
+        }
+        return parts.joined(separator: " · ")
     }
 }

--- a/apps/Panops/Sources/Panops/Views/NotesView.swift
+++ b/apps/Panops/Sources/Panops/Views/NotesView.swift
@@ -1,34 +1,140 @@
 import SwiftUI
 
-/// Presentational view rendering markdown notes.
-/// Uses AttributedString(markdown:) for rendering.
-/// Falls back to raw text on parse failure.
-/// Empty/nil → placeholder.
+/// Renders meeting notes as a clean document.
+///
+/// Preferred path: a decoded `StructuredNotes` IR (`notes.json`) — rendered as
+/// sections with narrative, key points, action items, screenshots, and a tag
+/// row. No raw markdown, no YAML.
+///
+/// Fallback: a `notes.md` string — the leading YAML frontmatter is stripped and
+/// the body is rendered with block structure (headings become styled titles).
+///
+/// Neither present → placeholder.
 struct NotesView: View {
-    let content: String?
+    let notes: StructuredNotes?
+    let markdownFallback: String?
+    let meetingDir: String
+
+    init(notes: StructuredNotes?, markdownFallback: String?, meetingDir: String = "") {
+        self.notes = notes
+        self.markdownFallback = markdownFallback
+        self.meetingDir = meetingDir
+    }
+
+    /// Convenience for markdown-only callers (legacy `NotesView(content:)`).
+    init(content: String?) {
+        self.init(notes: nil, markdownFallback: content, meetingDir: "")
+    }
 
     var body: some View {
-        if let md = content, !md.isEmpty {
+        if let notes {
+            structuredDocument(notes)
+        } else if let md = markdownFallback, !md.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             ScrollView {
-                if let rendered = try? AttributedString(
-                    markdown: md,
-                    options: AttributedString.MarkdownParsingOptions(
-                        interpretedSyntax: .inlineOnlyPreservingWhitespace
-                    )
-                ) {
-                    Text(rendered)
-                        .textSelection(.enabled)
-                        .padding()
-                } else {
-                    // Fallback: show raw text
-                    Text(md)
-                        .textSelection(.enabled)
-                        .font(.system(.body, design: .monospaced))
-                        .padding()
-                }
+                MarkdownBlocksView(markdown: Markdown.stripFrontmatter(md))
+                    .padding(20)
             }
         } else {
             placeholder
+        }
+    }
+
+    @ViewBuilder
+    private func structuredDocument(_ notes: StructuredNotes) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                ForEach(notes.sections) { section in
+                    sectionView(section)
+                }
+                if !notes.frontmatter.tags.isEmpty {
+                    tagRow(notes.frontmatter.tags)
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func sectionView(_ section: NotesSection) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if isMeaningfulTitle(section.title) {
+                Text(section.title)
+                    .font(.title3)
+                    .fontWeight(.bold)
+            }
+
+            if !section.narrativeMd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                MarkdownBlocksView(markdown: section.narrativeMd)
+            }
+
+            if !section.keyPoints.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Key points", systemImage: "star")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    ForEach(Array(section.keyPoints.enumerated()), id: \.offset) { _, point in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text("•").foregroundStyle(.secondary)
+                            Text(Markdown.inlineAttributed(point))
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+            }
+
+            if !section.actionItems.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Action items", systemImage: "checklist")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    ForEach(section.actionItems) { item in
+                        ActionItemRow(item: item)
+                    }
+                }
+            }
+
+            let shots = resolvedScreenshots(section.screenshots)
+            if !shots.isEmpty {
+                ScreenshotsStripView(urls: shots)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func tagRow(_ tags: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            FlowLayout(spacing: 8, lineSpacing: 8) {
+                ForEach(Array(tags.enumerated()), id: \.offset) { _, tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Color.accentColor.opacity(0.12))
+                        .foregroundStyle(Color.accentColor)
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+
+    private func isMeaningfulTitle(_ title: String) -> Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Resolve screenshot IR paths (relative to the meeting dir or absolute)
+    /// into validated file URLs under the meeting dir.
+    private func resolvedScreenshots(_ screenshots: [Screenshot]) -> [URL] {
+        guard !meetingDir.isEmpty else { return [] }
+        return screenshots.compactMap { shot -> URL? in
+            guard !shot.path.isEmpty else { return nil }
+            let candidate = shot.path.hasPrefix("/")
+                ? shot.path
+                : (meetingDir as NSString).appendingPathComponent(shot.path)
+            guard PathValidator.isPath(candidate, under: meetingDir),
+                  FileManager.default.fileExists(atPath: candidate) else { return nil }
+            return URL(fileURLWithPath: candidate)
         }
     }
 
@@ -38,5 +144,43 @@ struct NotesView: View {
             Text("No notes").foregroundStyle(.secondary)
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// A single action item rendered as a checkbox row. The checkbox is visual only
+/// (local state, not persisted) per the structured-notes IR having no done flag.
+private struct ActionItemRow: View {
+    let item: ActionItem
+    @State private var done = false
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Button {
+                done.toggle()
+            } label: {
+                Image(systemName: done ? "checkmark.square.fill" : "square")
+                    .foregroundStyle(done ? Color.accentColor : Color.secondary)
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(Markdown.inlineAttributed(item.description))
+                    .strikethrough(done, color: .secondary)
+                    .textSelection(.enabled)
+                if let detail = metaLine {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var metaLine: String? {
+        var parts: [String] = []
+        if let owner = item.owner, !owner.isEmpty { parts.append(owner) }
+        if let due = item.due, !due.isEmpty { parts.append("due \(due)") }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 }

--- a/apps/Panops/Sources/Panops/Views/SearchField.swift
+++ b/apps/Panops/Sources/Panops/Views/SearchField.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// A search input row: a magnifying-glass icon, a plain text field, and a
+/// clear button that appears once there's text. Outer padding / background
+/// styling is left to the call site so it can sit bare in the sidebar or
+/// inside a rounded pill.
+struct SearchField: View {
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/TranscriptView.swift
+++ b/apps/Panops/Sources/Panops/Views/TranscriptView.swift
@@ -1,34 +1,167 @@
 import SwiftUI
 
-/// Presentational view rendering transcript segments.
-/// Shows `[MM:SS–MM:SS] Speaker X: text` per segment.
-/// Empty/nil → "No transcript" placeholder.
+/// Speaker-grouped, readable transcript.
+///
+/// Consecutive segments from the same speaker collapse into one block with the
+/// speaker label shown once, a block timestamp, and the spoken text. A search
+/// field filters segments by text; a speaker menu filters by speaker (when the
+/// transcript is diarized into more than one speaker).
 struct TranscriptView: View {
     let transcript: Transcript?
 
+    @State private var searchText = ""
+    @State private var speakerFilter: String? = nil  // nil == All Speakers
+
     var body: some View {
-        if let t = transcript, !t.segments.isEmpty {
+        Group {
+            if let t = transcript, !t.segments.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    controlBar(distinctSpeakers: distinctSpeakers(t.segments))
+                    Divider()
+                    transcriptBody(blocks: blocks(from: t.segments))
+                }
+            } else {
+                placeholder
+            }
+        }
+        // Switching meetings reuses this view's @State; clear the speaker filter
+        // so a speaker from the previous meeting can't strand the new transcript
+        // on "No matching segments".
+        .onChange(of: transcript?.audioPath) { _, _ in
+            speakerFilter = nil
+        }
+    }
+
+    // MARK: - Controls
+
+    @ViewBuilder
+    private func controlBar(distinctSpeakers: [String]) -> some View {
+        HStack(spacing: 12) {
+            SearchField(placeholder: "Search transcript", text: $searchText)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(Color.secondary.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 7))
+
+            if distinctSpeakers.count > 1 {
+                Menu {
+                    Button("All Speakers") { speakerFilter = nil }
+                    Divider()
+                    ForEach(distinctSpeakers, id: \.self) { speaker in
+                        Button(speaker) { speakerFilter = speaker }
+                    }
+                } label: {
+                    Label(speakerFilter ?? "All Speakers", systemImage: "person.2")
+                        .lineLimit(1)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private func transcriptBody(blocks: [SpeakerBlock]) -> some View {
+        if blocks.isEmpty {
+            VStack {
+                Spacer()
+                Text("No matching segments").foregroundStyle(.secondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 8) {
-                    ForEach(t.segments, id: \.self) { seg in
-                        HStack(alignment: .top, spacing: 8) {
-                            Text(seg.timestampRange)
-                                .font(.system(.body, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                            if let speakerLabel = seg.speakerLabel {
-                                Text(speakerLabel + ":")
-                                    .fontWeight(.medium)
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(blocks) { block in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 8) {
+                                if let label = block.speakerLabel {
+                                    Text(label)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                                Text(timestamp(block.startMs))
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
                             }
-                            Text(seg.text)
+                            Text(block.text)
                                 .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
-                .padding()
+                .padding(16)
             }
-        } else {
-            placeholder
         }
+    }
+
+    // MARK: - Grouping / filtering
+
+    private struct SpeakerBlock: Identifiable {
+        let id: Int
+        let speakerLabel: String?
+        let startMs: UInt64
+        let text: String
+    }
+
+    private func filteredSegments(_ segments: [TranscriptSegment]) -> [TranscriptSegment] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return segments.filter { segment in
+            if let filter = speakerFilter, segment.speakerLabel != filter { return false }
+            if !query.isEmpty, !segment.text.lowercased().contains(query) { return false }
+            return true
+        }
+    }
+
+    private func blocks(from segments: [TranscriptSegment]) -> [SpeakerBlock] {
+        let filtered = filteredSegments(segments)
+        var result: [SpeakerBlock] = []
+        var currentLabel: String??  // double optional: unset vs (nil speaker)
+        var currentTexts: [String] = []
+        var currentStart: UInt64 = 0
+        var blockIndex = 0
+
+        func flush() {
+            guard let label = currentLabel, !currentTexts.isEmpty else { return }
+            let text = currentTexts.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+            result.append(SpeakerBlock(id: blockIndex, speakerLabel: label, startMs: currentStart, text: text))
+            blockIndex += 1
+            currentTexts = []
+        }
+
+        for segment in filtered {
+            if let existing = currentLabel, existing == segment.speakerLabel {
+                currentTexts.append(segment.text)
+            } else {
+                flush()
+                currentLabel = segment.speakerLabel
+                currentStart = segment.startMs
+                currentTexts = [segment.text]
+            }
+        }
+        flush()
+        return result
+    }
+
+    private func distinctSpeakers(_ segments: [TranscriptSegment]) -> [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for segment in segments {
+            if let label = segment.speakerLabel, !seen.contains(label) {
+                seen.insert(label)
+                ordered.append(label)
+            }
+        }
+        return ordered
+    }
+
+    private func timestamp(_ ms: UInt64) -> String {
+        let totalSec = ms / 1000
+        let minutes = totalSec / 60
+        let seconds = totalSec % 60
+        return "\(minutes):\(String(format: "%02d", seconds))"
     }
 
     private var placeholder: some View {
@@ -37,5 +170,6 @@ struct TranscriptView: View {
             Text("No transcript").foregroundStyle(.secondary)
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
+++ b/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("Markdown helpers")
+struct MarkdownTests {
+    @Test("stripFrontmatter removes leading YAML block")
+    func stripsFrontmatter() {
+        let src = """
+        ---
+        title: Team sync
+        date: 2026-06-05
+        ---
+        # Summary
+        Body text.
+        """
+        let body = Markdown.stripFrontmatter(src)
+        #expect(!body.contains("title: Team sync"))
+        #expect(body.hasPrefix("# Summary"))
+    }
+
+    @Test("stripFrontmatter leaves body without frontmatter untouched")
+    func noFrontmatter() {
+        let src = "# Summary\nBody text."
+        #expect(Markdown.stripFrontmatter(src) == src)
+    }
+
+    @Test("stripFrontmatter leaves unterminated frontmatter untouched")
+    func unterminatedFrontmatter() {
+        let src = "---\ntitle: oops\nno closing fence"
+        #expect(Markdown.stripFrontmatter(src) == src)
+    }
+
+    @Test("parseBlocks classifies headings, bullets, ordered, paragraphs")
+    func parsesBlocks() {
+        let src = """
+        # Heading one
+        A paragraph line
+        spanning two lines.
+
+        - bullet a
+        - bullet b
+        1. first
+        2) second
+        > a quote
+        """
+        let blocks = Markdown.parseBlocks(src)
+        #expect(blocks.contains(.heading(level: 1, text: "Heading one")))
+        #expect(blocks.contains(.paragraph(text: "A paragraph line spanning two lines.")))
+        #expect(blocks.contains(.bullet(text: "bullet a")))
+        #expect(blocks.contains(.bullet(text: "bullet b")))
+        #expect(blocks.contains(.ordered(number: 1, text: "first")))
+        #expect(blocks.contains(.ordered(number: 2, text: "second")))
+        #expect(blocks.contains(.quote(text: "a quote")))
+    }
+
+    @Test("parseBlocks captures fenced code verbatim")
+    func parsesCode() {
+        let src = """
+        intro
+
+        ```
+        let x = 1
+        let y = 2
+        ```
+        """
+        let blocks = Markdown.parseBlocks(src)
+        #expect(blocks.contains(.code(text: "let x = 1\nlet y = 2")))
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/MeetingStatusTests.swift
+++ b/apps/Panops/Tests/PanopsTests/MeetingStatusTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@MainActor
+@Suite("Meeting status derivation")
+struct MeetingStatusTests {
+    private func makeViewModel() -> AppViewModel {
+        // status(for:) never touches the client; a dummy socket path is fine.
+        AppViewModel(client: IpcClient(socketPath: URL(fileURLWithPath: "/tmp/panops-test.sock")))
+    }
+
+    private func summary(
+        id: String = "m-1",
+        endedAt: String? = nil,
+        hasNotes: Bool = false,
+        durationMs: UInt64 = 1000
+    ) -> MeetingSummary {
+        MeetingSummary(
+            id: id,
+            title: "Meeting",
+            startedAt: "2026-06-05T10:00:00Z",
+            durationMs: durationMs,
+            language: "en",
+            endedAt: endedAt,
+            hasNotes: hasNotes
+        )
+    }
+
+    @Test("active recording wins")
+    func recording() {
+        let vm = makeViewModel()
+        vm.activeRecordingMeetingId = "m-1"
+        #expect(vm.status(for: summary()) == .recording)
+    }
+
+    @Test("in-flight notes generation reads as processing")
+    func processing() {
+        let vm = makeViewModel()
+        vm.notesGenMeetingId = "m-1"
+        vm.state = .working(meetingId: "m-1", audioName: "a.wav")
+        #expect(vm.status(for: summary(hasNotes: false)) == .processing)
+    }
+
+    @Test("has_notes reads as ready")
+    func ready() {
+        let vm = makeViewModel()
+        #expect(vm.status(for: summary(endedAt: "2026-06-05T10:30:00Z", hasNotes: true)) == .ready)
+    }
+
+    @Test("ended without notes reads as needs notes")
+    func needsNotes() {
+        let vm = makeViewModel()
+        #expect(vm.status(for: summary(endedAt: "2026-06-05T10:30:00Z", hasNotes: false)) == .needsNotes)
+    }
+
+    @Test("open meeting with no notes and no duration reads as draft")
+    func draft() {
+        let vm = makeViewModel()
+        #expect(vm.status(for: summary(endedAt: nil, hasNotes: false, durationMs: 0)) == .draft)
+    }
+
+    @Test("old payload lacking ended_at but with a duration reads as needs notes")
+    func endedWithoutEndedAtFallsBackOnDuration() {
+        let vm = makeViewModel()
+        #expect(vm.status(for: summary(endedAt: nil, hasNotes: false, durationMs: 60_000)) == .needsNotes)
+    }
+}
+
+@Suite("Meeting deletion guard")
+struct MeetingDeletionGuardTests {
+    @Test("recording and processing meetings are not deletable")
+    func blockedStatuses() {
+        #expect(MeetingStatus.recording.isDeletable == false)
+        #expect(MeetingStatus.processing.isDeletable == false)
+    }
+
+    @Test("ready, needs-notes, and draft meetings are deletable")
+    func allowedStatuses() {
+        #expect(MeetingStatus.ready.isDeletable == true)
+        #expect(MeetingStatus.needsNotes.isDeletable == true)
+        #expect(MeetingStatus.draft.isDeletable == true)
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/StructuredNotesTests.swift
+++ b/apps/Panops/Tests/PanopsTests/StructuredNotesTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("StructuredNotes decoding")
+struct StructuredNotesTests {
+    @Test("StructuredNotes decodes engine-shaped notes.json")
+    func decodesFullNotesJson() throws {
+        let json = #"""
+        {
+          "schema_version": 1,
+          "language": "en",
+          "generated_at": "2026-06-05T10:01:00Z",
+          "frontmatter": {
+            "title": "Team sync",
+            "date": "2026-06-05",
+            "started_at": "2026-06-05T10:00:00+00:00",
+            "duration_ms": 1800000,
+            "speakers": ["Speaker 1", "Speaker 2"],
+            "languages": ["en", "es"],
+            "tags": ["planning", "q3"],
+            "template": "default",
+            "dialect": "notion-enhanced",
+            "panops_version": "0.1.0",
+            "source_audio": "system.wav"
+          },
+          "sections": [
+            {
+              "index": 1,
+              "title": "Intro",
+              "time_range_ms": [0, 600000],
+              "narrative_md": "We **kicked off** the sync.\n\n## Topics\n- one\n- two",
+              "key_points": ["Aligned on scope", "Picked owners"],
+              "action_items": [
+                { "description": "Draft the brief", "owner": "Fran", "due": "2026-06-10" },
+                { "description": "Book the room", "owner": null }
+              ],
+              "screenshots": [
+                { "ms_since_start": 120000, "path": "screenshots/shot-1.png", "caption": "Slide" }
+              ]
+            }
+          ]
+        }
+        """#
+
+        let notes = try JSONDecoder().decode(StructuredNotes.self, from: Data(json.utf8))
+
+        #expect(notes.schemaVersion == 1)
+        #expect(notes.language == "en")
+        #expect(notes.frontmatter.title == "Team sync")
+        #expect(notes.frontmatter.speakers.count == 2)
+        #expect(notes.frontmatter.languages == ["en", "es"])
+        #expect(notes.frontmatter.tags == ["planning", "q3"])
+        #expect(notes.frontmatter.dialect == "notion-enhanced")
+        #expect(notes.frontmatter.sourceAudio == "system.wav")
+
+        #expect(notes.sections.count == 1)
+        let section = notes.sections[0]
+        #expect(section.title == "Intro")
+        #expect(section.timeRangeMs == [0, 600000])
+        #expect(section.keyPoints.count == 2)
+        #expect(section.actionItems.count == 2)
+        #expect(section.actionItems[0].owner == "Fran")
+        #expect(section.actionItems[0].due == "2026-06-10")
+        #expect(section.actionItems[1].owner == nil)
+        #expect(section.screenshots.count == 1)
+        #expect(section.screenshots[0].path == "screenshots/shot-1.png")
+        #expect(section.screenshots[0].msSinceStart == 120000)
+    }
+
+    @Test("StructuredNotes decodes leniently when optional fields are absent")
+    func decodesLenient() throws {
+        // Minimal frontmatter, no sections, no source_audio, no captions.
+        let json = #"""
+        {
+          "schema_version": 1,
+          "language": "es",
+          "generated_at": "2026-06-05T10:01:00Z",
+          "frontmatter": {
+            "title": "Quick call",
+            "date": "2026-06-05",
+            "started_at": "2026-06-05T10:00:00+00:00",
+            "duration_ms": 60000,
+            "speakers": [],
+            "languages": ["es"],
+            "tags": [],
+            "template": "default",
+            "dialect": "basic",
+            "panops_version": "0.1.0"
+          },
+          "sections": []
+        }
+        """#
+
+        let notes = try JSONDecoder().decode(StructuredNotes.self, from: Data(json.utf8))
+        #expect(notes.frontmatter.sourceAudio == nil)
+        #expect(notes.sections.isEmpty)
+        #expect(notes.frontmatter.dialect == "basic")
+    }
+}
+
+@Suite("MeetingSummary lenient fields")
+struct MeetingSummaryLenientTests {
+    @Test("MeetingSummary decodes new fields when present")
+    func decodesNewFields() throws {
+        let json = #"""
+        {
+          "id": "m-1",
+          "title": "Sync",
+          "started_at": "2026-06-05T10:00:00Z",
+          "duration_ms": 1800000,
+          "language": "en",
+          "ended_at": "2026-06-05T10:30:00Z",
+          "has_notes": true
+        }
+        """#
+        let summary = try JSONDecoder().decode(MeetingSummary.self, from: Data(json.utf8))
+        #expect(summary.language == "en")
+        #expect(summary.endedAt == "2026-06-05T10:30:00Z")
+        #expect(summary.hasNotes == true)
+    }
+
+    @Test("MeetingSummary defaults new fields when absent (old wire shape)")
+    func defaultsWhenAbsent() throws {
+        let json = #"""
+        {
+          "id": "m-2",
+          "title": "Old shape",
+          "started_at": "2026-06-05T09:00:00Z",
+          "duration_ms": 1000
+        }
+        """#
+        let summary = try JSONDecoder().decode(MeetingSummary.self, from: Data(json.utf8))
+        #expect(summary.language == "")
+        #expect(summary.endedAt == nil)
+        #expect(summary.hasNotes == false)
+    }
+}


### PR DESCRIPTION
Turns the Mac app from a debug shell into a native meeting workspace (Phase A of the UX plan). Open-source/local-first guardrails honored: **no accounts/plans/quotas/members**; Share disabled; honest `Local · Private · your data stays on this Mac` trust strip.

## What
- **Rendered notes** (`NotesView` + new `StructuredNotes` model + `MarkdownText`): reads `notes.json` (the IR; falls back to `notes.md` with YAML stripped + block-rendered) → Summary/narrative, Key Points, **Action Items as checkboxes** (owner·due), inline screenshots, tag chips. No more literal `##`/YAML.
- **Tabbed, notes-primary detail** (`MeetingDetailView`): Notes | Transcript | Info; strong header (inline title, `date · time · duration · language · N speakers`), **trust chips**, Export (`.md`) / Reveal-in-Finder, disabled Share. Per-meeting **empty / processing (#80 progress) / error** states.
- **Grouped sidebar** (`MeetingListView`): Today/Yesterday/date sections, rich rows (title + **status pill**, time·duration·language), search, context-menu delete.
- **Transcript**: speaker-grouped blocks + search + speaker filter.
- New: `Chips` (StatusPill/TrustChip/TrustStrip), `FlowLayout`, `DateFormatting`. `AppViewModel` gains status derivation, generate-notes, delete, reveal.

## Verified locally
`swift build` clean; `swift test` **43 pass** (+14 new). IPC transport + recording lifecycle untouched.

## Notes
- Pairs with #207 (engine `notes.json` + `MeetingSummary` fields). The app decodes the new `MeetingSummary` fields if-present, so it works before/after #207; full sidebar status/language needs #207 merged.
- Recording-screen redesign + #204 provider-info chips are follow-up tasks. Title edit is local-only (no rename IPC yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)