### PR TITLE
ci: run package job on macos-26 (fixes #222)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,10 @@ jobs:
     # slow); runs on merge to main, the weekly cron, and manual dispatch —
     # mirrors heavy-test, so bundle/signing breakage is caught before release.
     if: github.event_name != 'pull_request'
-    runs-on: macos-latest
+    # macos-26: package.sh builds panops-llm-mac, whose Package.swift needs
+    # swift-tools 6.2 (only on macos-26's toolchain, like build-llm-sidecar);
+    # macos-latest ships Swift 6.1 and fails the manifest. See #222.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1.16.1


### PR DESCRIPTION
Fixes #222. The `package (ad-hoc .app)` job ran on `macos-latest` (Swift 6.1), but `scripts/package.sh` builds `panops-llm-mac` whose `Package.swift` declares `swift-tools-version: 6.2` → `error: package is using Swift tools version 6.2.0 but the installed version is 6.1.0`.

Move the job to **`macos-26`** — the same runner `build-llm-sidecar` already uses to build that sidecar successfully. One-line runner change; no manifest downgrade.

Note: the `package` job is `if: github.event_name != 'pull_request'`, so it does not run on this PR — it validates on merge to main. The runner is proven by the green `build-llm-sidecar (macos-26)` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)