### PR TITLE
build/packaging: bundle capture sidecar + simple dev/package commands

### DIFF
--- a/docs/dev-run.md
+++ b/docs/dev-run.md
@@ -3,6 +3,26 @@
 How to build and launch the Mac app from source during development. (For the
 distributable, brew-installable `.app`, see `docs/release-v0.1.md`.)
 
+## TL;DR — two commands
+
+```bash
+# A) Quick look (UI iteration). Builds engine + capture sidecar + runs the app
+#    from source. Command Line Tools is enough. Live Screen Recording will NOT
+#    work here (a bare swift-run binary can't get the macOS Screen Recording
+#    permission) — use this to browse the UI / generate notes from an audio file.
+scripts/dev.sh
+
+# B) Full flow WITH permissions (record → transcribe → notes). Builds + ad-hoc
+#    signs Panops.app (all three sidecars bundled), so macOS will grant Screen
+#    Recording + Microphone. Requires FULL Xcode (ASR/LLM sidecars) + macOS 26.
+scripts/package.sh
+open dist/Panops.app
+#    Then System Settings → Privacy & Security → grant Screen Recording + Mic,
+#    relaunch the app, and record a meeting.
+```
+
+Details + the manual smoke checklist below.
+
 ## Concept: there is no `.app` icon during dev
 
 The Mac app lives at `apps/Panops/` as a **SwiftPM executable** (source), not a

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Quick dev launch (no signing) — for UI iteration.
+# Builds the engine + capture sidecar (debug), then runs the app from source.
+#
+# NOTE: live Screen Recording needs the SIGNED bundle (scripts/package.sh) —
+# a bare `swift run` binary can't reliably get the macOS Screen Recording
+# permission. Use this for browsing the UI / generating notes from an existing
+# audio file; use package.sh to test the full record→transcribe→notes flow.
+#
+# Builds with the Command Line Tools (no full Xcode needed) — the engine, the
+# app, and the capture sidecar all build under CLT. (The ASR + LLM sidecars are
+# NOT built here; the engine falls back to whisper-rs + local ollama.)
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+REPO="$(pwd)"
+
+cargo build -p panops-engine
+( cd apps/panops-capture-mac && swift build )
+
+cd apps/Panops
+PANOPS_ENGINE_BIN="$REPO/target/debug/panops-engine" \
+PANOPS_CAPTURE_SIDECAR_BIN="$REPO/apps/panops-capture-mac/.build/debug/panops-capture-mac" \
+exec swift run

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,7 +5,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Preflight: the ASR (WhisperKit/CoreML) + LLM (FoundationModels) sidecars need
 # FULL Xcode, not just the Command Line Tools.
-if [[ "$(xcode-select -p 2>/dev/null)" == *CommandLineTools* ]]; then
+if [[ "$(xcode-select -p 2>/dev/null)" == "/Library/Developer/CommandLineTools" ]]; then
   echo "error: full Xcode required (xcode-select points at CommandLineTools)." >&2
   echo "  Install Xcode, then: sudo xcode-select -s /Applications/Xcode.app" >&2
   exit 1

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -2,21 +2,34 @@
 # Build + assemble + ad-hoc-sign Panops.app, then tar it. No Apple account.
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
+
+# Preflight: the ASR (WhisperKit/CoreML) + LLM (FoundationModels) sidecars need
+# FULL Xcode, not just the Command Line Tools.
+if [[ "$(xcode-select -p 2>/dev/null)" == *CommandLineTools* ]]; then
+  echo "error: full Xcode required (xcode-select points at CommandLineTools)." >&2
+  echo "  Install Xcode, then: sudo xcode-select -s /Applications/Xcode.app" >&2
+  exit 1
+fi
+
 VERSION="${1:-$(git describe --tags --always)}"
 OUT="dist"; APP="$OUT/Panops.app"; RES="$APP/Contents/Resources"; MACOS="$APP/Contents/MacOS"
 rm -rf "$OUT"; mkdir -p "$RES" "$MACOS"
 
-# 1. Release builds
+# 1. Release builds (engine + app + all three Swift sidecars: ASR, LLM, capture)
 cargo build --release -p panops-engine
-( cd apps/Panops        && swift build -c release )
-( cd apps/panops-asr-mac && swift build -c release )
-( cd apps/panops-llm-mac && swift build -c release )
+( cd apps/Panops            && swift build -c release )
+( cd apps/panops-asr-mac    && swift build -c release )
+( cd apps/panops-llm-mac    && swift build -c release )
+( cd apps/panops-capture-mac && swift build -c release )
 
-# 2. Assemble
+# 2. Assemble. Sidecars sit in Resources/ next to panops-engine so the engine's
+# sibling-of-engine resolver finds them (asr_resolver / llm_resolver /
+# capture_resolver) — no env vars needed in the bundle.
 cp target/release/panops-engine "$RES/panops-engine"
 cp apps/Panops/.build/release/Panops "$MACOS/Panops"
 cp apps/panops-asr-mac/.build/release/panops-asr-mac "$RES/panops-asr-mac"
 cp apps/panops-llm-mac/.build/release/panops-llm-mac "$RES/panops-llm-mac"
+cp apps/panops-capture-mac/.build/release/panops-capture-mac "$RES/panops-capture-mac"
 
 # 3. Info.plist
 cat > "$APP/Contents/Info.plist" <<PLIST
@@ -35,7 +48,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 PLIST
 
 # 4. Ad-hoc sign (inner binaries first, then the app), hardened runtime + entitlements
-for b in "$RES/panops-engine" "$RES/panops-asr-mac" "$RES/panops-llm-mac"; do
+for b in "$RES/panops-engine" "$RES/panops-asr-mac" "$RES/panops-llm-mac" "$RES/panops-capture-mac"; do
   codesign --force --options runtime --timestamp=none -s - "$b"
 done
 codesign --force --options runtime --timestamp=none \
@@ -48,3 +61,13 @@ TARBALL="$OUT/Panops-${VERSION}.tar.gz"
 tar -C "$OUT" -czf "$TARBALL" Panops.app
 shasum -a 256 "$TARBALL" | awk '{print $1}' > "$TARBALL.sha256"
 echo "built $TARBALL  sha256=$(cat "$TARBALL.sha256")"
+
+cat <<DONE
+
+✓ Signed app: $APP
+  To test the full record → transcribe → notes flow with permissions:
+    open $APP
+  Then grant Screen Recording + Microphone in
+  System Settings → Privacy & Security (relaunch the app after granting).
+  (Requires macOS 26 + Apple Intelligence enabled for on-device notes.)
+DONE

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -48,9 +48,15 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 PLIST
 
 # 4. Ad-hoc sign (inner binaries first, then the app), hardened runtime + entitlements
-for b in "$RES/panops-engine" "$RES/panops-asr-mac" "$RES/panops-llm-mac" "$RES/panops-capture-mac"; do
+for b in "$RES/panops-engine" "$RES/panops-asr-mac" "$RES/panops-llm-mac"; do
   codesign --force --options runtime --timestamp=none -s - "$b"
 done
+# The capture sidecar is the process that opens the microphone, so under the
+# hardened runtime IT needs the audio-input entitlement on its own executable
+# (it isn't inherited from the outer .app). Without this, mic recording fails
+# even after the user grants the Microphone permission.
+codesign --force --options runtime --timestamp=none \
+  --entitlements apps/Panops/Panops.entitlements -s - "$RES/panops-capture-mac"
 codesign --force --options runtime --timestamp=none \
   --entitlements apps/Panops/Panops.entitlements -s - "$APP"
 codesign --verify --deep --strict "$APP"


### PR DESCRIPTION
Makes the full record→transcribe→notes flow testable from a signed `.app`, and gives a clean one-command build for each case.

## The bug
`scripts/package.sh` built + bundled the ASR and LLM sidecars but **not** `panops-capture-mac` (added by the screen-recording slice). The engine resolves it as a sibling of `panops-engine` in `Resources/`, so the packaged `.app` had **no capture sidecar → couldn't record**. Now it builds, copies, and ad-hoc-signs the capture sidecar alongside the others.

## Two simple commands (see `docs/dev-run.md` TL;DR)
- **`scripts/dev.sh`** — quick UI iteration: builds engine + capture sidecar + `swift run` (CLT-only, no signing). Live Screen Recording won't work from a bare swift-run binary (documented).
- **`scripts/package.sh` + `open dist/Panops.app`** — the full flow with permissions: builds + ad-hoc-signs `Panops.app` with all three sidecars, so macOS grants **Screen Recording + Microphone**. Ends with a message telling you to open it + grant permissions. Added a **preflight** that fails clearly if full Xcode isn't selected (ASR/LLM sidecars need it).

## Verified
- Release builds of the CLT-buildable parts (engine, app, capture sidecar) — all green.
- `bash -n` syntax-clean on both scripts.
- Could **not** run the full `package.sh` here (this is a CLT-only machine; the ASR/LLM sidecars + the end-to-end signed-app run need full Xcode — that's the maintainer's setup). The script logic + the capture-sidecar bundling is the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)