### PR TITLE
Phase A UX: recording screen + New Recording setup sheet

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -647,7 +647,18 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                     controller: recordingController,
                     setup: activeSetup,
                     onRecordingStopped: { _ in
-                        try await vm.finishActiveLiveRecording()
+                        // The controller already cleared isRecording, so this
+                        // RecordingScreen unmounts the instant stop succeeds and
+                        // its local alert can never be seen. Route a finalize
+                        // failure to ContentView's own error state, which stays
+                        // mounted, so the user actually learns stop/finalize
+                        // failed instead of silently dropping back to the list.
+                        do {
+                            try await vm.finishActiveLiveRecording()
+                        } catch {
+                            AppViewModel.logFullError("recording.finish", error)
+                            toolbarRecordingError = "Recording stopped, but finishing the meeting failed."
+                        }
                     }
                 )
             } else if let meeting = vm.selectedMeeting {

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -370,10 +370,16 @@ final class AppViewModel: ObservableObject {
 
     /// Create a meeting through the existing `ipc.meeting.start` path, start
     /// live capture for it, select it in the sidebar, and refresh the list.
-    func startNewRecording<Controller: RecordingController>(using recordingController: Controller) async throws {
-        let meetingId = try await client.meetingStart()
+    /// `setup` carries the New Recording sheet's choices: title + language flow
+    /// into `meeting.start`, audio sources + screenshot sampling into
+    /// `recording.start`.
+    func startNewRecording<Controller: RecordingController>(
+        using recordingController: Controller,
+        setup: RecordingSetup = .default
+    ) async throws {
+        let meetingId = try await client.meetingStart(config: setup.meetingConfig)
         do {
-            try await recordingController.start(meetingId: meetingId)
+            try await recordingController.start(meetingId: meetingId, options: setup.recordingOptions)
         } catch {
             let recordingStartError = error
             do {
@@ -624,15 +630,31 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var recordingController: Controller
     @State private var isStartingNewRecording = false
     @State private var toolbarRecordingError: String?
+    @State private var showNewRecordingSheet = false
+    /// The setup chosen in the sheet, kept so the recording screen can show the
+    /// right capture-source indicators while recording.
+    @State private var activeSetup = RecordingSetup.default
 
     var body: some View {
         NavigationSplitView {
             MeetingListView(vm: vm)
         } detail: {
-            // A selected meeting owns its own Notes/Transcript/Info workspace,
-            // including per-meeting processing/error states. The audio-file
-            // flow (no selection) renders its working/done/error here instead.
-            if let meeting = vm.selectedMeeting {
+            // Active recording takes over the detail pane with the dedicated
+            // recording screen (timer + capture indicators + Stop), regardless
+            // of sidebar selection.
+            if recordingController.isRecording {
+                RecordingScreen(
+                    controller: recordingController,
+                    setup: activeSetup,
+                    onRecordingStopped: { _ in
+                        try await vm.finishActiveLiveRecording()
+                    }
+                )
+            } else if let meeting = vm.selectedMeeting {
+                // A selected meeting owns its own Notes/Transcript/Info
+                // workspace, including per-meeting processing/error states. The
+                // audio-file flow (no selection) renders its working/done/error
+                // here instead.
                 MeetingDetailView(
                     meeting: meeting,
                     vm: vm,
@@ -676,9 +698,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                 }
 
                 Button("New Recording") {
-                    Task { @MainActor in
-                        await startNewRecording()
-                    }
+                    showNewRecordingSheet = true
                 }
                 .disabled(isStartingNewRecording || recordingController.isRecording || isEngineNotConnected || isGeneratingNotes)
                 .help("Create a meeting and start live recording")
@@ -688,6 +708,16 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(toolbarRecordingError ?? "")
+        }
+        .sheet(isPresented: $showNewRecordingSheet) {
+            NewRecordingSheet(
+                onStart: { setup in
+                    showNewRecordingSheet = false
+                    activeSetup = setup
+                    Task { @MainActor in await startNewRecording(setup: setup) }
+                },
+                onCancel: { showNewRecordingSheet = false }
+            )
         }
         .task {
             await vm.refreshMeetings()
@@ -718,14 +748,14 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         )
     }
 
-    private func startNewRecording() async {
+    private func startNewRecording(setup: RecordingSetup) async {
         guard !isStartingNewRecording else { return }
         isStartingNewRecording = true
         defer { isStartingNewRecording = false }
 
         do {
             toolbarRecordingError = nil
-            try await vm.startNewRecording(using: recordingController)
+            try await vm.startNewRecording(using: recordingController, setup: setup)
         } catch {
             AppViewModel.logFullError("recording.new", error)
             toolbarRecordingError = "Couldn't start recording."
@@ -762,7 +792,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                 .multilineTextAlignment(.center)
 
             Button {
-                Task { @MainActor in await startNewRecording() }
+                showNewRecordingSheet = true
             } label: {
                 Label("New Recording", systemImage: "record.circle")
                     .padding(.horizontal, 8)

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -736,6 +736,15 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         .onChange(of: vm.selectedMeetingId) { _, _ in
             Task { await vm.loadSelectedMeeting() }
         }
+        .onChange(of: recordingController.isRecording) { _, recording in
+            // Keep the invariant "idle ⟹ activeSetup == .default". The sheet
+            // overrides it just before a sheet-driven start; every other start
+            // (the RecordBar resume) uses engine defaults, so once a recording
+            // ends we reset here. That way the next non-sheet start already has
+            // accurate capture chips before its RecordingScreen can appear,
+            // instead of showing a stale setup from a prior sheet run.
+            if !recording { activeSetup = .default }
+        }
     }
 
     private var isEngineNotConnected: Bool {
@@ -770,6 +779,10 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         } catch {
             AppViewModel.logFullError("recording.new", error)
             toolbarRecordingError = "Couldn't start recording."
+            // A failed sheet start may never flip isRecording (e.g. meeting.start
+            // threw), so the isRecording reset can't fire — clear the chosen
+            // setup here too so a later non-sheet start doesn't inherit it.
+            activeSetup = .default
         }
     }
 

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -571,12 +571,20 @@ actor IpcClient {
     /// loop.
     func meetingStart() async throws -> String {
         // meeting.start takes a MeetingConfig param (optional title/language);
-        // it is NOT a no-param method. EmptyParams() encodes to {} (an
-        // all-default MeetingConfig), so the wire params decode cleanly —
-        // sending no params here yields jsonrpsee -32602 Invalid params.
+        // it is NOT a no-param method. An all-nil MeetingConfig encodes to {}
+        // (an all-default config), so the wire params decode cleanly — sending
+        // no params here yields jsonrpsee -32602 Invalid params.
+        try await meetingStart(config: MeetingConfig(title: nil, language: nil))
+    }
+
+    /// `ipc.meeting.start` with an explicit config (optional title + language).
+    /// Auto-creates a meeting row and returns the meeting_id (a bare JSON
+    /// string). `nil` config fields are omitted on the wire so the engine
+    /// applies its defaults (title="", language="auto").
+    func meetingStart(config: MeetingConfig) async throws -> String {
         let result: String = try await sendRequest(
             method: "ipc.meeting.start",
-            params: EmptyParams()
+            params: config
         )
         return result
     }

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -22,6 +22,11 @@ enum RecordingPathValidationError: Error {
 @MainActor
 final class LiveRecordingController: RecordingController, ObservableObject {
     @Published private(set) var isRecording = false
+    /// Mirrors `recordingId != nil`: true only after `recording.start` is
+    /// accepted, false again once stopped. The Stop affordance gates on this so
+    /// it can't fire while the optimistic `isRecording` is up but no recording
+    /// id exists yet (a Stop then would no-op and leave the engine recording).
+    @Published private(set) var canStop = false
 
     private let ipcClient: any LiveRecordingIpcClient
     private var recordingId: String?
@@ -34,6 +39,7 @@ final class LiveRecordingController: RecordingController, ObservableObject {
         guard !isRecording else { return }
         isRecording = true
         recordingId = nil
+        canStop = false
 
         do {
             let accepted = try await ipcClient.recordingStart(
@@ -43,9 +49,11 @@ final class LiveRecordingController: RecordingController, ObservableObject {
                 screenshotThreshold: options.screenshotThreshold
             )
             recordingId = accepted.recordingId
+            canStop = true
         } catch {
             isRecording = false
             recordingId = nil
+            canStop = false
             throw error
         }
     }
@@ -62,6 +70,7 @@ final class LiveRecordingController: RecordingController, ObservableObject {
         let stopped = try await ipcClient.recordingStop(recordingId: activeRecordingId)
         recordingId = nil
         isRecording = false
+        canStop = false
         try validateArtifactPaths(stopped)
 
         let audioPath = stopped.systemAudioPath ?? stopped.micAudioPath

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -30,7 +30,7 @@ final class LiveRecordingController: RecordingController, ObservableObject {
         self.ipcClient = ipcClient
     }
 
-    func start(meetingId: String) async throws {
+    func start(meetingId: String, options: RecordingOptions) async throws {
         guard !isRecording else { return }
         isRecording = true
         recordingId = nil
@@ -38,9 +38,9 @@ final class LiveRecordingController: RecordingController, ObservableObject {
         do {
             let accepted = try await ipcClient.recordingStart(
                 meetingId: meetingId,
-                audioSources: .systemAndMic,
-                screenshotIntervalMs: 500,
-                screenshotThreshold: 0.15
+                audioSources: options.audioSources,
+                screenshotIntervalMs: options.screenshotIntervalMs,
+                screenshotThreshold: options.screenshotThreshold
             )
             recordingId = accepted.recordingId
         } catch {

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -162,6 +162,16 @@ enum AudioSourcesWire: String, Codable {
 struct MeetingConfig: Encodable {
     let title: String?
     let language: String?
+
+    // Explicit snake_case keys per the wire convention (see MeetingSummary).
+    // Both fields are single-word today, so this matches the current wire, but
+    // it pins the mapping so a future multi-word field can't silently drift from
+    // the engine's snake_case contract. Optionals still encode via
+    // `encodeIfPresent`, so an all-nil config stays `{}`.
+    enum CodingKeys: String, CodingKey {
+        case title
+        case language
+    }
 }
 
 /// Outgoing params for `ipc.recording.start`.

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -133,6 +133,26 @@ enum AudioSourcesWire: String, Codable {
     case systemOnly = "system_only"
     case micOnly = "mic_only"
     case systemAndMic = "system_and_mic"
+
+    /// Single source of truth for how an audio choice reads to the user. Used by
+    /// the New Recording picker and the recording-screen capture chip so the two
+    /// can't drift apart.
+    var displayLabel: String {
+        switch self {
+        case .systemAndMic: return "System + Mic"
+        case .micOnly: return "Mic only"
+        case .systemOnly: return "System only"
+        }
+    }
+
+    /// SF Symbol paired with `displayLabel` in the capture chip.
+    var icon: String {
+        switch self {
+        case .systemAndMic: return "waveform"
+        case .micOnly: return "mic"
+        case .systemOnly: return "speaker.wave.2"
+        }
+    }
 }
 
 /// Outgoing params for `ipc.meeting.start`. Mirrors `panops-protocol::MeetingConfig`.

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -135,6 +135,15 @@ enum AudioSourcesWire: String, Codable {
     case systemAndMic = "system_and_mic"
 }
 
+/// Outgoing params for `ipc.meeting.start`. Mirrors `panops-protocol::MeetingConfig`.
+/// Both fields optional; the engine applies defaults (title="", language="auto").
+/// `nil` fields are omitted by `JSONEncoder`, so an all-`nil` config encodes to
+/// `{}` — identical to the previous `EmptyParams()` path.
+struct MeetingConfig: Encodable {
+    let title: String?
+    let language: String?
+}
+
 /// Outgoing params for `ipc.recording.start`.
 struct RecordingStartParams: Encodable {
     let meetingId: String

--- a/apps/Panops/Sources/Panops/RecordingController.swift
+++ b/apps/Panops/Sources/Panops/RecordingController.swift
@@ -82,6 +82,12 @@ struct RecordingSetup: Equatable {
 @MainActor
 protocol RecordingController: AnyObject {
     var isRecording: Bool { get }
+    /// True only once `recording.start` has been accepted (a recording id
+    /// exists) and the recording hasn't been stopped yet. `isRecording` flips
+    /// optimistically before acceptance to block a double-start, so the UI must
+    /// gate Stop on this signal — not on `isRecording` — to avoid a Stop that
+    /// no-ops while the start is still in flight.
+    var canStop: Bool { get }
     func start(meetingId: String, options: RecordingOptions) async throws
     func stop() async throws -> URL?  // Returns audio file path
 }
@@ -99,10 +105,12 @@ extension RecordingController {
 @MainActor
 final class MockRecordingController: RecordingController, ObservableObject {
     @Published private(set) var isRecording = false
+    @Published private(set) var canStop = false
     @Published var showPlaceholderAlert = false
 
     func start(meetingId: String, options: RecordingOptions) async throws {
         isRecording = true
+        canStop = true
         // Placeholder: show alert after brief delay
         try await Task.sleep(nanoseconds: 500_000_000)
         showPlaceholderAlert = true
@@ -110,6 +118,7 @@ final class MockRecordingController: RecordingController, ObservableObject {
 
     func stop() async throws -> URL? {
         isRecording = false
+        canStop = false
         return nil
     }
 }

--- a/apps/Panops/Sources/Panops/RecordingController.swift
+++ b/apps/Panops/Sources/Panops/RecordingController.swift
@@ -1,12 +1,97 @@
 import Foundation
 import Combine
 
+/// Capture options chosen for a recording session and forwarded to
+/// `ipc.recording.start`. Defaults mirror the engine's own defaults.
+struct RecordingOptions: Equatable {
+    var audioSources: AudioSourcesWire
+    var screenshotIntervalMs: UInt64
+    var screenshotThreshold: Float
+
+    static let `default` = RecordingOptions(
+        audioSources: .systemAndMic,
+        screenshotIntervalMs: 500,
+        screenshotThreshold: 0.15
+    )
+}
+
+/// Language choice offered in the New Recording sheet. Maps to the
+/// `MeetingConfig.language` wire value; `.auto` omits it (engine defaults to
+/// "auto" and detects per-region).
+enum RecordingLanguage: String, CaseIterable, Identifiable {
+    case auto
+    case english
+    case spanish
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .english: return "English"
+        case .spanish: return "Spanish"
+        }
+    }
+
+    /// BCP-47 hint sent to the engine, or `nil` for auto-detect.
+    var wireValue: String? {
+        switch self {
+        case .auto: return nil
+        case .english: return "en"
+        case .spanish: return "es"
+        }
+    }
+}
+
+/// The user's choices from the New Recording sheet. Bridges the UI to the two
+/// backend calls: `meeting.start` (title + language) and `recording.start`
+/// (audio sources + screenshot sampling).
+struct RecordingSetup: Equatable {
+    var title: String = ""
+    var language: RecordingLanguage = .auto
+    var audioSources: AudioSourcesWire = .systemAndMic
+    /// Screenshots are always captured: the engine has no off-switch yet, so
+    /// this stays `true` and drives only the recording-screen indicator. See
+    /// the screenshots follow-up note.
+    var captureScreenshots: Bool = true
+
+    static let `default` = RecordingSetup()
+
+    /// `meeting.start` config. Empty title and `.auto` language both collapse to
+    /// omitted fields so the engine applies its own defaults.
+    var meetingConfig: MeetingConfig {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return MeetingConfig(
+            title: trimmed.isEmpty ? nil : trimmed,
+            language: language.wireValue
+        )
+    }
+
+    /// `recording.start` options. Screenshot sampling stays at engine defaults
+    /// (no off-switch on the wire yet).
+    var recordingOptions: RecordingOptions {
+        RecordingOptions(
+            audioSources: audioSources,
+            screenshotIntervalMs: RecordingOptions.default.screenshotIntervalMs,
+            screenshotThreshold: RecordingOptions.default.screenshotThreshold
+        )
+    }
+}
+
 /// Protocol for recording control.
 @MainActor
 protocol RecordingController: AnyObject {
     var isRecording: Bool { get }
-    func start(meetingId: String) async throws
+    func start(meetingId: String, options: RecordingOptions) async throws
     func stop() async throws -> URL?  // Returns audio file path
+}
+
+extension RecordingController {
+    /// Start with the engine-default capture options. Used by the in-meeting
+    /// resume affordance, which has no explicit setup to thread.
+    func start(meetingId: String) async throws {
+        try await start(meetingId: meetingId, options: .default)
+    }
 }
 
 /// Mock implementation for previews/tests.
@@ -16,7 +101,7 @@ final class MockRecordingController: RecordingController, ObservableObject {
     @Published private(set) var isRecording = false
     @Published var showPlaceholderAlert = false
 
-    func start(meetingId: String) async throws {
+    func start(meetingId: String, options: RecordingOptions) async throws {
         isRecording = true
         // Placeholder: show alert after brief delay
         try await Task.sleep(nanoseconds: 500_000_000)

--- a/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
+++ b/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Modal setup sheet shown before a recording starts. Collects the title,
+/// language, audio sources, and screenshot preference, then hands a
+/// `RecordingSetup` back via `onStart` — the caller drives the existing
+/// `meeting.start` → `recording.start` flow with it.
+struct NewRecordingSheet: View {
+    /// Display order for the audio picker: the most common pick first.
+    private static let audioChoices: [AudioSourcesWire] = [.systemAndMic, .micOnly, .systemOnly]
+
+    let onStart: (RecordingSetup) -> Void
+    let onCancel: () -> Void
+
+    @State private var setup = RecordingSetup.default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("New Recording")
+                .font(.title2.weight(.semibold))
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
+
+            Form {
+                TextField("Title", text: $setup.title, prompt: Text("Optional"))
+
+                Picker("Language", selection: $setup.language) {
+                    ForEach(RecordingLanguage.allCases) { language in
+                        Text(language.label).tag(language)
+                    }
+                }
+
+                Picker("Audio", selection: $setup.audioSources) {
+                    ForEach(Self.audioChoices, id: \.self) { source in
+                        Text(audioLabel(source)).tag(source)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Toggle("Capture screenshots", isOn: $setup.captureScreenshots)
+                        .disabled(true)
+                    Text("Screenshots are always captured in this version.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                TrustStrip()
+                Spacer()
+                Button("Cancel", role: .cancel) { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Start") { onStart(setup) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+            .padding(20)
+        }
+        .frame(width: 420)
+    }
+
+    private func audioLabel(_ source: AudioSourcesWire) -> String {
+        switch source {
+        case .systemAndMic: return "System + Mic"
+        case .micOnly: return "Mic only"
+        case .systemOnly: return "System only"
+        }
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
+++ b/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
@@ -32,7 +32,7 @@ struct NewRecordingSheet: View {
 
                 Picker("Audio", selection: $setup.audioSources) {
                     ForEach(Self.audioChoices, id: \.self) { source in
-                        Text(audioLabel(source)).tag(source)
+                        Text(source.displayLabel).tag(source)
                     }
                 }
 
@@ -58,13 +58,5 @@ struct NewRecordingSheet: View {
             .padding(20)
         }
         .frame(width: 420)
-    }
-
-    private func audioLabel(_ source: AudioSourcesWire) -> String {
-        switch source {
-        case .systemAndMic: return "System + Mic"
-        case .micOnly: return "Mic only"
-        case .systemOnly: return "System only"
-        }
     }
 }

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -113,13 +113,15 @@ struct RecordingScreen<Controller: RecordingController & ObservableObject>: View
     }
 
     private var activeSources: [CaptureSource] {
-        var sources: [CaptureSource] = []
-        if setup.audioSources == .micOnly || setup.audioSources == .systemAndMic {
-            sources.append(CaptureSource(id: "mic", icon: "mic", label: "Mic"))
-        }
-        if setup.audioSources == .systemOnly || setup.audioSources == .systemAndMic {
-            sources.append(CaptureSource(id: "system", icon: "speaker.wave.2", label: "System audio"))
-        }
+        // One audio chip labelled from the shared `displayLabel` so its wording
+        // matches the New Recording picker exactly, plus the screenshots chip.
+        var sources: [CaptureSource] = [
+            CaptureSource(
+                id: "audio",
+                icon: setup.audioSources.icon,
+                label: setup.audioSources.displayLabel
+            )
+        ]
         if setup.captureScreenshots {
             sources.append(CaptureSource(id: "screenshots", icon: "photo", label: "Screenshots"))
         }

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -1,5 +1,154 @@
 import SwiftUI
 
+/// Elapsed-time formatting for the recording screen. Pure + testable; the
+/// timer is client-side (counts up from the moment the screen appears) — the
+/// engine emits no authoritative recording clock.
+enum RecordingClock {
+    /// "MM:SS" under an hour, "H:MM:SS" once it passes one. Negatives clamp to
+    /// zero so a clock-skew blip never renders a negative timer.
+    static func label(seconds: Int) -> String {
+        let total = max(0, seconds)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%02d:%02d", minutes, secs)
+    }
+}
+
+/// The full recording screen: a large client-side timer, the capture-source
+/// indicators chosen in the setup sheet, the honest trust strip, and a
+/// prominent Stop. Shown while `controller.isRecording`. Deliberately shows no
+/// live transcript — transcript + notes are produced only after Stop.
+struct RecordingScreen<Controller: RecordingController & ObservableObject>: View {
+    @ObservedObject var controller: Controller
+    let setup: RecordingSetup
+    let onRecordingStopped: (URL?) async throws -> Void
+
+    @State private var isStopping = false
+    @State private var errorMessage: String?
+    @State private var startDate: Date?
+
+    init(
+        controller: Controller,
+        setup: RecordingSetup,
+        onRecordingStopped: @escaping (URL?) async throws -> Void = { _ in }
+    ) {
+        self._controller = ObservedObject(wrappedValue: controller)
+        self.setup = setup
+        self.onRecordingStopped = onRecordingStopped
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 11, height: 11)
+                Text("Recording")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+
+            TimelineView(.periodic(from: startDate ?? Date(), by: 1)) { context in
+                Text(RecordingClock.label(seconds: elapsedSeconds(asOf: context.date)))
+                    .font(.system(size: 60, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+            }
+
+            captureSourceIndicators
+
+            Text("Transcript & notes appear after recording stops.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button(role: .destructive) {
+                Task { @MainActor in await stop() }
+            } label: {
+                Label("Stop Recording", systemImage: "stop.fill")
+                    .padding(.horizontal, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(.red)
+            .disabled(isStopping)
+            .help("Stop recording and generate notes")
+
+            Spacer()
+            TrustStrip()
+                .padding(.bottom, 12)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .onAppear { if startDate == nil { startDate = Date() } }
+        .alert("Recording error", isPresented: errorPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    /// Active capture sources, derived from the chosen setup. Static-from-config
+    /// is honest here: there are no live capture-status events to reflect.
+    private var captureSourceIndicators: some View {
+        HStack(spacing: 8) {
+            ForEach(activeSources) { source in
+                TrustChip(systemImage: source.icon, label: source.label)
+            }
+        }
+    }
+
+    private struct CaptureSource: Identifiable {
+        let id: String
+        let icon: String
+        let label: String
+    }
+
+    private var activeSources: [CaptureSource] {
+        var sources: [CaptureSource] = []
+        if setup.audioSources == .micOnly || setup.audioSources == .systemAndMic {
+            sources.append(CaptureSource(id: "mic", icon: "mic", label: "Mic"))
+        }
+        if setup.audioSources == .systemOnly || setup.audioSources == .systemAndMic {
+            sources.append(CaptureSource(id: "system", icon: "speaker.wave.2", label: "System audio"))
+        }
+        if setup.captureScreenshots {
+            sources.append(CaptureSource(id: "screenshots", icon: "photo", label: "Screenshots"))
+        }
+        return sources
+    }
+
+    private func elapsedSeconds(asOf now: Date) -> Int {
+        guard let startDate else { return 0 }
+        return Int(now.timeIntervalSince(startDate))
+    }
+
+    private var errorPresented: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private func stop() async {
+        guard !isStopping else { return }
+        isStopping = true
+        defer { isStopping = false }
+        do {
+            let audioURL = try await controller.stop()
+            try await onRecordingStopped(audioURL)
+        } catch {
+            AppViewModel.logFullError("recording.stop", error)
+            errorMessage = "Couldn't stop recording."
+        }
+    }
+}
+
 /// Record/Stop control bar backed by an injected RecordingController.
 struct RecordBar<Controller: RecordingController & ObservableObject>: View {
     @ObservedObject var controller: Controller

--- a/apps/Panops/Sources/Panops/Views/RecordBar.swift
+++ b/apps/Panops/Sources/Panops/Views/RecordBar.swift
@@ -76,7 +76,10 @@ struct RecordingScreen<Controller: RecordingController & ObservableObject>: View
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .tint(.red)
-            .disabled(isStopping)
+            // Disabled until the engine accepts the start (canStop). `isRecording`
+            // flips optimistically before acceptance, so gating on it alone would
+            // show an enabled Stop that no-ops during a slow start.
+            .disabled(isStopping || !controller.canStop)
             .help("Stop recording and generate notes")
 
             Spacer()

--- a/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
+++ b/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
@@ -24,6 +24,32 @@ struct LiveRecordingControllerTests {
         #expect(controller.isRecording)
     }
 
+    @Test("Stop is gated until recording.start is accepted")
+    func canStopGatesUntilStartAccepted() async throws {
+        let fake = FakeLiveRecordingIpcClient(startDelayNanoseconds: 50_000_000)
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        #expect(controller.canStop == false)
+
+        let firstStart = Task { @MainActor in
+            try await controller.start(meetingId: "meeting-1")
+        }
+        try await Task.sleep(nanoseconds: 1_000_000)
+
+        // Optimistic isRecording is up (blocks a double-start), but the engine
+        // hasn't accepted yet — Stop must stay disabled while the start is in
+        // flight, otherwise it no-ops and recording continues after acceptance.
+        #expect(controller.isRecording)
+        #expect(controller.canStop == false)
+
+        try await firstStart.value
+        // recording.start accepted (recordingId set) — Stop is now live.
+        #expect(controller.canStop)
+
+        _ = try await controller.stop()
+        #expect(controller.canStop == false)
+    }
+
     @Test("start failure resets recording state")
     func startFailureResetsRecordingState() async throws {
         let fake = FakeLiveRecordingIpcClient(startError: TestRecordingError.startFailed)

--- a/apps/Panops/Tests/PanopsTests/RecordingControllerOptionsTests.swift
+++ b/apps/Panops/Tests/PanopsTests/RecordingControllerOptionsTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import Panops
+
+/// Records the capture params it was asked to start with, so tests can assert
+/// `LiveRecordingController` forwards the chosen `RecordingOptions` to the wire.
+private actor CapturingRecordingIpcClient: LiveRecordingIpcClient {
+    private(set) var audioSources: AudioSourcesWire?
+    private(set) var intervalMs: UInt64?
+    private(set) var threshold: Float?
+
+    func recordingStart(
+        meetingId: String,
+        audioSources: AudioSourcesWire,
+        screenshotIntervalMs: UInt64,
+        screenshotThreshold: Float
+    ) async throws -> RecordingAccepted {
+        self.audioSources = audioSources
+        self.intervalMs = screenshotIntervalMs
+        self.threshold = screenshotThreshold
+        return RecordingAccepted(recordingId: "rec-1")
+    }
+
+    func recordingStop(recordingId: String) async throws -> RecordingStopped {
+        RecordingStopped(systemAudioPath: nil, micAudioPath: nil, screenshotPaths: [], durationMs: 0)
+    }
+}
+
+@Suite("RecordingController option passthrough")
+@MainActor
+struct RecordingControllerOptionsTests {
+    @Test("chosen options are forwarded to recording.start")
+    func forwardsChosenOptions() async throws {
+        let fake = CapturingRecordingIpcClient()
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        try await controller.start(
+            meetingId: "m1",
+            options: RecordingOptions(
+                audioSources: .micOnly,
+                screenshotIntervalMs: 1000,
+                screenshotThreshold: 0.5
+            )
+        )
+
+        #expect(await fake.audioSources == .micOnly)
+        #expect(await fake.intervalMs == 1000)
+        #expect(await fake.threshold == 0.5)
+        #expect(controller.isRecording)
+    }
+
+    @Test("the no-options start uses engine-default capture options")
+    func defaultStartUsesDefaults() async throws {
+        let fake = CapturingRecordingIpcClient()
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        try await controller.start(meetingId: "m1")
+
+        #expect(await fake.audioSources == .systemAndMic)
+        #expect(await fake.intervalMs == 500)
+        #expect(await fake.threshold == 0.15)
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/RecordingSetupTests.swift
+++ b/apps/Panops/Tests/PanopsTests/RecordingSetupTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("RecordingLanguage")
+struct RecordingLanguageTests {
+    @Test("auto omits the language hint; others map to BCP-47")
+    func wireValue() {
+        #expect(RecordingLanguage.auto.wireValue == nil)
+        #expect(RecordingLanguage.english.wireValue == "en")
+        #expect(RecordingLanguage.spanish.wireValue == "es")
+    }
+}
+
+@Suite("RecordingSetup mapping")
+struct RecordingSetupTests {
+    @Test("empty title and auto language collapse to omitted config fields")
+    func defaultsCollapse() {
+        let config = RecordingSetup().meetingConfig
+        #expect(config.title == nil)
+        #expect(config.language == nil)
+    }
+
+    @Test("whitespace-only title collapses to nil; language still maps")
+    func whitespaceTitle() {
+        let setup = RecordingSetup(title: "   ", language: .english)
+        #expect(setup.meetingConfig.title == nil)
+        #expect(setup.meetingConfig.language == "en")
+    }
+
+    @Test("title is trimmed and language mapped")
+    func titleTrimmedLanguageMapped() {
+        let setup = RecordingSetup(title: "  Standup  ", language: .spanish)
+        #expect(setup.meetingConfig.title == "Standup")
+        #expect(setup.meetingConfig.language == "es")
+    }
+
+    @Test("recordingOptions carries the chosen audio source at engine defaults")
+    func recordingOptionsAudio() {
+        let options = RecordingSetup(audioSources: .systemOnly).recordingOptions
+        #expect(options.audioSources == .systemOnly)
+        #expect(options.screenshotIntervalMs == 500)
+        #expect(options.screenshotThreshold == 0.15)
+    }
+}
+
+@Suite("MeetingConfig encoding")
+struct MeetingConfigEncodingTests {
+    private var encoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }
+
+    @Test("all-nil config encodes to an empty object")
+    func emptyEncoding() throws {
+        let data = try encoder.encode(MeetingConfig(title: nil, language: nil))
+        #expect(String(data: data, encoding: .utf8) == "{}")
+    }
+
+    @Test("set fields are encoded with snake_case-compatible keys")
+    func fullEncoding() throws {
+        let data = try encoder.encode(MeetingConfig(title: "Standup", language: "es"))
+        #expect(String(data: data, encoding: .utf8) == #"{"language":"es","title":"Standup"}"#)
+    }
+}
+
+@Suite("RecordingClock")
+struct RecordingClockTests {
+    @Test("formats MM:SS under an hour")
+    func underAnHour() {
+        #expect(RecordingClock.label(seconds: 0) == "00:00")
+        #expect(RecordingClock.label(seconds: 5) == "00:05")
+        #expect(RecordingClock.label(seconds: 65) == "01:05")
+        #expect(RecordingClock.label(seconds: 3599) == "59:59")
+    }
+
+    @Test("rolls into H:MM:SS at and beyond one hour")
+    func atAndBeyondAnHour() {
+        #expect(RecordingClock.label(seconds: 3600) == "1:00:00")
+        #expect(RecordingClock.label(seconds: 3661) == "1:01:01")
+        #expect(RecordingClock.label(seconds: 36000) == "10:00:00")
+    }
+
+    @Test("negative input clamps to zero")
+    func negativeClamps() {
+        #expect(RecordingClock.label(seconds: -10) == "00:00")
+    }
+}


### PR DESCRIPTION
Completes Phase A §A5 of the UX overhaul (last piece after #207/#208/#209).

## What
- **New Recording setup sheet** (`Views/NewRecordingSheet.swift`) shown before `meeting.start`/`recording.start`: title, language (Auto/English/Spanish), audio source (System+Mic / Mic only / System only), screenshots toggle.
- **Recording screen** (`RecordingScreen` in `Views/RecordBar.swift`): large client-side elapsed timer, capture-source indicators, the `TrustStrip`, prominent Stop, and "Transcript & notes appear after recording stops." **No fake live ASR / transcript.**
- Config plumbing: Swift `MeetingConfig` wire type, `RecordingOptions`/`RecordingSetup` value types, extended the `RecordingController.start` seam to carry the chosen options, `meetingStart(config:)`.

## Sheet field → real backend param
| Field | Wired to |
|---|---|
| Title | `MeetingConfig.title` → `ipc.meeting.start` (empty → omitted) |
| Language | `MeetingConfig.language` (Auto→nil, English→`en`, Spanish→`es`) |
| Audio source | `RecordingStartParams.audio_sources` → `ipc.recording.start` |
| Screenshots | **Not wireable** — no backend off-switch; toggle disabled+ON with caption. Follow-up: #213 |

## Verify
`swift build` clean (zero warnings); `swift test` **59 tests in 16 suites pass** (CLT framework rpaths). No real-socket test (live smoke stays env-gated).

## Notes
- Local-first / open-source: no accounts/plans/quotas. Screenshots toggle is honest about current capability (#213 to add the off-path).
- Real live capture is Anchor B; this is the recording **UI** wired to the existing recording lifecycle.

Closes Task #4 (Phase A). 🤖 Generated with [Claude Code](https://claude.com/claude-code)