### PR TITLE
Anchor B: window targeting + capture.windows

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -316,6 +316,14 @@ final class AppViewModel: ObservableObject {
         try await client.meetingDeleteVideo(meetingId: meetingId)
     }
 
+    /// Fetch the engine's list of capturable windows for the New Recording
+    /// sheet's window picker. Thin passthrough to the IPC client (mirrors
+    /// `deleteVideoForMeeting`), so the sheet can be handed a real fetch closure
+    /// without exposing the private client.
+    func captureWindows() async throws -> [WindowInfo] {
+        try await client.captureWindows()
+    }
+
     /// Open a path (typically a meeting directory) in Finder, guarded to the
     /// panops data dir.
     func openInFinder(path: String) {
@@ -802,7 +810,8 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                     activeSetup = setup
                     Task { @MainActor in await startNewRecording(setup: setup) }
                 },
-                onCancel: { showNewRecordingSheet = false }
+                onCancel: { showNewRecordingSheet = false },
+                fetchWindows: { try await vm.captureWindows() }
             )
         }
         .task {

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -626,6 +626,14 @@ actor IpcClient {
         )
     }
 
+    /// `ipc.capture.windows` — fetches available windows for capture.
+    /// Returns a list of windows with their id, app name, and title.
+    func captureWindows() async throws -> [WindowInfo] {
+        return try await sendRequestNoParams(
+            method: "ipc.capture.windows"
+        )
+    }
+
     /// `ipc.recording.start` — starts live capture for an existing meeting.
     /// Returns the engine-issued recording session id used by
     /// `ipc.recording.stop`.
@@ -635,7 +643,8 @@ actor IpcClient {
         screenshotIntervalMs: UInt64 = 500,
         screenshotThreshold: Float = 0.15,
         recordVideo: Bool = false,
-        autoGenerateNotes: Bool = true
+        autoGenerateNotes: Bool = true,
+        captureTarget: CaptureTarget = .display
     ) async throws -> RecordingAccepted {
         let params = RecordingStartParams(
             meetingId: meetingId,
@@ -643,7 +652,8 @@ actor IpcClient {
             screenshotIntervalMs: screenshotIntervalMs,
             screenshotThreshold: screenshotThreshold,
             recordVideo: recordVideo,
-            autoGenerateNotes: autoGenerateNotes
+            autoGenerateNotes: autoGenerateNotes,
+            captureTarget: captureTarget
         )
         return try await sendRequest(
             method: "ipc.recording.start",

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -627,11 +627,16 @@ actor IpcClient {
     }
 
     /// `ipc.capture.windows` — fetches available windows for capture.
-    /// Returns a list of windows with their id, app name, and title.
+    /// Sends an empty params object (`{}`, positional like every other method);
+    /// the engine replies with a `{"windows":[...]}` wrapper. Sending no params
+    /// at all yields jsonrpsee -32602 (the handler takes a `CaptureWindowsParams`
+    /// arg), and the result is a wrapper object, not a bare array.
     func captureWindows() async throws -> [WindowInfo] {
-        return try await sendRequestNoParams(
-            method: "ipc.capture.windows"
+        let result: CaptureWindowsResult = try await sendRequest(
+            method: "ipc.capture.windows",
+            params: EmptyParams()
         )
+        return result.windows
     }
 
     /// `ipc.recording.start` — starts live capture for an existing meeting.

--- a/apps/Panops/Sources/Panops/LiveRecordingController.swift
+++ b/apps/Panops/Sources/Panops/LiveRecordingController.swift
@@ -8,12 +8,15 @@ protocol LiveRecordingIpcClient: Sendable {
         screenshotIntervalMs: UInt64,
         screenshotThreshold: Float,
         recordVideo: Bool,
-        autoGenerateNotes: Bool
+        autoGenerateNotes: Bool,
+        captureTarget: CaptureTarget
     ) async throws -> RecordingAccepted
 
     func recordingStop(recordingId: String) async throws -> RecordingStopped
 
     func meetingDeleteVideo(meetingId: String) async throws -> (deleted: Bool, freedBytes: UInt64)
+
+    func captureWindows() async throws -> [WindowInfo]
 }
 
 extension IpcClient: LiveRecordingIpcClient {}
@@ -56,7 +59,8 @@ final class LiveRecordingController: RecordingController, ObservableObject {
                 screenshotIntervalMs: options.screenshotIntervalMs,
                 screenshotThreshold: options.screenshotThreshold,
                 recordVideo: options.recordVideo,
-                autoGenerateNotes: options.autoGenerateNotes
+                autoGenerateNotes: options.autoGenerateNotes,
+                captureTarget: options.captureTarget
             )
             recordingId = accepted.recordingId
             autoGenerateNotesRequested = options.autoGenerateNotes

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -155,6 +155,61 @@ enum AudioSourcesWire: String, Codable {
     }
 }
 
+/// Capture target for `ipc.recording.start` — display or a specific window.
+enum CaptureTarget: Codable, Equatable {
+    case display
+    case window(windowId: UInt32)
+}
+
+extension CaptureTarget {
+    /// Wire encoding: `{"kind":"display"}` or `{"kind":"window","window_id":<u32>}`
+    enum WireKind: String, Codable {
+        case display
+        case window
+    }
+}
+
+/// Wire encoding for `CaptureTarget`.
+struct CaptureTargetWire: Encodable {
+    let kind: CaptureTargetWire.Kind
+    let windowId: UInt32?
+
+    enum Kind: String, Codable {
+        case display
+        case window
+    }
+
+    init(_ target: CaptureTarget) {
+        switch target {
+        case .display:
+            self.kind = .display
+            self.windowId = nil
+        case .window(windowId: let id):
+            self.kind = .window
+            self.windowId = id
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case windowId = "window_id"
+    }
+}
+
+/// A window available for capture, returned by `ipc.capture.windows`.
+struct WindowInfo: Decodable, Equatable, Identifiable {
+    var id: UInt32 { windowId }
+    let windowId: UInt32
+    let appName: String
+    let title: String
+
+    enum CodingKeys: String, CodingKey {
+        case windowId = "window_id"
+        case appName = "app_name"
+        case title
+    }
+}
+
 /// Outgoing params for `ipc.meeting.start`. Mirrors `panops-protocol::MeetingConfig`.
 /// Both fields optional; the engine applies defaults (title="", language="auto").
 /// `nil` fields are omitted by `JSONEncoder`, so an all-`nil` config encodes to
@@ -182,6 +237,7 @@ struct RecordingStartParams: Encodable {
     let screenshotThreshold: Float
     let recordVideo: Bool
     let autoGenerateNotes: Bool
+    let captureTarget: CaptureTargetWire
 
     enum CodingKeys: String, CodingKey {
         case meetingId = "meeting_id"
@@ -190,6 +246,44 @@ struct RecordingStartParams: Encodable {
         case screenshotThreshold = "screenshot_threshold"
         case recordVideo = "record_video"
         case autoGenerateNotes = "auto_generate_notes"
+        case captureTarget = "capture_target"
+    }
+
+    /// Create params with display capture target (default).
+    init(
+        meetingId: String,
+        audioSources: AudioSourcesWire,
+        screenshotIntervalMs: UInt64,
+        screenshotThreshold: Float,
+        recordVideo: Bool,
+        autoGenerateNotes: Bool
+    ) {
+        self.meetingId = meetingId
+        self.audioSources = audioSources
+        self.screenshotIntervalMs = screenshotIntervalMs
+        self.screenshotThreshold = screenshotThreshold
+        self.recordVideo = recordVideo
+        self.autoGenerateNotes = autoGenerateNotes
+        self.captureTarget = CaptureTargetWire(.display)
+    }
+
+    /// Create params with a specific window capture target.
+    init(
+        meetingId: String,
+        audioSources: AudioSourcesWire,
+        screenshotIntervalMs: UInt64,
+        screenshotThreshold: Float,
+        recordVideo: Bool,
+        autoGenerateNotes: Bool,
+        captureTarget: CaptureTarget
+    ) {
+        self.meetingId = meetingId
+        self.audioSources = audioSources
+        self.screenshotIntervalMs = screenshotIntervalMs
+        self.screenshotThreshold = screenshotThreshold
+        self.recordVideo = recordVideo
+        self.autoGenerateNotes = autoGenerateNotes
+        self.captureTarget = CaptureTargetWire(captureTarget)
     }
 }
 

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -210,6 +210,17 @@ struct WindowInfo: Decodable, Equatable, Identifiable {
     }
 }
 
+/// Result wrapper for `ipc.capture.windows`. Mirrors
+/// `panops-protocol::CaptureWindowsResult` — the engine returns
+/// `{"windows":[...]}`, not a bare array.
+struct CaptureWindowsResult: Decodable, Equatable {
+    let windows: [WindowInfo]
+
+    enum CodingKeys: String, CodingKey {
+        case windows
+    }
+}
+
 /// Outgoing params for `ipc.meeting.start`. Mirrors `panops-protocol::MeetingConfig`.
 /// Both fields optional; the engine applies defaults (title="", language="auto").
 /// `nil` fields are omitted by `JSONEncoder`, so an all-`nil` config encodes to

--- a/apps/Panops/Sources/Panops/RecordingController.swift
+++ b/apps/Panops/Sources/Panops/RecordingController.swift
@@ -9,19 +9,22 @@ struct RecordingOptions: Equatable {
     var screenshotThreshold: Float
     var recordVideo: Bool
     var autoGenerateNotes: Bool
+    var captureTarget: CaptureTarget
 
     init(
         audioSources: AudioSourcesWire = .systemAndMic,
         screenshotIntervalMs: UInt64 = 500,
         screenshotThreshold: Float = 0.15,
         recordVideo: Bool = false,
-        autoGenerateNotes: Bool = true
+        autoGenerateNotes: Bool = true,
+        captureTarget: CaptureTarget = .display
     ) {
         self.audioSources = audioSources
         self.screenshotIntervalMs = screenshotIntervalMs
         self.screenshotThreshold = screenshotThreshold
         self.recordVideo = recordVideo
         self.autoGenerateNotes = autoGenerateNotes
+        self.captureTarget = captureTarget
     }
 
     static let `default` = RecordingOptions()
@@ -68,6 +71,7 @@ struct RecordingSetup: Equatable {
     var captureScreenshots: Bool = true
     var recordVideo: Bool = false
     var autoGenerateNotes: Bool = true
+    var captureTarget: CaptureTarget = .display
 
     static let `default` = RecordingSetup()
 
@@ -89,7 +93,8 @@ struct RecordingSetup: Equatable {
             screenshotIntervalMs: RecordingOptions.default.screenshotIntervalMs,
             screenshotThreshold: RecordingOptions.default.screenshotThreshold,
             recordVideo: recordVideo,
-            autoGenerateNotes: autoGenerateNotes
+            autoGenerateNotes: autoGenerateNotes,
+            captureTarget: captureTarget
         )
     }
 }

--- a/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
+++ b/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
@@ -1,13 +1,53 @@
 import SwiftUI
 
-/// Example windows for preview mode when IpcClient isn't available.
-private struct IpcClientMock {
-    static func captureWindows() async throws -> [WindowInfo] {
-        return [
-            WindowInfo(windowId: 1, appName: "Safari", title: "panops - Example Window"),
-            WindowInfo(windowId: 2, appName: "Xcode", title: "PanopsApp.swift"),
-            WindowInfo(windowId: 3, appName: "Terminal", title: "zsh")
-        ]
+/// Radio choice for the capture-target picker. File-scope (not nested) so the
+/// pure `CaptureTargetResolver` and its tests can reference it.
+enum CaptureTargetChoice: String, CaseIterable, Identifiable {
+    case display = "Full display"
+    case window = "Window…"
+
+    var id: String { rawValue }
+}
+
+/// Pure mapping from the sheet's capture-target UI state to the `CaptureTarget`
+/// submitted to `recording.start`. Extracted from the View so the
+/// window-selection guard is unit-testable without driving SwiftUI.
+enum CaptureTargetResolver {
+    /// Sentinel target used while "Window…" is chosen but no real window is
+    /// selected yet. The Start guard treats it as not-submittable so window_id 0
+    /// never reaches the engine.
+    static let unselectedWindow: CaptureTarget = .window(windowId: 0)
+
+    /// Resolve the capture target from the radio choice, the selected window id,
+    /// and the currently-available window list:
+    /// - `.display` choice → `.display`.
+    /// - `.window` with a real selected id present in the list → `.window(id)`.
+    /// - `.window` with no windows available → `.display` (fall back).
+    /// - `.window` with windows available but none chosen → `unselectedWindow`.
+    static func resolve(
+        choice: CaptureTargetChoice,
+        selectedWindowId: UInt32?,
+        windowList: [WindowInfo]
+    ) -> CaptureTarget {
+        switch choice {
+        case .display:
+            return .display
+        case .window:
+            if let id = selectedWindowId,
+               id != 0,
+               windowList.contains(where: { $0.windowId == id }) {
+                return .window(windowId: id)
+            }
+            if windowList.isEmpty {
+                return .display
+            }
+            return unselectedWindow
+        }
+    }
+
+    /// A target is submittable unless it's the awaiting-a-pick sentinel.
+    static func canStart(target: CaptureTarget) -> Bool {
+        target != unselectedWindow
     }
 }
 
@@ -21,21 +61,34 @@ struct NewRecordingSheet: View {
 
     let onStart: (RecordingSetup) -> Void
     let onCancel: () -> Void
+    /// Window-list provider. Production injects the real engine IPC
+    /// (`IpcClient.captureWindows()` via the view model); tests/previews inject a
+    /// fake list so they never touch a socket. `@MainActor` so it can safely
+    /// reach the main-actor view model.
+    let fetchWindows: @MainActor () async throws -> [WindowInfo]
+
+    init(
+        onStart: @escaping (RecordingSetup) -> Void,
+        onCancel: @escaping () -> Void,
+        fetchWindows: @escaping @MainActor () async throws -> [WindowInfo]
+    ) {
+        self.onStart = onStart
+        self.onCancel = onCancel
+        self.fetchWindows = fetchWindows
+    }
 
     @State private var setup = RecordingSetup.default
     @State private var windowList: [WindowInfo] = []
     @State private var isFetchingWindows = false
     @State private var windowsError: Error?
     @State private var selectedWindowId: UInt32?
-
-    private enum CaptureTargetChoice: String, CaseIterable, Identifiable {
-        case display = "Full display"
-        case window = "Window…"
-
-        var id: String { rawValue }
-    }
-
     @State private var selectedChoice: CaptureTargetChoice = .display
+
+    /// Start is blocked only when the chosen target is the awaiting-a-pick
+    /// sentinel; the display and a real window both submit.
+    private var canStart: Bool {
+        CaptureTargetResolver.canStart(target: setup.captureTarget)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -89,77 +142,12 @@ struct NewRecordingSheet: View {
                 }
                 .pickerStyle(.radioGroup)
                 .onChange(of: selectedChoice) { _, newValue in
-                    switch newValue {
-                    case .display:
-                        setup.captureTarget = .display
-                        selectedWindowId = nil
-                    case .window:
-                        setup.captureTarget = .window(windowId: 0)  // Placeholder, will be set from list
-                    }
+                    if newValue == .display { selectedWindowId = nil }
+                    reconcileCaptureTarget()
                 }
 
                 if selectedChoice == .window {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            if isFetchingWindows {
-                                ProgressView()
-                            } else if let error = windowsError {
-                                Text("Error: \(error.localizedDescription)")
-                                    .foregroundColor(.red)
-                                    .font(.caption)
-                            } else {
-                                Text("Select a window to capture")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            if !isFetchingWindows && windowList.isEmpty && windowsError == nil {
-                                Button("Refresh") {
-                                    Task { @MainActor in
-                                        await fetchWindows()
-                                    }
-                                }
-                                .font(.caption)
-                            }
-                        }
-
-                        if isFetchingWindows {
-                            Text("Loading windows…")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else if windowsError != nil {
-                            Text("No windows available — recording the full display instead")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Button("Try again") {
-                                Task { @MainActor in
-                                    await fetchWindows()
-                                }
-                            }
-                        } else if windowList.isEmpty {
-                            Text("No windows available — recording the full display instead")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Button("Try again") {
-                                Task { @MainActor in
-                                    await fetchWindows()
-                                }
-                            }
-                        } else {
-                            Picker("Window", selection: $selectedWindowId) {
-                                ForEach(windowList) { window in
-                                    Text("\(window.appName): \(window.title)")
-                                        .tag(window.windowId)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .onChange(of: selectedWindowId) { _, newValue in
-                                if let id = newValue {
-                                    setup.captureTarget = .window(windowId: id)
-                                }
-                            }
-                        }
-                    }
+                    windowSelection
                 }
             }
             .formStyle(.grouped)
@@ -172,31 +160,98 @@ struct NewRecordingSheet: View {
                 Button("Start") { onStart(setup) }
                     .keyboardShortcut(.defaultAction)
                     .buttonStyle(.borderedProminent)
+                    .disabled(!canStart)
             }
             .padding(20)
         }
         .frame(width: 420)
         .onAppear {
             Task { @MainActor in
-                await fetchWindows()
+                await loadWindows()
             }
         }
     }
 
-    private func fetchWindows() async {
+    /// The window-selection block shown under "Window…": a loading state, a
+    /// fall-back note + retry when no windows exist (or the fetch failed), or the
+    /// window menu when windows are available.
+    @ViewBuilder
+    private var windowSelection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if isFetchingWindows {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Loading windows…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if windowList.isEmpty {
+                // No windows (none available, or the fetch failed): the resolver
+                // has already fallen back to the full display, so Start stays
+                // enabled. Offer a retry.
+                HStack {
+                    Text(windowsError == nil
+                        ? "No windows available — recording the full display instead."
+                        : "Couldn't load windows — recording the full display instead.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Try again") {
+                        Task { @MainActor in await loadWindows() }
+                    }
+                    .font(.caption)
+                }
+            } else {
+                Text("Select a window to capture.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Picker("Window", selection: $selectedWindowId) {
+                    Text("Select a window…").tag(UInt32?.none)
+                    ForEach(windowList) { window in
+                        Text("\(window.appName): \(window.title)")
+                            .tag(UInt32?.some(window.windowId))
+                    }
+                }
+                .pickerStyle(.menu)
+                .onChange(of: selectedWindowId) { _, _ in
+                    reconcileCaptureTarget()
+                }
+            }
+        }
+    }
+
+    /// Recompute `setup.captureTarget` from the current UI state. Keeps Start
+    /// gated so a window target is only submitted with a real, selected window
+    /// (never window_id 0); falls back to the full display when no windows exist.
+    @MainActor
+    private func reconcileCaptureTarget() {
+        setup.captureTarget = CaptureTargetResolver.resolve(
+            choice: selectedChoice,
+            selectedWindowId: selectedWindowId,
+            windowList: windowList
+        )
+    }
+
+    /// Fetch the capturable window list from the injected provider (the real
+    /// engine IPC in production). On failure or an empty list, fall back to the
+    /// full display so the sheet stays usable and never submits window_id 0.
+    @MainActor
+    private func loadWindows() async {
         isFetchingWindows = true
         windowsError = nil
         defer { isFetchingWindows = false }
 
         do {
-            let windows = try await IpcClientMock.captureWindows()
-            windowList = windows
+            windowList = try await fetchWindows()
         } catch {
             windowsError = error
-            // On error, fall back to display mode
-            selectedChoice = .display
-            setup.captureTarget = .display
+            windowList = []
+        }
+        // Drop a stale selection no longer in the refreshed list, then recompute
+        // the target (which falls back to display when the list is empty).
+        if let id = selectedWindowId, !windowList.contains(where: { $0.windowId == id }) {
             selectedWindowId = nil
         }
+        reconcileCaptureTarget()
     }
 }

--- a/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
+++ b/apps/Panops/Sources/Panops/Views/NewRecordingSheet.swift
@@ -1,7 +1,18 @@
 import SwiftUI
 
+/// Example windows for preview mode when IpcClient isn't available.
+private struct IpcClientMock {
+    static func captureWindows() async throws -> [WindowInfo] {
+        return [
+            WindowInfo(windowId: 1, appName: "Safari", title: "panops - Example Window"),
+            WindowInfo(windowId: 2, appName: "Xcode", title: "PanopsApp.swift"),
+            WindowInfo(windowId: 3, appName: "Terminal", title: "zsh")
+        ]
+    }
+}
+
 /// Modal setup sheet shown before a recording starts. Collects the title,
-/// language, audio sources, and screenshot preference, then hands a
+/// language, audio sources, capture target, and screenshot preference, then hands a
 /// `RecordingSetup` back via `onStart` — the caller drives the existing
 /// `meeting.start` → `recording.start` flow with it.
 struct NewRecordingSheet: View {
@@ -12,6 +23,19 @@ struct NewRecordingSheet: View {
     let onCancel: () -> Void
 
     @State private var setup = RecordingSetup.default
+    @State private var windowList: [WindowInfo] = []
+    @State private var isFetchingWindows = false
+    @State private var windowsError: Error?
+    @State private var selectedWindowId: UInt32?
+
+    private enum CaptureTargetChoice: String, CaseIterable, Identifiable {
+        case display = "Full display"
+        case window = "Window…"
+
+        var id: String { rawValue }
+    }
+
+    @State private var selectedChoice: CaptureTargetChoice = .display
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -57,6 +81,86 @@ struct NewRecordingSheet: View {
                 Text("Capture now, generate notes later — good when Ollama / Apple Intelligence is unavailable.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Picker("Capture target", selection: $selectedChoice) {
+                    ForEach(CaptureTargetChoice.allCases) { choice in
+                        Text(choice.rawValue).tag(choice)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+                .onChange(of: selectedChoice) { _, newValue in
+                    switch newValue {
+                    case .display:
+                        setup.captureTarget = .display
+                        selectedWindowId = nil
+                    case .window:
+                        setup.captureTarget = .window(windowId: 0)  // Placeholder, will be set from list
+                    }
+                }
+
+                if selectedChoice == .window {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            if isFetchingWindows {
+                                ProgressView()
+                            } else if let error = windowsError {
+                                Text("Error: \(error.localizedDescription)")
+                                    .foregroundColor(.red)
+                                    .font(.caption)
+                            } else {
+                                Text("Select a window to capture")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if !isFetchingWindows && windowList.isEmpty && windowsError == nil {
+                                Button("Refresh") {
+                                    Task { @MainActor in
+                                        await fetchWindows()
+                                    }
+                                }
+                                .font(.caption)
+                            }
+                        }
+
+                        if isFetchingWindows {
+                            Text("Loading windows…")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else if windowsError != nil {
+                            Text("No windows available — recording the full display instead")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Button("Try again") {
+                                Task { @MainActor in
+                                    await fetchWindows()
+                                }
+                            }
+                        } else if windowList.isEmpty {
+                            Text("No windows available — recording the full display instead")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Button("Try again") {
+                                Task { @MainActor in
+                                    await fetchWindows()
+                                }
+                            }
+                        } else {
+                            Picker("Window", selection: $selectedWindowId) {
+                                ForEach(windowList) { window in
+                                    Text("\(window.appName): \(window.title)")
+                                        .tag(window.windowId)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .onChange(of: selectedWindowId) { _, newValue in
+                                if let id = newValue {
+                                    setup.captureTarget = .window(windowId: id)
+                                }
+                            }
+                        }
+                    }
+                }
             }
             .formStyle(.grouped)
 
@@ -72,5 +176,27 @@ struct NewRecordingSheet: View {
             .padding(20)
         }
         .frame(width: 420)
+        .onAppear {
+            Task { @MainActor in
+                await fetchWindows()
+            }
+        }
+    }
+
+    private func fetchWindows() async {
+        isFetchingWindows = true
+        windowsError = nil
+        defer { isFetchingWindows = false }
+
+        do {
+            let windows = try await IpcClientMock.captureWindows()
+            windowList = windows
+        } catch {
+            windowsError = error
+            // On error, fall back to display mode
+            selectedChoice = .display
+            setup.captureTarget = .display
+            selectedWindowId = nil
+        }
     }
 }

--- a/apps/Panops/Tests/PanopsTests/CaptureTargetResolverTests.swift
+++ b/apps/Panops/Tests/PanopsTests/CaptureTargetResolverTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import Panops
+
+@Suite("Capture-target resolver")
+struct CaptureTargetResolverTests {
+    private let windows = [
+        WindowInfo(windowId: 42, appName: "Safari", title: "Panops"),
+        WindowInfo(windowId: 7, appName: "Xcode", title: "App.swift"),
+    ]
+
+    @Test("display choice resolves to .display and can start")
+    func displayChoice() {
+        let target = CaptureTargetResolver.resolve(
+            choice: .display, selectedWindowId: nil, windowList: windows
+        )
+        #expect(target == .display)
+        #expect(CaptureTargetResolver.canStart(target: target))
+    }
+
+    @Test("a chosen window maps to capture_target .window(id)")
+    func chosenWindowMapsToWindowId() {
+        let target = CaptureTargetResolver.resolve(
+            choice: .window, selectedWindowId: 42, windowList: windows
+        )
+        #expect(target == .window(windowId: 42))
+        #expect(CaptureTargetResolver.canStart(target: target))
+    }
+
+    @Test("window choice with no selection blocks Start")
+    func windowChoiceWithoutSelectionBlocksStart() {
+        let target = CaptureTargetResolver.resolve(
+            choice: .window, selectedWindowId: nil, windowList: windows
+        )
+        #expect(target == .window(windowId: 0))
+        #expect(!CaptureTargetResolver.canStart(target: target))
+    }
+
+    @Test("window choice with an empty list falls back to display")
+    func windowChoiceWithEmptyListFallsBack() {
+        let target = CaptureTargetResolver.resolve(
+            choice: .window, selectedWindowId: nil, windowList: []
+        )
+        #expect(target == .display)
+        #expect(CaptureTargetResolver.canStart(target: target))
+    }
+
+    @Test("a stale selection not in the list blocks Start")
+    func staleSelectionBlocksStart() {
+        let target = CaptureTargetResolver.resolve(
+            choice: .window, selectedWindowId: 999, windowList: windows
+        )
+        #expect(target == .window(windowId: 0))
+        #expect(!CaptureTargetResolver.canStart(target: target))
+    }
+
+    @Test("window_id 0 is never submittable")
+    func windowIdZeroNeverSubmittable() {
+        #expect(!CaptureTargetResolver.canStart(target: .window(windowId: 0)))
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -376,6 +376,40 @@ struct IpcClientCodecTests {
         #expect(window.title == "Example Window")
     }
 
+    @Test("CaptureWindowsResult decodes the {windows:[...]} wrapper")
+    func captureWindowsResult_decodes() throws {
+        let json = #"""
+        {
+          "windows": [
+            { "window_id": 42, "app_name": "Safari", "title": "Panops" },
+            { "window_id": 7, "app_name": "Xcode", "title": "App.swift" }
+          ]
+        }
+        """#
+        let result = try decoder.decode(CaptureWindowsResult.self, from: json.data(using: .utf8)!)
+        #expect(result.windows.count == 2)
+        #expect(result.windows[0] == WindowInfo(windowId: 42, appName: "Safari", title: "Panops"))
+        #expect(result.windows[1].windowId == 7)
+    }
+
+    @Test("CaptureWindowsResult decodes an empty window list")
+    func captureWindowsResult_decodesEmpty() throws {
+        let json = #"{ "windows": [] }"#
+        let result = try decoder.decode(CaptureWindowsResult.self, from: json.data(using: .utf8)!)
+        #expect(result.windows.isEmpty)
+    }
+
+    @Test("capture.windows request encodes empty params as a positional array")
+    func captureWindowsRequest_encodesEmptyParams() throws {
+        // The engine handler takes a `CaptureWindowsParams {}` arg: the param must
+        // be a 1-element positional array holding an empty object, not omitted.
+        let req = JsonRpcRequest(id: 1, method: "ipc.capture.windows", param: EmptyParams())
+        let data = try encoder.encode(req)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"method\":\"ipc.capture.windows\""), "method missing: \(json)")
+        #expect(json.contains("\"params\":[{}]"), "expected [{}] params, got: \(json)")
+    }
+
     @Test("CaptureTarget.display encodes correctly")
     func captureTarget_display_encodes() throws {
         let encoder = JSONEncoder()

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -360,4 +360,41 @@ struct IpcClientCodecTests {
         #expect(result.deleted == false)
         #expect(result.freedBytes == 0)
     }
+
+    @Test("WindowInfo decodes from engine response")
+    func windowInfo_decodes() throws {
+        let json = #"""
+        {
+          "window_id": 123,
+          "app_name": "Safari",
+          "title": "Example Window"
+        }
+        """#
+        let window = try decoder.decode(WindowInfo.self, from: json.data(using: .utf8)!)
+        #expect(window.windowId == 123)
+        #expect(window.appName == "Safari")
+        #expect(window.title == "Example Window")
+    }
+
+    @Test("CaptureTarget.display encodes correctly")
+    func captureTarget_display_encodes() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let wire = CaptureTargetWire(.display)
+        let data = try encoder.encode(wire)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"kind\":\"display\""))
+        #expect(!json.contains("\"window_id\""), "window_id should be omitted for display: \(json)")
+    }
+
+    @Test("CaptureTarget.window encodes correctly")
+    func captureTarget_window_encodes() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let wire = CaptureTargetWire(.window(windowId: 456))
+        let data = try encoder.encode(wire)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"kind\":\"window\""))
+        #expect(json.contains("\"window_id\":456"))
+    }
 }

--- a/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
+++ b/apps/Panops/Tests/PanopsTests/LiveRecordingControllerTests.swift
@@ -109,6 +109,18 @@ struct LiveRecordingControllerTests {
         #expect(lastAutoGenerateNotes == false)
     }
 
+    @Test("start passes captureTarget to engine")
+    func startRecordsCaptureTarget() async throws {
+        let fake = FakeLiveRecordingIpcClient()
+        let controller = LiveRecordingController(ipcClient: fake)
+
+        let options = RecordingOptions(captureTarget: .window(windowId: 123))
+        try await controller.start(meetingId: "meeting-1", options: options)
+
+        let target = await fake.lastCaptureTargetValue()
+        #expect(target == .window(windowId: 123))
+    }
+
     @Test("stop surfaces the engine-issued auto-notes job id")
     func stopSurfacesNotesJobId() async throws {
         let stopped = RecordingStopped(
@@ -180,6 +192,7 @@ private actor FakeLiveRecordingIpcClient: LiveRecordingIpcClient {
     private let stopped: RecordingStopped
     private var lastRecordVideo: Bool = false
     private var lastAutoGenerateNotes: Bool = false
+    private var lastCaptureTarget: CaptureTarget = .display
 
     init(
         startDelayNanoseconds: UInt64 = 0,
@@ -207,11 +220,13 @@ private actor FakeLiveRecordingIpcClient: LiveRecordingIpcClient {
         screenshotIntervalMs: UInt64,
         screenshotThreshold: Float,
         recordVideo: Bool,
-        autoGenerateNotes: Bool
+        autoGenerateNotes: Bool,
+        captureTarget: CaptureTarget
     ) async throws -> RecordingAccepted {
         startCalls += 1
         lastRecordVideo = recordVideo
         lastAutoGenerateNotes = autoGenerateNotes
+        lastCaptureTarget = captureTarget
         if startDelayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: startDelayNanoseconds)
         }
@@ -243,5 +258,13 @@ private actor FakeLiveRecordingIpcClient: LiveRecordingIpcClient {
 
     func startCallCountAndRecordVideo() -> (Int, Bool, Bool) {
         (startCalls, lastRecordVideo, lastAutoGenerateNotes)
+    }
+
+    func captureWindows() async throws -> [WindowInfo] {
+        []
+    }
+
+    func lastCaptureTargetValue() -> CaptureTarget {
+        lastCaptureTarget
     }
 }

--- a/apps/Panops/Tests/PanopsTests/RecordingControllerOptionsTests.swift
+++ b/apps/Panops/Tests/PanopsTests/RecordingControllerOptionsTests.swift
@@ -10,6 +10,7 @@ private actor CapturingRecordingIpcClient: LiveRecordingIpcClient {
     private(set) var threshold: Float?
     private(set) var recordVideo: Bool?
     private(set) var autoGenerateNotes: Bool?
+    private(set) var captureTarget: CaptureTarget?
 
     func recordingStart(
         meetingId: String,
@@ -17,13 +18,15 @@ private actor CapturingRecordingIpcClient: LiveRecordingIpcClient {
         screenshotIntervalMs: UInt64,
         screenshotThreshold: Float,
         recordVideo: Bool,
-        autoGenerateNotes: Bool
+        autoGenerateNotes: Bool,
+        captureTarget: CaptureTarget
     ) async throws -> RecordingAccepted {
         self.audioSources = audioSources
         self.intervalMs = screenshotIntervalMs
         self.threshold = screenshotThreshold
         self.recordVideo = recordVideo
         self.autoGenerateNotes = autoGenerateNotes
+        self.captureTarget = captureTarget
         return RecordingAccepted(recordingId: "rec-1")
     }
 
@@ -33,6 +36,10 @@ private actor CapturingRecordingIpcClient: LiveRecordingIpcClient {
 
     func meetingDeleteVideo(meetingId: String) async throws -> (deleted: Bool, freedBytes: UInt64) {
         (deleted: false, freedBytes: 0)
+    }
+
+    func captureWindows() async throws -> [WindowInfo] {
+        []
     }
 }
 

--- a/apps/panops-capture-mac/README.md
+++ b/apps/panops-capture-mac/README.md
@@ -39,7 +39,8 @@ reserved but unemitted for v0.1).
   "screenshots_dir":"<meeting_dir>/screenshots",
   "audio_sources":"system_and_mic",
   "screenshot_interval_ms":500,
-  "screenshot_threshold":0.15
+  "screenshot_threshold":0.15,
+  "capture_target":{"kind":"display"}
 }]}
 ```
 
@@ -47,6 +48,30 @@ reserved but unemitted for v0.1).
 
 A `null` audio path means "do not capture that source"; the paths MUST agree
 with `audio_sources` (`system_only` / `mic_only` / `system_and_mic`).
+
+`capture_target` selects what the `SCStream` captures: `{"kind":"display"}`
+(default; omit the field for the same effect) captures the first display, and
+`{"kind":"window","window_id":<u32>}` captures a single window by its
+`SCWindow.windowID` (from `--list-windows` below). An unknown `window_id` falls
+back to full-display capture (logged to stderr); capture never fails on it.
+
+## Window enumeration (`--list-windows`)
+
+Invoked with `--list-windows`, the sidecar enumerates on-screen windows, prints
+a JSON array to stdout, and exits 0 — no capture session:
+
+```bash
+panops-capture-mac --list-windows
+```
+
+```json
+[{"window_id":12345,"app_name":"Zoom","title":"Standup"}, ...]
+```
+
+`window_id` is the `SCWindow.windowID` to pass back as `capture_target`. panops's
+own windows, untitled windows, and zero-frame windows are filtered out.
+Enumeration failure (e.g. Screen-Recording denied) prints `[]`. Like live
+capture, this needs the Screen-Recording TCC grant.
 
 `capture.stop`:
 

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/Codecs.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/Codecs.swift
@@ -12,6 +12,7 @@ struct CaptureParams: Decodable {
     let screenshotIntervalMs: UInt64?
     let screenshotThreshold: Float?
     let recordVideo: Bool?               // also mux a playable recording.mov
+    let captureTarget: CaptureTarget?    // what the SCStream captures (default: display)
 
     enum CodingKeys: String, CodingKey {
         case meetingId = "meeting_id"
@@ -22,6 +23,20 @@ struct CaptureParams: Decodable {
         case screenshotIntervalMs = "screenshot_interval_ms"
         case screenshotThreshold = "screenshot_threshold"
         case recordVideo = "record_video"
+        case captureTarget = "capture_target"
+    }
+}
+
+/// Wire form of `capture_target`: `{"kind":"display"}` (default) or
+/// `{"kind":"window","window_id":<u32>}`. Decoded leniently — domain mapping
+/// (and the display fallback for malformed shapes) lives in `CaptureTargetKind`.
+struct CaptureTarget: Decodable {
+    let kind: String                     // "display" | "window"
+    let windowId: UInt32?                // present when kind == "window"
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case windowId = "window_id"
     }
 }
 

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/Recorder.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/Recorder.swift
@@ -53,6 +53,7 @@ final class Recorder: NSObject, SCStreamOutput, @unchecked Sendable {
 
     private let plan: TrackPlan
     private let videoPath: String?
+    private let target: CaptureTargetKind
     private let lock = NSLock()
     private var stream: SCStream?
     private var systemWriter: WavWriter?
@@ -63,9 +64,16 @@ final class Recorder: NSObject, SCStreamOutput, @unchecked Sendable {
     private let sampleQueue = DispatchQueue(label: "ar.tzk.panops.capture.audio")
     private(set) var startedAtMs: UInt64 = 0
 
-    init(plan: TrackPlan, systemPath: String?, micPath: String?, videoPath: String?) throws {
+    init(
+        plan: TrackPlan,
+        systemPath: String?,
+        micPath: String?,
+        videoPath: String?,
+        target: CaptureTargetKind = .display
+    ) throws {
         self.plan = plan
         self.videoPath = videoPath
+        self.target = target
         super.init()
 
         guard !plan.wantsSystem || systemPath != nil else {
@@ -100,10 +108,30 @@ final class Recorder: NSObject, SCStreamOutput, @unchecked Sendable {
         } catch {
             throw Self.mapSCStreamError(error)
         }
-        guard let display = content.displays.first else {
-            throw CaptureFailure.noDisplay
+        // Resolve the content filter + capture dimensions from the target.
+        // window: a desktop-independent filter over the matching SCWindow;
+        // display (or an unknown window_id): the full first display.
+        let filter: SCContentFilter
+        let width: Int
+        let height: Int
+        switch target {
+        case .window(let windowID):
+            if let window = content.windows.first(where: { UInt32($0.windowID) == windowID }) {
+                filter = SCContentFilter(desktopIndependentWindow: window)
+                width = Int(window.frame.width)
+                height = Int(window.frame.height)
+            } else {
+                FileHandle.standardError.write(
+                    Data("capture_target window \(windowID) not found; using full display\n".utf8))
+                guard let display = content.displays.first else { throw CaptureFailure.noDisplay }
+                filter = SCContentFilter(display: display, excludingWindows: [])
+                (width, height) = (display.width, display.height)
+            }
+        case .display:
+            guard let display = content.displays.first else { throw CaptureFailure.noDisplay }
+            filter = SCContentFilter(display: display, excludingWindows: [])
+            (width, height) = (display.width, display.height)
         }
-        let filter = SCContentFilter(display: display, excludingWindows: [])
 
         let config = SCStreamConfiguration()
         config.capturesAudio = plan.wantsSystem
@@ -118,8 +146,8 @@ final class Recorder: NSObject, SCStreamOutput, @unchecked Sendable {
         config.channelCount = 1
         // Screen frames feed the screenshotter. Cadence is bounded by the
         // minimum frame interval; the screenshotter dedups beyond that.
-        config.width = display.width
-        config.height = display.height
+        config.width = width
+        config.height = height
         config.pixelFormat = kCVPixelFormatType_32BGRA
         config.queueDepth = 5
         // Frame cadence: a video recording needs a smooth rate, but the
@@ -139,7 +167,7 @@ final class Recorder: NSObject, SCStreamOutput, @unchecked Sendable {
         if let path = videoPath {
             do {
                 writer = try VideoWriter(
-                    url: URL(fileURLWithPath: path), width: display.width, height: display.height
+                    url: URL(fileURLWithPath: path), width: width, height: height
                 )
             } catch {
                 FileHandle.standardError.write(

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/Windows.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/Windows.swift
@@ -1,0 +1,86 @@
+import Foundation
+import ScreenCaptureKit
+
+/// What an `SCStream` should capture: the whole display (default) or one window
+/// by its `SCWindow.windowID`. Parsed from the `capture_target` start param.
+enum CaptureTargetKind: Equatable {
+    case display
+    case window(UInt32)
+
+    /// Map the wire `capture_target` to a target. A missing param, an
+    /// unrecognized kind, or a `"window"` kind without a `window_id` all fall
+    /// back to full-display capture (the slice-11 default), so a malformed
+    /// target degrades to the safe behavior instead of failing the session.
+    init(wire: CaptureTarget?) {
+        switch wire?.kind {
+        case "window":
+            if let id = wire?.windowId { self = .window(id) } else { self = .display }
+        default:
+            self = .display
+        }
+    }
+}
+
+/// One on-screen window in the wire shape the engine's `--list-windows`
+/// consumer binds to: `{"window_id":<u32>,"app_name":"<string>","title":"<string>"}`.
+struct WindowInfo: Encodable, Equatable {
+    let windowId: UInt32
+    let appName: String
+    let title: String
+
+    enum CodingKeys: String, CodingKey {
+        case windowId = "window_id"
+        case appName = "app_name"
+        case title = "title"
+    }
+}
+
+/// Raw `SCWindow` properties in a ScreenCaptureKit-free form so the filter +
+/// shape logic is unit-testable without a live display.
+struct RawWindow {
+    let windowID: UInt32
+    let appName: String?
+    let bundleID: String?
+    let title: String?
+    let isEmptyFrame: Bool
+}
+
+/// True when a window belongs to panops itself (the app or this sidecar) — by
+/// bundle-id prefix or app name — so we never offer panops's own UI as a
+/// capture target.
+func isPanopsOwned(bundleID: String?, appName: String) -> Bool {
+    if let bundleID, bundleID.hasPrefix("ar.tzk.panops") { return true }
+    return appName.lowercased().contains("panops")
+}
+
+/// Filter raw windows to shareable targets and map to the wire shape: drop
+/// zero-frame windows, untitled windows, and panops's own windows. An empty
+/// `app_name` is kept (the contract allows it) as long as the window is titled.
+func shareableWindows(_ raws: [RawWindow]) -> [WindowInfo] {
+    raws.compactMap { raw in
+        guard !raw.isEmptyFrame else { return nil }
+        let title = raw.title ?? ""
+        guard !title.isEmpty else { return nil }
+        let appName = raw.appName ?? ""
+        guard !isPanopsOwned(bundleID: raw.bundleID, appName: appName) else { return nil }
+        return WindowInfo(windowId: raw.windowID, appName: appName, title: title)
+    }
+}
+
+/// Enumerate on-screen, non-desktop windows as filtered wire-shape entries.
+/// Throws if ScreenCaptureKit enumeration fails (e.g. Screen-Recording denied).
+func listShareableWindows() async throws -> [WindowInfo] {
+    let content = try await SCShareableContent.excludingDesktopWindows(
+        true, onScreenWindowsOnly: true
+    )
+    let raws = content.windows.map { window in
+        RawWindow(
+            windowID: UInt32(window.windowID),
+            appName: window.owningApplication?.applicationName,
+            bundleID: window.owningApplication?.bundleIdentifier,
+            title: window.title,
+            isEmptyFrame: window.frame.isEmpty   // CGRect.isEmpty: width or height <= 0
+        )
+    }
+    return shareableWindows(raws)
+}

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/main.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/main.swift
@@ -1,11 +1,40 @@
 import Foundation
 import Darwin
+import ScreenCaptureKit
 
 // Stateful capture sidecar. Unlike the request/response ASR sidecar, capture
 // is a session: `capture.start` opens an SCStream + screenshotter and acks;
 // `capture.stop` finalizes and returns the paths. One session at a time.
 
 FileHandle.standardError.write(Data("panops-capture-mac starting\n".utf8))
+
+/// One-shot window enumeration: print the on-screen windows as a JSON array to
+/// stdout and exit, before any capture session. On enumeration failure (e.g.
+/// Screen-Recording denied) emit `[]` so the engine always parses valid JSON.
+func runListWindows() async {
+    let windows: [WindowInfo]
+    do {
+        windows = try await listShareableWindows()
+    } catch {
+        FileHandle.standardError.write(Data("--list-windows enumeration failed: \(error)\n".utf8))
+        print("[]")
+        fflush(stdout)
+        return
+    }
+    let enc = JSONEncoder()
+    enc.outputFormatting = [.withoutEscapingSlashes]
+    if let data = try? enc.encode(windows), let line = String(data: data, encoding: .utf8) {
+        print(line)
+    } else {
+        print("[]")
+    }
+    fflush(stdout)
+}
+
+if CommandLine.arguments.contains("--list-windows") {
+    await runListWindows()
+    exit(0)
+}
 
 /// A live capture: the SCStream recorder + the screen-frame screenshotter,
 /// keyed by the meeting that started it.
@@ -138,7 +167,8 @@ while !shutdownRequested, let line = readLine(strippingNewline: true) {
                 plan: plan,
                 systemPath: params.systemAudioPath,
                 micPath: params.micAudioPath,
-                videoPath: videoPath
+                videoPath: videoPath,
+                target: CaptureTargetKind(wire: params.captureTarget)
             )
             let screenshotter = try Screenshotter(
                 dir: params.screenshotsDir ?? FileManager.default.temporaryDirectory.path,

--- a/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/WindowTargetingTests.swift
+++ b/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/WindowTargetingTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import PanopsCaptureMac
+
+/// Covers the pure window-targeting logic that runs without ScreenCaptureKit:
+/// the `--list-windows` filter + JSON shape and `capture_target` decoding into a
+/// `CaptureTargetKind`. The live `SCShareableContent`/`SCContentFilter` path is
+/// exercised by the manual Mac smoke (no screen/TCC in CI).
+struct WindowTargetingTests {
+    // MARK: - --list-windows filter + shape
+
+    @Test func shareableWindowsMapsAndDropsNonShareable() {
+        let raws = [
+            RawWindow(windowID: 1, appName: "Zoom", bundleID: "us.zoom.xos",
+                      title: "Standup", isEmptyFrame: false),                      // kept
+            RawWindow(windowID: 2, appName: "Finder", bundleID: "com.apple.finder",
+                      title: "", isEmptyFrame: false),                             // untitled → drop
+            RawWindow(windowID: 3, appName: "Safari", bundleID: "com.apple.Safari",
+                      title: "News", isEmptyFrame: true),                          // zero frame → drop
+            RawWindow(windowID: 4, appName: "panops", bundleID: "ar.tzk.panops.capture-mac",
+                      title: "panops", isEmptyFrame: false),                       // own window → drop
+        ]
+        #expect(shareableWindows(raws) == [WindowInfo(windowId: 1, appName: "Zoom", title: "Standup")])
+    }
+
+    @Test func emptyAppNameKeptWhenTitled() {
+        // app_name = applicationName ?? "" — an empty app_name is valid output.
+        let raws = [RawWindow(windowID: 9, appName: nil, bundleID: nil,
+                              title: "Untitled doc", isEmptyFrame: false)]
+        #expect(shareableWindows(raws) == [WindowInfo(windowId: 9, appName: "", title: "Untitled doc")])
+    }
+
+    @Test func isPanopsOwnedByBundlePrefixOrName() {
+        #expect(isPanopsOwned(bundleID: "ar.tzk.panops", appName: ""))
+        #expect(isPanopsOwned(bundleID: "ar.tzk.panops.capture-mac", appName: "x"))
+        #expect(isPanopsOwned(bundleID: nil, appName: "Panops"))          // name match, any case
+        #expect(!isPanopsOwned(bundleID: "us.zoom.xos", appName: "Zoom"))
+    }
+
+    @Test func windowInfoEncodesWireShape() throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys]
+        let data = try enc.encode(WindowInfo(windowId: 42, appName: "Zoom", title: "Meeting"))
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json == #"{"app_name":"Zoom","title":"Meeting","window_id":42}"#)
+    }
+
+    // MARK: - capture_target parsing
+
+    @Test func captureParamsDecodesWindowTarget() throws {
+        let json = #"{"meeting_id":"m1","capture_target":{"kind":"window","window_id":7}}"#
+        let params = try JSONDecoder().decode(CaptureParams.self, from: Data(json.utf8))
+        #expect(params.captureTarget?.kind == "window")
+        #expect(params.captureTarget?.windowId == 7)
+        #expect(CaptureTargetKind(wire: params.captureTarget) == .window(7))
+    }
+
+    @Test func captureParamsWithoutTargetDefaultsToDisplay() throws {
+        let json = #"{"meeting_id":"m1"}"#
+        let params = try JSONDecoder().decode(CaptureParams.self, from: Data(json.utf8))
+        #expect(params.captureTarget == nil)
+        #expect(CaptureTargetKind(wire: params.captureTarget) == .display)
+    }
+
+    @Test func displayKindMapsToDisplay() throws {
+        let target = try JSONDecoder().decode(CaptureTarget.self, from: Data(#"{"kind":"display"}"#.utf8))
+        #expect(CaptureTargetKind(wire: target) == .display)
+    }
+
+    @Test func windowKindWithoutIdFallsBackToDisplay() throws {
+        // Malformed window target (no window_id) degrades to full-display capture.
+        let target = try JSONDecoder().decode(CaptureTarget.self, from: Data(#"{"kind":"window"}"#.utf8))
+        #expect(CaptureTargetKind(wire: target) == .display)
+    }
+
+    @Test func unknownKindFallsBackToDisplay() throws {
+        let target = try JSONDecoder().decode(CaptureTarget.self, from: Data(#"{"kind":"bogus"}"#.utf8))
+        #expect(CaptureTargetKind(wire: target) == .display)
+    }
+}

--- a/crates/panops-core/src/capture.rs
+++ b/crates/panops-core/src/capture.rs
@@ -24,6 +24,24 @@ pub enum AudioSources {
     SystemAndMic,
 }
 
+/// Screen target to capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CaptureTarget {
+    /// Capture the full display.
+    #[default]
+    Display,
+    /// Capture a specific window by ScreenCaptureKit window id.
+    Window { window_id: u32 },
+}
+
+/// Window metadata returned by [`Capture::list_windows`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowInfo {
+    pub window_id: u32,
+    pub app_name: String,
+    pub title: String,
+}
+
 /// Configuration for a capture session.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CaptureConfig {
@@ -35,6 +53,8 @@ pub struct CaptureConfig {
     pub screenshot_interval_ms: u64,
     /// Vision FeaturePrint cosine distance threshold for change detection.
     pub screenshot_threshold: f32,
+    /// Screen target to capture. Defaults to full-display capture.
+    pub capture_target: CaptureTarget,
 }
 
 impl Default for CaptureConfig {
@@ -44,6 +64,7 @@ impl Default for CaptureConfig {
             record_video: false,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
+            capture_target: CaptureTarget::Display,
         }
     }
 }
@@ -101,6 +122,9 @@ pub enum CaptureError {
 /// runs ScreenCaptureKit + AVFoundation. Fake adapters (FakeCapture)
 /// yield synthetic PCM frames and pre-generated screenshot fixtures.
 pub trait Capture: Send + Sync {
+    /// List capturable windows.
+    fn list_windows(&self) -> Result<Vec<WindowInfo>, CaptureError>;
+
     /// Start capturing audio + screenshots for a meeting.
     /// Returns a session handle. Audio + screenshots stream as IPC events
     /// (implemented at the engine layer, not here).
@@ -131,6 +155,12 @@ mod tests {
         assert!(!cfg.record_video);
         assert_eq!(cfg.screenshot_interval_ms, 500);
         assert!(cfg.screenshot_threshold > 0.0 && cfg.screenshot_threshold < 1.0);
+        assert_eq!(cfg.capture_target, CaptureTarget::Display);
+    }
+
+    #[test]
+    fn capture_target_default_is_display() {
+        assert_eq!(CaptureTarget::default(), CaptureTarget::Display);
     }
 
     #[test]

--- a/crates/panops-core/src/conformance/capture.rs
+++ b/crates/panops-core/src/conformance/capture.rs
@@ -12,7 +12,9 @@
 
 use std::path::Path;
 
-use crate::capture::{AudioSources, Capture, CaptureConfig, CaptureError, CaptureSession};
+use crate::capture::{
+    AudioSources, Capture, CaptureConfig, CaptureError, CaptureSession, CaptureTarget,
+};
 
 /// Run the full conformance suite against a `Capture` implementation.
 ///
@@ -30,13 +32,31 @@ pub fn run_suite<C: Capture>(adapter: &C, fixtures_dir: &Path) {
 /// `false` — it must not opt out of the production marker just because its
 /// sidecar is stubbed for CI.
 pub fn run_suite_with<C: Capture>(adapter: &C, fixtures_dir: &Path, expected_is_fake: bool) {
+    list_windows_returns_window_info(adapter);
     start_returns_session(adapter, fixtures_dir);
+    start_accepts_window_capture_target(adapter, fixtures_dir);
     stop_returns_valid_audio(adapter, fixtures_dir);
     stop_returns_screenshot_paths(adapter, fixtures_dir);
     stop_track_presence_matches_sources(adapter);
     record_video_writes_recording_mov(adapter);
     stop_session_not_found(adapter);
     is_fake_marker(adapter, expected_is_fake);
+}
+
+fn list_windows_returns_window_info<C: Capture>(adapter: &C) {
+    let windows = adapter.list_windows().expect("list_windows should succeed");
+    assert!(
+        !windows.is_empty(),
+        "list_windows must return at least one capturable window"
+    );
+    for window in windows {
+        assert_ne!(window.window_id, 0, "window_id should be non-zero");
+        assert!(
+            !window.app_name.trim().is_empty(),
+            "app_name should be non-empty"
+        );
+        assert!(!window.title.trim().is_empty(), "title should be non-empty");
+    }
 }
 
 fn temp_meeting_dir() -> std::path::PathBuf {
@@ -77,6 +97,32 @@ fn start_returns_session<C: Capture>(adapter: &C, _fixtures_dir: &Path) {
     let _ = adapter.stop_capture(&session);
 
     // Clean up temp dir.
+    let _ = std::fs::remove_dir_all(&meeting_dir);
+}
+
+fn start_accepts_window_capture_target<C: Capture>(adapter: &C, _fixtures_dir: &Path) {
+    let meeting_id = "test_meeting_window_target";
+    let meeting_dir = temp_meeting_dir();
+    std::fs::create_dir_all(&meeting_dir).expect("create temp meeting dir");
+
+    let window = adapter
+        .list_windows()
+        .expect("list_windows should succeed")
+        .into_iter()
+        .next()
+        .expect("conformance window");
+    let config = CaptureConfig {
+        capture_target: CaptureTarget::Window {
+            window_id: window.window_id,
+        },
+        ..CaptureConfig::default()
+    };
+    let session = adapter
+        .start_capture(meeting_id, &meeting_dir, &config)
+        .expect("start_capture should accept a window target");
+    assert_eq!(session.meeting_id, meeting_id);
+    let _ = adapter.stop_capture(&session);
+
     let _ = std::fs::remove_dir_all(&meeting_dir);
 }
 

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -714,6 +714,7 @@ use std::path::PathBuf;
 
 use crate::capture::{
     AudioSources, Capture, CaptureConfig, CaptureError, CaptureResult, CaptureSession,
+    CaptureTarget, WindowInfo,
 };
 
 /// A fake `Capture` adapter for testing. Produces:
@@ -722,7 +723,15 @@ use crate::capture::{
 ///
 /// Thread-safe: sessions are tracked in an internal `Mutex<HashMap>`.
 pub struct FakeCapture {
-    sessions: Mutex<std::collections::HashMap<String, (PathBuf, u64, AudioSources, bool)>>,
+    sessions: Mutex<std::collections::HashMap<String, FakeCaptureSession>>,
+}
+
+struct FakeCaptureSession {
+    meeting_dir: PathBuf,
+    started_at_ms: u64,
+    audio_sources: AudioSources,
+    record_video: bool,
+    capture_target: CaptureTarget,
 }
 
 impl Default for FakeCapture {
@@ -740,6 +749,21 @@ impl FakeCapture {
 }
 
 impl Capture for FakeCapture {
+    fn list_windows(&self) -> Result<Vec<WindowInfo>, CaptureError> {
+        Ok(vec![
+            WindowInfo {
+                window_id: 101,
+                app_name: "Safari".into(),
+                title: "Panops Fixture Window".into(),
+            },
+            WindowInfo {
+                window_id: 202,
+                app_name: "Notes".into(),
+                title: "Meeting Notes".into(),
+            },
+        ])
+    }
+
     fn start_capture(
         &self,
         meeting_id: &str,
@@ -758,12 +782,13 @@ impl Capture for FakeCapture {
             .map_err(|_| CaptureError::Capture("mutex poisoned".into()))?;
         sessions.insert(
             meeting_id.to_string(),
-            (
-                meeting_dir.to_path_buf(),
+            FakeCaptureSession {
+                meeting_dir: meeting_dir.to_path_buf(),
                 started_at_ms,
-                config.audio_sources,
-                config.record_video,
-            ),
+                audio_sources: config.audio_sources,
+                record_video: config.record_video,
+                capture_target: config.capture_target,
+            },
         );
 
         Ok(CaptureSession {
@@ -777,32 +802,38 @@ impl Capture for FakeCapture {
             .sessions
             .lock()
             .map_err(|_| CaptureError::Capture("mutex poisoned".into()))?;
-        let (meeting_dir, started_at_ms, audio_sources, record_video) = sessions
+        let fake_session = sessions
             .remove(&session.meeting_id)
             .ok_or_else(|| CaptureError::SessionNotFound(session.meeting_id.clone()))?;
+        let _capture_target = fake_session.capture_target;
 
         // Compute duration (at least 1s for valid WAV).
         let ended_at_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|e| CaptureError::Capture(e.to_string()))?
             .as_millis() as u64;
-        let duration_ms = ended_at_ms.saturating_sub(started_at_ms).max(1000);
+        let duration_ms = ended_at_ms
+            .saturating_sub(fake_session.started_at_ms)
+            .max(1000);
 
         // Write one synthetic 16 kHz mono WAV per requested source — never a
         // mixed track (slice 11, Decision §2). Each field is `Some` only when
         // its source was requested via `audio_sources`.
-        let want_system = !matches!(audio_sources, AudioSources::MicOnly);
-        let want_mic = !matches!(audio_sources, AudioSources::SystemOnly);
+        let want_system = !matches!(fake_session.audio_sources, AudioSources::MicOnly);
+        let want_mic = !matches!(fake_session.audio_sources, AudioSources::SystemOnly);
         let system_audio_path = if want_system {
             Some(write_sine_wav(
-                &meeting_dir.join("system.wav"),
+                &fake_session.meeting_dir.join("system.wav"),
                 duration_ms,
             )?)
         } else {
             None
         };
         let mic_audio_path = if want_mic {
-            Some(write_sine_wav(&meeting_dir.join("mic.wav"), duration_ms)?)
+            Some(write_sine_wav(
+                &fake_session.meeting_dir.join("mic.wav"),
+                duration_ms,
+            )?)
         } else {
             None
         };
@@ -813,7 +844,7 @@ impl Capture for FakeCapture {
         // old ancestor-walk failed there). Emit a minimal embedded JPEG
         // (SOI + JFIF APP0 + EOI) instead — enough for the contract, which
         // only requires the screenshot paths to exist.
-        let screenshots_dir = meeting_dir.join("screenshots");
+        let screenshots_dir = fake_session.meeting_dir.join("screenshots");
         std::fs::create_dir_all(&screenshots_dir).map_err(CaptureError::Io)?;
 
         const FAKE_JPEG: &[u8] = &[
@@ -827,8 +858,8 @@ impl Capture for FakeCapture {
             screenshot_paths.push(dest_path);
         }
 
-        if record_video {
-            write_fake_mov(&meeting_dir.join("recording.mov"))?;
+        if fake_session.record_video {
+            write_fake_mov(&fake_session.meeting_dir.join("recording.mov"))?;
         }
 
         Ok(CaptureResult {

--- a/crates/panops-core/src/lib.rs
+++ b/crates/panops-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod wer;
 pub use asr::{AsrError, AsrProvider};
 pub use capture::{
     AudioSources, Capture, CaptureConfig, CaptureError, CaptureResult, CaptureSession,
+    CaptureTarget, WindowInfo,
 };
 pub use diar::{DiarError, Diarizer, SpeakerTurn};
 pub use exporter::{ExportArtifact, ExportError, NotesExporter};

--- a/crates/panops-engine/src/capture_resolver.rs
+++ b/crates/panops-engine/src/capture_resolver.rs
@@ -57,6 +57,14 @@ pub fn pick_capture() -> Arc<dyn Capture + Send + Sync> {
 struct NotYetImplementedCapture;
 
 impl Capture for NotYetImplementedCapture {
+    fn list_windows(
+        &self,
+    ) -> Result<Vec<panops_core::capture::WindowInfo>, panops_core::capture::CaptureError> {
+        Err(panops_core::capture::CaptureError::Capture(
+            "live capture not available — PANOPS_CAPTURE_SIDECAR_BIN not set".into(),
+        ))
+    }
+
     fn start_capture(
         &self,
         _meeting_id: &str,

--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -26,10 +26,11 @@ use panops_core::notes::ir::StructuredNotes;
 use panops_core::notes::pipeline::NotesGenerator;
 use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
-    Event, IpcError, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, Meeting,
-    MeetingConfig, MeetingDeleteVideoParams, MeetingDeleteVideoResult, MeetingSummary,
-    NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
-    RecordingStartParams, RecordingStopParams, RecordingStopped, ServerInfo,
+    CaptureWindowsParams, CaptureWindowsResult, Event, IpcError, JobAccepted, JobDoneEvent,
+    JobErrorEvent, JobProgressEvent, Meeting, MeetingConfig, MeetingDeleteVideoParams,
+    MeetingDeleteVideoResult, MeetingSummary, NotesDialect, NotesGenerateParams,
+    NotesGenerateResult, RecordingAccepted, RecordingStartParams, RecordingStopParams,
+    RecordingStopped, ServerInfo, WindowInfo,
 };
 use tokio::sync::broadcast;
 
@@ -97,6 +98,12 @@ pub(super) trait Ipc {
         &self,
         params: RecordingStopParams,
     ) -> Result<RecordingStopped, ErrorObjectOwned>;
+
+    #[method(name = "capture.windows")]
+    async fn capture_windows(
+        &self,
+        params: CaptureWindowsParams,
+    ) -> Result<CaptureWindowsResult, ErrorObjectOwned>;
 
     #[subscription(
         name = "events.subscribe" => "events",
@@ -439,6 +446,20 @@ impl IpcServer for IpcImpl {
         }
 
         Ok(stopped)
+    }
+
+    async fn capture_windows(
+        &self,
+        _params: CaptureWindowsParams,
+    ) -> Result<CaptureWindowsResult, ErrorObjectOwned> {
+        let capture = crate::capture_resolver::pick_capture();
+        spawn_blocking_into_ipc("capture.windows", move || {
+            let windows = capture.list_windows().map_err(IpcError::from)?;
+            Ok(CaptureWindowsResult {
+                windows: windows.into_iter().map(WindowInfo::from).collect(),
+            })
+        })
+        .await
     }
 
     async fn subscribe_events(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
@@ -1739,6 +1760,7 @@ mod recording_auto_generate_tests {
             auto_generate_notes: true,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
+            capture_target: panops_protocol::CaptureTarget::Display,
         })
         .await
         .expect("recording.start");
@@ -1805,6 +1827,7 @@ mod recording_auto_generate_tests {
             auto_generate_notes: true,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
+            capture_target: panops_protocol::CaptureTarget::Display,
         })
         .await
         .expect("recording.start");
@@ -1874,6 +1897,7 @@ mod recording_auto_generate_tests {
             auto_generate_notes: true,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
+            capture_target: panops_protocol::CaptureTarget::Display,
         })
         .await
         .expect("recording.start");

--- a/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
+++ b/crates/panops-engine/tests/ipc_recording_start_stop_round_trip.rs
@@ -17,7 +17,7 @@ use panops_core::conformance::fakes::{
 };
 use panops_core::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 use panops_engine::server::{EngineServices, run_serve_in_process};
-use panops_protocol::{Event, RecordingAccepted, RecordingStopped};
+use panops_protocol::{CaptureWindowsResult, Event, RecordingAccepted, RecordingStopped};
 use tempfile::tempdir;
 use tokio::sync::watch;
 
@@ -220,6 +220,55 @@ async fn recording_start_with_audio_sources_wire() {
     // audio_sources = mic_only → only the mic track is present.
     assert!(stopped.system_audio_path.is_none(), "no system track");
     assert!(stopped.mic_audio_path.is_some(), "mic track present");
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn capture_windows_returns_fake_window_list() {
+    ensure_test_capture();
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(panops_core::conformance::fakes::KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+    let result: CaptureWindowsResult = ClientT::request(
+        &client,
+        "ipc.capture.windows",
+        rpc_params![serde_json::json!({})],
+    )
+    .await
+    .expect("capture.windows");
+
+    assert!(
+        result.windows.iter().any(|w| w.window_id == 101
+            && w.app_name == "Safari"
+            && w.title == "Panops Fixture Window"),
+        "fake window list should be returned, got {:?}",
+        result.windows
+    );
 
     let _ = shutdown_tx.send(true);
     let _ = server.await;

--- a/crates/panops-mac/src/bin/fake_capture_sidecar.rs
+++ b/crates/panops-mac/src/bin/fake_capture_sidecar.rs
@@ -27,6 +27,17 @@ mod macos {
     use std::io::{BufRead, Write};
 
     pub fn run() {
+        if std::env::args().any(|arg| arg == "--list-windows") {
+            println!(
+                "{}",
+                serde_json::json!([
+                    { "window_id": 101u32, "app_name": "Safari", "title": "Panops Fixture Window" },
+                    { "window_id": 202u32, "app_name": "Notes", "title": "Meeting Notes" }
+                ])
+            );
+            return;
+        }
+
         let mode = std::env::var("PANOPS_FAKE_SIDECAR_MODE").unwrap_or_default();
         let stdin = std::io::stdin();
         let mut out = std::io::stdout();

--- a/crates/panops-mac/src/screencapturekit_capture.rs
+++ b/crates/panops-mac/src/screencapturekit_capture.rs
@@ -20,6 +20,7 @@ use std::sync::Mutex;
 
 use panops_core::capture::{
     AudioSources, Capture, CaptureConfig, CaptureError, CaptureResult, CaptureSession,
+    CaptureTarget, WindowInfo,
 };
 use serde::{Deserialize, Deserializer};
 
@@ -123,6 +124,13 @@ struct StopResult {
     screenshot_paths: Vec<String>,
     #[serde(default)]
     duration_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct WindowInfoWire {
+    window_id: u32,
+    app_name: String,
+    title: String,
 }
 
 impl ScreenCaptureKitCapture {
@@ -308,6 +316,32 @@ impl ScreenCaptureKitCapture {
 }
 
 impl Capture for ScreenCaptureKitCapture {
+    fn list_windows(&self) -> Result<Vec<WindowInfo>, CaptureError> {
+        let output = Command::new(&self.binary)
+            .arg("--list-windows")
+            .envs(self.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .output()
+            .map_err(|e| CaptureError::Sidecar(format!("list-windows spawn: {e}")))?;
+        if !output.status.success() {
+            return Err(CaptureError::Sidecar(format!(
+                "list-windows exited with status {}",
+                output.status
+            )));
+        }
+        let windows: Vec<WindowInfoWire> = serde_json::from_slice(&output.stdout)
+            .map_err(|e| CaptureError::Sidecar(format!("list-windows decode: {e}")))?;
+        Ok(windows
+            .into_iter()
+            .map(|w| WindowInfo {
+                window_id: w.window_id,
+                app_name: w.app_name,
+                title: w.title,
+            })
+            .collect())
+    }
+
     fn start_capture(
         &self,
         meeting_id: &str,
@@ -325,6 +359,7 @@ impl Capture for ScreenCaptureKitCapture {
             "video_path": meeting_dir.join("recording.mov").display().to_string(),
             "screenshot_interval_ms": config.screenshot_interval_ms,
             "screenshot_threshold": config.screenshot_threshold,
+            "capture_target": capture_target_json(config.capture_target),
         });
         let started: StartedResult = self.call("capture.start", params)?;
         // Insert into the sessions map AFTER successful sidecar call.
@@ -414,6 +449,16 @@ fn audio_sources_str(sources: AudioSources) -> &'static str {
     }
 }
 
+/// Map `CaptureTarget` to the sidecar control-protocol shape.
+fn capture_target_json(target: CaptureTarget) -> serde_json::Value {
+    match target {
+        CaptureTarget::Display => serde_json::json!({ "kind": "display" }),
+        CaptureTarget::Window { window_id } => {
+            serde_json::json!({ "kind": "window", "window_id": window_id })
+        }
+    }
+}
+
 /// Map a sidecar JSON-RPC error code to an opaque `CaptureError`. Full
 /// detail is logged via `tracing`; only the code shapes the variant.
 fn map_sidecar_error(code: i32) -> CaptureError {
@@ -460,6 +505,18 @@ mod tests {
         assert_eq!(
             audio_sources_str(AudioSources::SystemAndMic),
             "system_and_mic"
+        );
+    }
+
+    #[test]
+    fn capture_target_json_uses_pinned_shape() {
+        assert_eq!(
+            capture_target_json(CaptureTarget::Display),
+            serde_json::json!({ "kind": "display" })
+        );
+        assert_eq!(
+            capture_target_json(CaptureTarget::Window { window_id: 42 }),
+            serde_json::json!({ "kind": "window", "window_id": 42 })
         );
     }
 

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -14,9 +14,10 @@ pub mod methods;
 
 pub use error::IpcError;
 pub use methods::{
-    AudioSourcesWire, Event, JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, LlmInfo,
-    Meeting, MeetingConfig, MeetingDeleteVideoParams, MeetingDeleteVideoResult, MeetingSummary,
-    NotesDialect, NotesGenerateParams, NotesGenerateResult, RecordingAccepted,
-    RecordingProgressEvent, RecordingStartParams, RecordingStopParams, RecordingStopped,
-    ScreenshotEvent, ServerInfo,
+    AudioSourcesWire, CaptureTarget, CaptureWindowsParams, CaptureWindowsResult, Event,
+    JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, LlmInfo, Meeting, MeetingConfig,
+    MeetingDeleteVideoParams, MeetingDeleteVideoResult, MeetingSummary, NotesDialect,
+    NotesGenerateParams, NotesGenerateResult, RecordingAccepted, RecordingProgressEvent,
+    RecordingStartParams, RecordingStopParams, RecordingStopped, ScreenshotEvent, ServerInfo,
+    WindowInfo,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -277,6 +277,35 @@ pub enum AudioSourcesWire {
     SystemAndMic,
 }
 
+/// Screen target selection for `recording.start`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CaptureTarget {
+    #[default]
+    Display,
+    Window {
+        window_id: u32,
+    },
+}
+
+/// Capturable window metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WindowInfo {
+    pub window_id: u32,
+    pub app_name: String,
+    pub title: String,
+}
+
+/// Params for `ipc.capture.windows`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CaptureWindowsParams {}
+
+/// Result for `ipc.capture.windows`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CaptureWindowsResult {
+    pub windows: Vec<WindowInfo>,
+}
+
 fn default_screenshot_interval() -> u64 {
     500
 }
@@ -307,6 +336,9 @@ pub struct RecordingStartParams {
     pub screenshot_interval_ms: u64,
     #[serde(default = "default_screenshot_threshold")]
     pub screenshot_threshold: f32,
+    /// Screen target to capture. Defaults to full-display capture.
+    #[serde(default)]
+    pub capture_target: CaptureTarget,
 }
 
 #[cfg(feature = "domain-conversions")]
@@ -332,6 +364,37 @@ impl From<panops_core::capture::AudioSources> for AudioSourcesWire {
 }
 
 #[cfg(feature = "domain-conversions")]
+impl From<CaptureTarget> for panops_core::capture::CaptureTarget {
+    fn from(value: CaptureTarget) -> Self {
+        match value {
+            CaptureTarget::Display => Self::Display,
+            CaptureTarget::Window { window_id } => Self::Window { window_id },
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::capture::CaptureTarget> for CaptureTarget {
+    fn from(value: panops_core::capture::CaptureTarget) -> Self {
+        match value {
+            panops_core::capture::CaptureTarget::Display => Self::Display,
+            panops_core::capture::CaptureTarget::Window { window_id } => Self::Window { window_id },
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::capture::WindowInfo> for WindowInfo {
+    fn from(value: panops_core::capture::WindowInfo) -> Self {
+        Self {
+            window_id: value.window_id,
+            app_name: value.app_name,
+            title: value.title,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
 impl From<&RecordingStartParams> for panops_core::capture::CaptureConfig {
     fn from(value: &RecordingStartParams) -> Self {
         Self {
@@ -339,6 +402,7 @@ impl From<&RecordingStartParams> for panops_core::capture::CaptureConfig {
             record_video: value.record_video,
             screenshot_interval_ms: value.screenshot_interval_ms,
             screenshot_threshold: value.screenshot_threshold,
+            capture_target: value.capture_target.into(),
         }
     }
 }
@@ -651,11 +715,16 @@ mod tests {
             auto_generate_notes: true,
             screenshot_interval_ms: 500,
             screenshot_threshold: 0.15,
+            capture_target: CaptureTarget::Window { window_id: 42 },
         };
         let json = serde_json::to_string(&p).unwrap();
         assert!(json.contains(r#""record_video":true"#), "got: {json}");
         assert!(
             json.contains(r#""auto_generate_notes":true"#),
+            "got: {json}"
+        );
+        assert!(
+            json.contains(r#""capture_target":{"kind":"window","window_id":42}"#),
             "got: {json}"
         );
         let back: RecordingStartParams = serde_json::from_str(&json).unwrap();
@@ -672,6 +741,7 @@ mod tests {
         assert!(!p.auto_generate_notes); // default/back-compat
         assert_eq!(p.screenshot_interval_ms, 500); // default
         assert_eq!(p.screenshot_threshold, 0.15); // default
+        assert_eq!(p.capture_target, CaptureTarget::Display); // default
     }
 
     #[cfg(feature = "domain-conversions")]
@@ -684,6 +754,7 @@ mod tests {
             auto_generate_notes: true,
             screenshot_interval_ms: 250,
             screenshot_threshold: 0.2,
+            capture_target: CaptureTarget::Window { window_id: 99 },
         };
         let cfg = panops_core::capture::CaptureConfig::from(&p);
         assert_eq!(
@@ -693,9 +764,52 @@ mod tests {
         assert!(cfg.record_video);
         assert_eq!(cfg.screenshot_interval_ms, 250);
         assert_eq!(cfg.screenshot_threshold, 0.2);
+        assert_eq!(
+            cfg.capture_target,
+            panops_core::capture::CaptureTarget::Window { window_id: 99 }
+        );
 
         let wire = AudioSourcesWire::from(panops_core::capture::AudioSources::SystemOnly);
         assert_eq!(wire, AudioSourcesWire::SystemOnly);
+        let wire_target =
+            CaptureTarget::from(panops_core::capture::CaptureTarget::Window { window_id: 7 });
+        assert_eq!(wire_target, CaptureTarget::Window { window_id: 7 });
+    }
+
+    #[test]
+    fn capture_target_wire_contracts_are_snake_case_tagged() {
+        assert_eq!(
+            serde_json::to_string(&CaptureTarget::Display).unwrap(),
+            r#"{"kind":"display"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&CaptureTarget::Window { window_id: 42 }).unwrap(),
+            r#"{"kind":"window","window_id":42}"#
+        );
+        let defaulted: RecordingStartParams =
+            serde_json::from_str(r#"{"meeting_id":"m1"}"#).unwrap();
+        assert_eq!(defaulted.capture_target, CaptureTarget::Display);
+    }
+
+    #[test]
+    fn capture_windows_shapes_round_trip() {
+        let params = CaptureWindowsParams {};
+        assert_eq!(serde_json::to_string(&params).unwrap(), r#"{}"#);
+
+        let result = CaptureWindowsResult {
+            windows: vec![WindowInfo {
+                window_id: 42,
+                app_name: "Safari".into(),
+                title: "Panops".into(),
+            }],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert_eq!(
+            json,
+            r#"{"windows":[{"window_id":42,"app_name":"Safari","title":"Panops"}]}"#
+        );
+        let back: CaptureWindowsResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, result);
     }
 
     #[test]


### PR DESCRIPTION
**Stacked on #219** (base = `feat/anchor-b-video-pr2`). Final piece of the screen-recording slice: record the **full display or a specific window** (privacy-cleaner for meetings — no desktop/notifications leak in).

Built in parallel across the fleet (codex Rust · claude sidecar · claudea app) against pinned wire contracts.

## What
- **Protocol/engine**: `recording.start` gains `capture_target` (`{"kind":"display"}` default or `{"kind":"window","window_id":N}`); new `ipc.capture.windows` → `{windows:[{window_id,app_name,title}]}` backed by a new `Capture::list_windows` port method. The macOS adapter implements it by invoking the capture sidecar in a one-shot `--list-windows` mode and parsing its JSON.
- **Capture sidecar**: a `--list-windows` mode (enumerates on-screen windows via `SCShareableContent`, emits the pinned JSON) and `capture_target` → `SCContentFilter` (full display, or `desktopIndependentWindow` by id; falls back to display + logs if the window's gone). The existing video + screenshot path operates on whatever the filter selects — no second stream.
- **App**: the New Recording sheet gains a **Capture target** picker (Full display / a specific window fetched via `capture.windows`), with graceful empty/error fallback to full display.

`CaptureTarget` lives on the domain `CaptureConfig` (it *is* a capture concern, unlike `auto_generate_notes`).

## Verified locally
- `cargo build/test/clippy --workspace --locked` — green **incl. Unix-socket IPC tests** (capture_target wire/default/shape, capture.windows, list_windows conformance).
- `apps/panops-capture-mac`: `swift build` clean + **31 tests** (9 new window-targeting).
- `apps/Panops`: `swift build` clean + **82 tests**.

## Notes
- Real window enumeration / window capture needs screen-recording permission (packaging slice); buildable + dev-testable now.
- This **completes the screen-recording slice** (#215 skeleton → #219 record+notes/defer → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)