### PR TITLE
Phase B (1/3): Spaces/Projects/Tags — storage foundation

### DIFF
--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -364,7 +364,8 @@ impl crate::exporter::NotesExporter for FakeNotesExporter {
 use chrono::Utc;
 
 use crate::storage::{
-    Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError,
+    Meeting, MeetingDraft, MeetingListFilter, MeetingSummary, Note, NoteDraft, Project, Space,
+    Storage, StorageError, Tag,
 };
 
 /// In-process `Storage` fake. Used by `panops-core`'s own tests and
@@ -377,6 +378,15 @@ pub struct InMemoryStorage {
 struct InMemoryInner {
     meetings: HashMap<String, Meeting>,
     notes: HashMap<String, Note>,
+    spaces: HashMap<String, Space>,
+    projects: HashMap<String, Project>,
+    tags: HashMap<String, Tag>,
+    meeting_tags: HashMap<String, Vec<String>>,
+    meeting_spaces: HashMap<String, String>,
+    meeting_projects: HashMap<String, String>,
+    next_space_id: u64,
+    next_project_id: u64,
+    next_tag_id: u64,
 }
 
 impl Default for InMemoryStorage {
@@ -391,6 +401,15 @@ impl InMemoryStorage {
             inner: Mutex::new(InMemoryInner {
                 meetings: HashMap::new(),
                 notes: HashMap::new(),
+                spaces: HashMap::new(),
+                projects: HashMap::new(),
+                tags: HashMap::new(),
+                meeting_tags: HashMap::new(),
+                meeting_spaces: HashMap::new(),
+                meeting_projects: HashMap::new(),
+                next_space_id: 1,
+                next_project_id: 1,
+                next_tag_id: 1,
             }),
         }
     }
@@ -506,10 +525,46 @@ impl Storage for InMemoryStorage {
     }
 
     fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError> {
+        self.list_meetings_filtered(MeetingListFilter::default())
+    }
+
+    fn list_meetings_filtered(
+        &self,
+        filter: MeetingListFilter,
+    ) -> Result<Vec<MeetingSummary>, StorageError> {
         let inner = self.inner.lock().unwrap();
         let mut rows: Vec<MeetingSummary> = inner
             .meetings
             .values()
+            .filter(|m| {
+                if filter.unsorted && inner.meeting_spaces.contains_key(&m.id) {
+                    return false;
+                }
+                if let Some(space_id) = &filter.space_id {
+                    if inner.meeting_spaces.get(&m.id).map(String::as_str)
+                        != Some(space_id.as_str())
+                    {
+                        return false;
+                    }
+                }
+                if let Some(project_id) = &filter.project_id {
+                    if inner.meeting_projects.get(&m.id).map(String::as_str)
+                        != Some(project_id.as_str())
+                    {
+                        return false;
+                    }
+                }
+                if let Some(tag_id) = &filter.tag_id {
+                    if !inner
+                        .meeting_tags
+                        .get(&m.id)
+                        .is_some_and(|tags| tags.iter().any(|t| t == tag_id))
+                    {
+                        return false;
+                    }
+                }
+                true
+            })
             .map(|m| MeetingSummary {
                 id: m.id.clone(),
                 title: m.title.clone(),
@@ -518,6 +573,9 @@ impl Storage for InMemoryStorage {
                 duration_ms: m.duration_ms.unwrap_or(0),
                 language: m.language.clone(),
                 has_notes: inner.notes.values().any(|n| n.meeting_id == m.id),
+                space_id: inner.meeting_spaces.get(&m.id).cloned(),
+                project_id: inner.meeting_projects.get(&m.id).cloned(),
+                tags: inner.meeting_tags.get(&m.id).cloned().unwrap_or_default(),
             })
             .collect();
         rows.sort_by(|a, b| b.started_at.cmp(&a.started_at));
@@ -566,6 +624,9 @@ impl Storage for InMemoryStorage {
         }
         // FK cascade simulation.
         inner.notes.retain(|_, n| n.meeting_id != id);
+        inner.meeting_tags.remove(id);
+        inner.meeting_spaces.remove(id);
+        inner.meeting_projects.remove(id);
         Ok(())
     }
 
@@ -603,6 +664,318 @@ impl Storage for InMemoryStorage {
             .filter(|n| n.meeting_id == meeting_id)
             .cloned()
             .collect())
+    }
+
+    fn create_space(&self, name: &str) -> Result<Space, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        let id = format!("space_{}", inner.next_space_id);
+        inner.next_space_id += 1;
+        let position = next_position(inner.spaces.values().map(|s| s.position));
+        let space = Space {
+            id: id.clone(),
+            name: name.into(),
+            position,
+        };
+        inner.spaces.insert(id, space.clone());
+        Ok(space)
+    }
+
+    fn list_spaces(&self) -> Result<Vec<Space>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        let mut rows: Vec<Space> = inner.spaces.values().cloned().collect();
+        rows.sort_by(|a, b| {
+            a.position
+                .cmp(&b.position)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        Ok(rows)
+    }
+
+    fn rename_space(&self, id: &str, name: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        let space = inner
+            .spaces
+            .get_mut(id)
+            .ok_or_else(|| StorageError::NotFound {
+                id: id.into(),
+                kind: "space",
+            })?;
+        space.name = name.into();
+        Ok(())
+    }
+
+    fn delete_space(&self, id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.spaces.remove(id).is_none() {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "space",
+            });
+        }
+        let project_ids: Vec<String> = inner
+            .projects
+            .values()
+            .filter(|p| p.space_id == id)
+            .map(|p| p.id.clone())
+            .collect();
+        for project_id in project_ids {
+            inner.projects.remove(&project_id);
+            clear_project_assignments(&mut inner, &project_id);
+        }
+        clear_space_assignments(&mut inner, id);
+        Ok(())
+    }
+
+    fn create_project(&self, space_id: &str, name: &str) -> Result<Project, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if !inner.spaces.contains_key(space_id) {
+            return Err(StorageError::NotFound {
+                id: space_id.into(),
+                kind: "space",
+            });
+        }
+        let id = format!("project_{}", inner.next_project_id);
+        inner.next_project_id += 1;
+        let position = next_position(
+            inner
+                .projects
+                .values()
+                .filter(|p| p.space_id == space_id)
+                .map(|p| p.position),
+        );
+        let project = Project {
+            id: id.clone(),
+            space_id: space_id.into(),
+            name: name.into(),
+            position,
+        };
+        inner.projects.insert(id, project.clone());
+        Ok(project)
+    }
+
+    fn list_projects(&self, space_id: Option<&str>) -> Result<Vec<Project>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        let mut rows: Vec<Project> = inner
+            .projects
+            .values()
+            .filter(|p| space_id.is_none_or(|s| p.space_id == s))
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            a.space_id
+                .cmp(&b.space_id)
+                .then_with(|| a.position.cmp(&b.position))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        Ok(rows)
+    }
+
+    fn rename_project(&self, id: &str, name: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        let project = inner
+            .projects
+            .get_mut(id)
+            .ok_or_else(|| StorageError::NotFound {
+                id: id.into(),
+                kind: "project",
+            })?;
+        project.name = name.into();
+        Ok(())
+    }
+
+    fn delete_project(&self, id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.projects.remove(id).is_none() {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "project",
+            });
+        }
+        clear_project_assignments(&mut inner, id);
+        Ok(())
+    }
+
+    fn create_tag(&self, name: &str) -> Result<Tag, StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(existing) = inner.tags.values().find(|t| t.name == name) {
+            return Ok(existing.clone());
+        }
+        let id = format!("tag_{}", inner.next_tag_id);
+        inner.next_tag_id += 1;
+        let tag = Tag {
+            id: id.clone(),
+            name: name.into(),
+        };
+        inner.tags.insert(id, tag.clone());
+        Ok(tag)
+    }
+
+    fn list_tags(&self) -> Result<Vec<Tag>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        let mut rows: Vec<Tag> = inner.tags.values().cloned().collect();
+        rows.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+        Ok(rows)
+    }
+
+    fn delete_tag(&self, id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.tags.remove(id).is_none() {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "tag",
+            });
+        }
+        for tag_ids in inner.meeting_tags.values_mut() {
+            tag_ids.retain(|tag_id| tag_id != id);
+        }
+        Ok(())
+    }
+
+    fn tag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        ensure_meeting_exists(&inner, meeting_id)?;
+        ensure_tag_exists(&inner, tag_id)?;
+        let tags = inner.meeting_tags.entry(meeting_id.into()).or_default();
+        if !tags.iter().any(|t| t == tag_id) {
+            tags.push(tag_id.into());
+            tags.sort();
+        }
+        Ok(())
+    }
+
+    fn untag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError> {
+        let mut inner = self.inner.lock().unwrap();
+        ensure_meeting_exists(&inner, meeting_id)?;
+        ensure_tag_exists(&inner, tag_id)?;
+        if let Some(tags) = inner.meeting_tags.get_mut(meeting_id) {
+            tags.retain(|t| t != tag_id);
+        }
+        Ok(())
+    }
+
+    fn list_tags_for_meeting(&self, meeting_id: &str) -> Result<Vec<Tag>, StorageError> {
+        let inner = self.inner.lock().unwrap();
+        ensure_meeting_exists(&inner, meeting_id)?;
+        let mut rows: Vec<Tag> = inner
+            .meeting_tags
+            .get(meeting_id)
+            .into_iter()
+            .flatten()
+            .filter_map(|tag_id| inner.tags.get(tag_id))
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+        Ok(rows)
+    }
+
+    fn assign_meeting(
+        &self,
+        meeting_id: &str,
+        space_id: Option<String>,
+        project_id: Option<String>,
+    ) -> Result<(), StorageError> {
+        let inner = &mut *self.inner.lock().unwrap();
+        ensure_meeting_exists(inner, meeting_id)?;
+        if let Some(project_id) = project_id.as_deref() {
+            let project = inner
+                .projects
+                .get(project_id)
+                .ok_or_else(|| StorageError::NotFound {
+                    id: project_id.into(),
+                    kind: "project",
+                })?;
+            set_assignment(
+                inner,
+                meeting_id,
+                Some(project.space_id.clone()),
+                Some(project.id.clone()),
+            );
+            return Ok(());
+        }
+        if let Some(space_id) = space_id.as_deref() {
+            if !inner.spaces.contains_key(space_id) {
+                return Err(StorageError::NotFound {
+                    id: space_id.into(),
+                    kind: "space",
+                });
+            }
+        }
+        set_assignment(inner, meeting_id, space_id, None);
+        Ok(())
+    }
+}
+
+fn next_position(values: impl Iterator<Item = i64>) -> i64 {
+    values.max().map_or(0, |v| v + 1)
+}
+
+fn ensure_meeting_exists(inner: &InMemoryInner, meeting_id: &str) -> Result<(), StorageError> {
+    if inner.meetings.contains_key(meeting_id) {
+        Ok(())
+    } else {
+        Err(StorageError::NotFound {
+            id: meeting_id.into(),
+            kind: "meeting",
+        })
+    }
+}
+
+fn ensure_tag_exists(inner: &InMemoryInner, tag_id: &str) -> Result<(), StorageError> {
+    if inner.tags.contains_key(tag_id) {
+        Ok(())
+    } else {
+        Err(StorageError::NotFound {
+            id: tag_id.into(),
+            kind: "tag",
+        })
+    }
+}
+
+fn set_assignment(
+    inner: &mut InMemoryInner,
+    meeting_id: &str,
+    space_id: Option<String>,
+    project_id: Option<String>,
+) {
+    match space_id {
+        Some(id) => {
+            inner.meeting_spaces.insert(meeting_id.into(), id);
+        }
+        None => {
+            inner.meeting_spaces.remove(meeting_id);
+        }
+    }
+    match project_id {
+        Some(id) => {
+            inner.meeting_projects.insert(meeting_id.into(), id);
+        }
+        None => {
+            inner.meeting_projects.remove(meeting_id);
+        }
+    }
+}
+
+fn clear_space_assignments(inner: &mut InMemoryInner, space_id: &str) {
+    let meeting_ids: Vec<String> = inner
+        .meeting_spaces
+        .iter()
+        .filter(|(_, id)| id.as_str() == space_id)
+        .map(|(key, _)| key.clone())
+        .collect();
+    for meeting_id in meeting_ids {
+        inner.meeting_spaces.remove(&meeting_id);
+    }
+}
+
+fn clear_project_assignments(inner: &mut InMemoryInner, project_id: &str) {
+    let meeting_ids: Vec<String> = inner
+        .meeting_projects
+        .iter()
+        .filter(|(_, id)| id.as_str() == project_id)
+        .map(|(key, _)| key.clone())
+        .collect();
+    for meeting_id in meeting_ids {
+        inner.meeting_projects.remove(&meeting_id);
     }
 }
 

--- a/crates/panops-core/src/conformance/storage.rs
+++ b/crates/panops-core/src/conformance/storage.rs
@@ -14,7 +14,7 @@
 //! - `delete_meeting` removes the row AND cascades note deletion.
 //! - `create_note` round-trips via `list_notes_for_meeting`.
 
-use crate::storage::{MeetingDraft, NoteDraft, Storage, StorageError};
+use crate::storage::{MeetingDraft, MeetingListFilter, NoteDraft, Storage, StorageError};
 
 /// Run the full conformance suite against a `Storage` implementation.
 pub fn run_suite<S: Storage>(adapter: &S) {
@@ -29,6 +29,13 @@ pub fn run_suite<S: Storage>(adapter: &S) {
     create_and_list_notes_for_meeting(adapter);
     create_meeting_with_note_atomic_happy_path(adapter);
     create_meeting_with_note_rolls_back_on_note_collision(adapter);
+    spaces_create_list_rename_delete(adapter);
+    projects_create_list_rename_delete(adapter);
+    tags_create_list_delete_and_idempotent_name(adapter);
+    tag_meeting_untag_and_list_tags_for_meeting(adapter);
+    assign_meeting_handles_space_and_project_sets_space(adapter);
+    list_meetings_supports_org_filters(adapter);
+    deleting_org_rows_preserves_meetings_and_clears_refs(adapter);
 }
 
 fn create_get_round_trip<S: Storage>(adapter: &S) {
@@ -352,6 +359,305 @@ fn create_meeting_with_note_rolls_back_on_note_collision<S: Storage>(adapter: &S
         matches!(look, Err(StorageError::NotFound { .. })),
         "expected new_m to be rolled back, got {look:?}"
     );
+}
+
+fn spaces_create_list_rename_delete<S: Storage>(adapter: &S) {
+    let space = adapter.create_space("Work").expect("create space");
+    assert_eq!(space.name, "Work");
+    assert!(space.position >= 0);
+
+    adapter
+        .rename_space(&space.id, "Deep Work")
+        .expect("rename space");
+    let spaces = adapter.list_spaces().expect("list spaces");
+    assert!(
+        spaces
+            .iter()
+            .any(|s| s.id == space.id && s.name == "Deep Work")
+    );
+
+    adapter.delete_space(&space.id).expect("delete space");
+    let spaces = adapter.list_spaces().expect("list spaces after delete");
+    assert!(!spaces.iter().any(|s| s.id == space.id));
+
+    let err = adapter
+        .rename_space(&space.id, "Missing")
+        .expect_err("renaming deleted space should fail");
+    assert!(matches!(err, StorageError::NotFound { kind: "space", .. }));
+}
+
+fn projects_create_list_rename_delete<S: Storage>(adapter: &S) {
+    let space_a = adapter.create_space("Projects A").expect("space a");
+    let space_b = adapter.create_space("Projects B").expect("space b");
+    let project = adapter
+        .create_project(&space_a.id, "Launch")
+        .expect("create project");
+    let other = adapter
+        .create_project(&space_b.id, "Other")
+        .expect("create other project");
+    assert_eq!(project.space_id, space_a.id);
+
+    adapter
+        .rename_project(&project.id, "Renamed Launch")
+        .expect("rename project");
+    let filtered = adapter
+        .list_projects(Some(&space_a.id))
+        .expect("list projects for one space");
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].id, project.id);
+    assert_eq!(filtered[0].name, "Renamed Launch");
+
+    let all = adapter.list_projects(None).expect("list all projects");
+    assert!(all.iter().any(|p| p.id == other.id));
+
+    adapter.delete_project(&project.id).expect("delete project");
+    let filtered = adapter
+        .list_projects(Some(&space_a.id))
+        .expect("list projects after delete");
+    assert!(filtered.is_empty());
+
+    let err = adapter
+        .create_project("missing-space", "Nope")
+        .expect_err("project in missing space should fail");
+    assert!(matches!(err, StorageError::NotFound { kind: "space", .. }));
+}
+
+fn tags_create_list_delete_and_idempotent_name<S: Storage>(adapter: &S) {
+    let tag = adapter.create_tag("urgent").expect("create tag");
+    let same = adapter
+        .create_tag("urgent")
+        .expect("create tag with same name should be idempotent");
+    assert_eq!(tag, same);
+
+    let tags = adapter.list_tags().expect("list tags");
+    assert!(tags.iter().any(|t| t.id == tag.id && t.name == "urgent"));
+
+    adapter.delete_tag(&tag.id).expect("delete tag");
+    let tags = adapter.list_tags().expect("list tags after delete");
+    assert!(!tags.iter().any(|t| t.id == tag.id));
+}
+
+fn tag_meeting_untag_and_list_tags_for_meeting<S: Storage>(adapter: &S) {
+    let meeting_id = "m_tagging";
+    adapter
+        .create_meeting(draft(meeting_id, "Tagging", "2026-05-09T10:00:00+00:00"))
+        .expect("create meeting");
+    let tag = adapter.create_tag("customer").expect("create tag");
+
+    adapter
+        .tag_meeting(meeting_id, &tag.id)
+        .expect("tag meeting");
+    adapter
+        .tag_meeting(meeting_id, &tag.id)
+        .expect("tag meeting idempotent");
+    let tags = adapter
+        .list_tags_for_meeting(meeting_id)
+        .expect("list tags for meeting");
+    assert_eq!(tags, vec![tag.clone()]);
+
+    let summary = adapter
+        .list_meetings()
+        .expect("list meetings")
+        .into_iter()
+        .find(|m| m.id == meeting_id)
+        .expect("tagged meeting summary");
+    assert_eq!(summary.tags, vec![tag.id.clone()]);
+
+    adapter
+        .untag_meeting(meeting_id, &tag.id)
+        .expect("untag meeting");
+    let tags = adapter
+        .list_tags_for_meeting(meeting_id)
+        .expect("list tags after untag");
+    assert!(tags.is_empty());
+
+    let err = adapter
+        .tag_meeting("missing-meeting", &tag.id)
+        .expect_err("tagging missing meeting should fail");
+    assert!(matches!(
+        err,
+        StorageError::NotFound {
+            kind: "meeting",
+            ..
+        }
+    ));
+}
+
+fn assign_meeting_handles_space_and_project_sets_space<S: Storage>(adapter: &S) {
+    let meeting_id = "m_assign";
+    adapter
+        .create_meeting(draft(meeting_id, "Assign", "2026-05-10T10:00:00+00:00"))
+        .expect("create meeting");
+    let space = adapter.create_space("Assignments").expect("create space");
+    let project = adapter
+        .create_project(&space.id, "Nested")
+        .expect("create project");
+
+    adapter
+        .assign_meeting(meeting_id, Some(space.id.clone()), None)
+        .expect("assign to space");
+    let space_summary = summary(adapter, meeting_id);
+    assert_eq!(space_summary.space_id.as_deref(), Some(space.id.as_str()));
+    assert!(space_summary.project_id.is_none());
+
+    adapter
+        .assign_meeting(meeting_id, None, Some(project.id.clone()))
+        .expect("assign to project");
+    let project_summary = summary(adapter, meeting_id);
+    assert_eq!(project_summary.space_id.as_deref(), Some(space.id.as_str()));
+    assert_eq!(
+        project_summary.project_id.as_deref(),
+        Some(project.id.as_str())
+    );
+
+    adapter
+        .assign_meeting(meeting_id, None, None)
+        .expect("clear assignment");
+    let cleared_summary = summary(adapter, meeting_id);
+    assert!(cleared_summary.space_id.is_none());
+    assert!(cleared_summary.project_id.is_none());
+}
+
+fn list_meetings_supports_org_filters<S: Storage>(adapter: &S) {
+    let inbox_id = "m_filter_inbox";
+    let space_id = "m_filter_space";
+    let project_id = "m_filter_project";
+    adapter
+        .create_meeting(draft(inbox_id, "Inbox", "2026-05-11T10:00:00+00:00"))
+        .expect("create inbox meeting");
+    adapter
+        .create_meeting(draft(space_id, "Space", "2026-05-12T10:00:00+00:00"))
+        .expect("create space meeting");
+    adapter
+        .create_meeting(draft(project_id, "Project", "2026-05-13T10:00:00+00:00"))
+        .expect("create project meeting");
+    let space = adapter.create_space("Filter Space").expect("create space");
+    let project = adapter
+        .create_project(&space.id, "Filter Project")
+        .expect("create project");
+    let tag = adapter.create_tag("filter-tag").expect("create tag");
+    adapter
+        .assign_meeting(space_id, Some(space.id.clone()), None)
+        .expect("assign space meeting");
+    adapter
+        .assign_meeting(project_id, None, Some(project.id.clone()))
+        .expect("assign project meeting");
+    adapter
+        .tag_meeting(project_id, &tag.id)
+        .expect("tag project meeting");
+
+    let inbox_rows = adapter
+        .list_meetings_filtered(MeetingListFilter {
+            unsorted: true,
+            ..MeetingListFilter::default()
+        })
+        .expect("inbox filter");
+    assert!(inbox_rows.iter().any(|m| m.id == inbox_id));
+    assert!(
+        !inbox_rows
+            .iter()
+            .any(|m| m.id == space_id || m.id == project_id)
+    );
+
+    let space_rows = adapter
+        .list_meetings_filtered(MeetingListFilter {
+            space_id: Some(space.id.clone()),
+            ..MeetingListFilter::default()
+        })
+        .expect("space filter");
+    assert!(space_rows.iter().any(|m| m.id == space_id));
+    assert!(space_rows.iter().any(|m| m.id == project_id));
+    assert!(!space_rows.iter().any(|m| m.id == inbox_id));
+
+    let project_rows = adapter
+        .list_meetings_filtered(MeetingListFilter {
+            project_id: Some(project.id.clone()),
+            ..MeetingListFilter::default()
+        })
+        .expect("project filter");
+    assert_eq!(
+        project_rows
+            .iter()
+            .map(|m| m.id.as_str())
+            .filter(|id| [project_id, space_id, inbox_id].contains(id))
+            .collect::<Vec<_>>(),
+        vec![project_id]
+    );
+
+    let tag_rows = adapter
+        .list_meetings_filtered(MeetingListFilter {
+            tag_id: Some(tag.id.clone()),
+            ..MeetingListFilter::default()
+        })
+        .expect("tag filter");
+    assert_eq!(
+        tag_rows
+            .iter()
+            .map(|m| m.id.as_str())
+            .filter(|id| [project_id, space_id, inbox_id].contains(id))
+            .collect::<Vec<_>>(),
+        vec![project_id]
+    );
+}
+
+fn deleting_org_rows_preserves_meetings_and_clears_refs<S: Storage>(adapter: &S) {
+    let project_meeting = "m_delete_project_ref";
+    let space_meeting = "m_delete_space_ref";
+    adapter
+        .create_meeting(draft(
+            project_meeting,
+            "Project Ref",
+            "2026-05-14T10:00:00+00:00",
+        ))
+        .expect("create project ref meeting");
+    adapter
+        .create_meeting(draft(
+            space_meeting,
+            "Space Ref",
+            "2026-05-15T10:00:00+00:00",
+        ))
+        .expect("create space ref meeting");
+
+    let project_space = adapter.create_space("Delete Project Space").expect("space");
+    let project = adapter
+        .create_project(&project_space.id, "Delete Me")
+        .expect("project");
+    adapter
+        .assign_meeting(project_meeting, None, Some(project.id.clone()))
+        .expect("assign project ref");
+    adapter.delete_project(&project.id).expect("delete project");
+    let project_summary = summary(adapter, project_meeting);
+    assert_eq!(
+        project_summary.space_id.as_deref(),
+        Some(project_space.id.as_str()),
+        "deleting only a project should keep the containing space assignment"
+    );
+    assert!(project_summary.project_id.is_none());
+
+    let space = adapter.create_space("Delete Space").expect("space");
+    let project = adapter
+        .create_project(&space.id, "Deleted With Space")
+        .expect("project");
+    adapter
+        .assign_meeting(space_meeting, None, Some(project.id.clone()))
+        .expect("assign space ref");
+    adapter.delete_space(&space.id).expect("delete space");
+    let space_summary = summary(adapter, space_meeting);
+    assert!(space_summary.space_id.is_none());
+    assert!(space_summary.project_id.is_none());
+    assert!(
+        adapter.get_meeting(project_meeting).is_ok() && adapter.get_meeting(space_meeting).is_ok(),
+        "org deletes must not delete meetings"
+    );
+}
+
+fn summary<S: Storage>(adapter: &S, meeting_id: &str) -> crate::storage::MeetingSummary {
+    adapter
+        .list_meetings()
+        .expect("list meetings")
+        .into_iter()
+        .find(|m| m.id == meeting_id)
+        .expect("meeting summary")
 }
 
 fn draft(id: &str, title: &str, started_at: &str) -> MeetingDraft {

--- a/crates/panops-core/src/storage.rs
+++ b/crates/panops-core/src/storage.rs
@@ -12,6 +12,10 @@ pub trait Storage: Send + Sync {
     fn create_meeting(&self, draft: MeetingDraft) -> Result<Meeting, StorageError>;
     fn get_meeting(&self, id: &str) -> Result<Meeting, StorageError>;
     fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError>;
+    fn list_meetings_filtered(
+        &self,
+        filter: MeetingListFilter,
+    ) -> Result<Vec<MeetingSummary>, StorageError>;
     fn update_meeting_ended(
         &self,
         id: &str,
@@ -22,6 +26,26 @@ pub trait Storage: Send + Sync {
     fn delete_meeting(&self, id: &str) -> Result<(), StorageError>;
     fn create_note(&self, draft: NoteDraft) -> Result<Note, StorageError>;
     fn list_notes_for_meeting(&self, meeting_id: &str) -> Result<Vec<Note>, StorageError>;
+    fn create_space(&self, name: &str) -> Result<Space, StorageError>;
+    fn list_spaces(&self) -> Result<Vec<Space>, StorageError>;
+    fn rename_space(&self, id: &str, name: &str) -> Result<(), StorageError>;
+    fn delete_space(&self, id: &str) -> Result<(), StorageError>;
+    fn create_project(&self, space_id: &str, name: &str) -> Result<Project, StorageError>;
+    fn list_projects(&self, space_id: Option<&str>) -> Result<Vec<Project>, StorageError>;
+    fn rename_project(&self, id: &str, name: &str) -> Result<(), StorageError>;
+    fn delete_project(&self, id: &str) -> Result<(), StorageError>;
+    fn create_tag(&self, name: &str) -> Result<Tag, StorageError>;
+    fn list_tags(&self) -> Result<Vec<Tag>, StorageError>;
+    fn delete_tag(&self, id: &str) -> Result<(), StorageError>;
+    fn tag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError>;
+    fn untag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError>;
+    fn list_tags_for_meeting(&self, meeting_id: &str) -> Result<Vec<Tag>, StorageError>;
+    fn assign_meeting(
+        &self,
+        meeting_id: &str,
+        space_id: Option<String>,
+        project_id: Option<String>,
+    ) -> Result<(), StorageError>;
 
     /// Atomic combined insert: meeting + note + (optional) ended_at
     /// in a single transaction. Used by the CLI's `notes` flow so a
@@ -68,6 +92,40 @@ pub struct MeetingSummary {
     pub duration_ms: u64,
     pub language: String,
     pub has_notes: bool,
+    pub space_id: Option<String>,
+    pub project_id: Option<String>,
+    /// Tag ids assigned to this meeting.
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MeetingListFilter {
+    pub space_id: Option<String>,
+    pub project_id: Option<String>,
+    pub tag_id: Option<String>,
+    /// When true, return meetings in the implicit Inbox (`space_id IS NULL`).
+    pub unsorted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Space {
+    pub id: String,
+    pub name: String,
+    pub position: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Project {
+    pub id: String,
+    pub space_id: String,
+    pub name: String,
+    pub position: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tag {
+    pub id: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/panops-portable/src/rusqlite_storage.rs
+++ b/crates/panops-portable/src/rusqlite_storage.rs
@@ -5,13 +5,15 @@
 //! capture); for now everything lives in one registry DB.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use chrono::Utc;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use panops_core::storage::{
-    Meeting, MeetingDraft, MeetingSummary, Note, NoteDraft, Storage, StorageError,
+    Meeting, MeetingDraft, MeetingListFilter, MeetingSummary, Note, NoteDraft, Project, Space,
+    Storage, StorageError, Tag,
 };
 
 /// Lock the connection mutex, mapping a poisoned mutex to a
@@ -58,7 +60,7 @@ fn map_meeting_constraint_violation(
     StorageError::sql(err)
 }
 
-const EXPECTED_SCHEMA_VERSION: u32 = 1;
+const EXPECTED_SCHEMA_VERSION: u32 = 2;
 
 // `PRAGMA foreign_keys = ON` is set per-connection in `new()`, not in DDL —
 // the DDL `PRAGMA` would be redundant on a fresh DB and a no-op on re-open
@@ -71,7 +73,9 @@ CREATE TABLE IF NOT EXISTS meeting (
     ended_at TEXT,
     duration_ms INTEGER,
     language TEXT NOT NULL DEFAULT 'auto',
-    dir_path TEXT NOT NULL UNIQUE
+    dir_path TEXT NOT NULL UNIQUE,
+    space_id TEXT REFERENCES space(id) ON DELETE SET NULL,
+    project_id TEXT REFERENCES project(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_meeting_started_at ON meeting(started_at DESC);
@@ -86,7 +90,74 @@ CREATE TABLE IF NOT EXISTS note (
 );
 
 CREATE INDEX IF NOT EXISTS idx_note_meeting_id ON note(meeting_id);
+
+CREATE TABLE IF NOT EXISTS space (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS project (
+    id TEXT PRIMARY KEY,
+    space_id TEXT NOT NULL REFERENCES space(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tag (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS meeting_tag (
+    meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE,
+    tag_id TEXT NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+    PRIMARY KEY (meeting_id, tag_id)
+);
 ";
+
+const MIGRATE_V1_TO_V2: &str = r"
+CREATE TABLE IF NOT EXISTS space (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS project (
+    id TEXT PRIMARY KEY,
+    space_id TEXT NOT NULL REFERENCES space(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tag (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS meeting_tag (
+    meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE,
+    tag_id TEXT NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+    PRIMARY KEY (meeting_id, tag_id)
+);
+";
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn new_id(prefix: &str) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let n = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{now:x}_{n:x}")
+}
 
 pub struct RusqliteStorage {
     conn: Arc<Mutex<Connection>>,
@@ -111,6 +182,10 @@ impl RusqliteStorage {
             conn.execute_batch(DDL).map_err(StorageError::sql)?;
             conn.execute_batch(&format!("PRAGMA user_version = {EXPECTED_SCHEMA_VERSION};"))
                 .map_err(StorageError::sql)?;
+        } else if actual == 1 {
+            migrate_v1_to_v2(&conn)?;
+            conn.execute_batch(&format!("PRAGMA user_version = {EXPECTED_SCHEMA_VERSION};"))
+                .map_err(StorageError::sql)?;
         } else if actual != EXPECTED_SCHEMA_VERSION {
             return Err(StorageError::SchemaMismatch {
                 actual,
@@ -122,6 +197,37 @@ impl RusqliteStorage {
             conn: Arc::new(Mutex::new(conn)),
         })
     }
+}
+
+fn migrate_v1_to_v2(conn: &Connection) -> Result<(), StorageError> {
+    conn.execute_batch(MIGRATE_V1_TO_V2)
+        .map_err(StorageError::sql)?;
+    if !column_exists(conn, "meeting", "space_id")? {
+        conn.execute_batch(
+            "ALTER TABLE meeting ADD COLUMN space_id TEXT REFERENCES space(id) ON DELETE SET NULL;",
+        )
+        .map_err(StorageError::sql)?;
+    }
+    if !column_exists(conn, "meeting", "project_id")? {
+        conn.execute_batch("ALTER TABLE meeting ADD COLUMN project_id TEXT REFERENCES project(id) ON DELETE SET NULL;")
+            .map_err(StorageError::sql)?;
+    }
+    Ok(())
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool, StorageError> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table});"))
+        .map_err(StorageError::sql)?;
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(1))
+        .map_err(StorageError::sql)?;
+    for row in rows {
+        if row.map_err(StorageError::sql)? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn map_meeting_row(r: &rusqlite::Row) -> rusqlite::Result<Meeting> {
@@ -292,6 +398,13 @@ impl Storage for RusqliteStorage {
     }
 
     fn list_meetings(&self) -> Result<Vec<MeetingSummary>, StorageError> {
+        self.list_meetings_filtered(MeetingListFilter::default())
+    }
+
+    fn list_meetings_filtered(
+        &self,
+        filter: MeetingListFilter,
+    ) -> Result<Vec<MeetingSummary>, StorageError> {
         let conn = lock(&self.conn)?;
         let mut stmt = conn
             .prepare(
@@ -302,7 +415,9 @@ impl Storage for RusqliteStorage {
                      ended_at,
                      COALESCE(duration_ms, 0),
                      language,
-                     EXISTS (SELECT 1 FROM note WHERE note.meeting_id = meeting.id)
+                     EXISTS (SELECT 1 FROM note WHERE note.meeting_id = meeting.id),
+                     space_id,
+                     project_id
                  FROM meeting ORDER BY started_at DESC",
             )
             .map_err(StorageError::sql)?;
@@ -318,12 +433,35 @@ impl Storage for RusqliteStorage {
                     duration_ms: r.get::<_, i64>(4)?.max(0) as u64,
                     language: r.get(5)?,
                     has_notes: r.get(6)?,
+                    space_id: r.get(7)?,
+                    project_id: r.get(8)?,
+                    tags: Vec::new(),
                 })
             })
             .map_err(StorageError::sql)?;
         let mut out = Vec::new();
         for r in rows {
-            out.push(r.map_err(StorageError::sql)?);
+            let mut summary = r.map_err(StorageError::sql)?;
+            summary.tags = tag_ids_for_meeting(&conn, &summary.id)?;
+            if filter.unsorted && summary.space_id.is_some() {
+                continue;
+            }
+            if let Some(space_id) = &filter.space_id {
+                if summary.space_id.as_deref() != Some(space_id.as_str()) {
+                    continue;
+                }
+            }
+            if let Some(project_id) = &filter.project_id {
+                if summary.project_id.as_deref() != Some(project_id.as_str()) {
+                    continue;
+                }
+            }
+            if let Some(tag_id) = &filter.tag_id {
+                if !summary.tags.iter().any(|id| id == tag_id) {
+                    continue;
+                }
+            }
+            out.push(summary);
         }
         Ok(out)
     }
@@ -462,6 +600,351 @@ impl Storage for RusqliteStorage {
         }
         Ok(out)
     }
+
+    fn create_space(&self, name: &str) -> Result<Space, StorageError> {
+        let conn = lock(&self.conn)?;
+        let id = new_id("space");
+        let position = next_position(&conn, "space", None)?;
+        let created_at = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO space (id, name, position, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![id, name, position, created_at],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(Space {
+            id,
+            name: name.into(),
+            position,
+        })
+    }
+
+    fn list_spaces(&self) -> Result<Vec<Space>, StorageError> {
+        let conn = lock(&self.conn)?;
+        let mut stmt = conn
+            .prepare("SELECT id, name, position FROM space ORDER BY position ASC, name ASC")
+            .map_err(StorageError::sql)?;
+        collect_mapped(stmt.query_map([], map_space).map_err(StorageError::sql)?)
+    }
+
+    fn rename_space(&self, id: &str, name: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute(
+                "UPDATE space SET name = ?2 WHERE id = ?1",
+                params![id, name],
+            )
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "space",
+            });
+        }
+        Ok(())
+    }
+
+    fn delete_space(&self, id: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute("DELETE FROM space WHERE id = ?1", params![id])
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "space",
+            });
+        }
+        Ok(())
+    }
+
+    fn create_project(&self, space_id: &str, name: &str) -> Result<Project, StorageError> {
+        let conn = lock(&self.conn)?;
+        ensure_row_exists(&conn, "space", space_id)?;
+        let id = new_id("project");
+        let position = next_position(&conn, "project", Some(space_id))?;
+        let created_at = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO project (id, space_id, name, position, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, space_id, name, position, created_at],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(Project {
+            id,
+            space_id: space_id.into(),
+            name: name.into(),
+            position,
+        })
+    }
+
+    fn list_projects(&self, space_id: Option<&str>) -> Result<Vec<Project>, StorageError> {
+        let conn = lock(&self.conn)?;
+        if let Some(space_id) = space_id {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, space_id, name, position
+                     FROM project WHERE space_id = ?1
+                     ORDER BY position ASC, name ASC",
+                )
+                .map_err(StorageError::sql)?;
+            collect_mapped(
+                stmt.query_map(params![space_id], map_project)
+                    .map_err(StorageError::sql)?,
+            )
+        } else {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, space_id, name, position
+                     FROM project ORDER BY space_id ASC, position ASC, name ASC",
+                )
+                .map_err(StorageError::sql)?;
+            collect_mapped(stmt.query_map([], map_project).map_err(StorageError::sql)?)
+        }
+    }
+
+    fn rename_project(&self, id: &str, name: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute(
+                "UPDATE project SET name = ?2 WHERE id = ?1",
+                params![id, name],
+            )
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "project",
+            });
+        }
+        Ok(())
+    }
+
+    fn delete_project(&self, id: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute("DELETE FROM project WHERE id = ?1", params![id])
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "project",
+            });
+        }
+        Ok(())
+    }
+
+    fn create_tag(&self, name: &str) -> Result<Tag, StorageError> {
+        let conn = lock(&self.conn)?;
+        if let Some(tag) = get_tag_by_name(&conn, name)? {
+            return Ok(tag);
+        }
+        let id = new_id("tag");
+        let created_at = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO tag (id, name, created_at) VALUES (?1, ?2, ?3)",
+            params![id, name, created_at],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(Tag {
+            id,
+            name: name.into(),
+        })
+    }
+
+    fn list_tags(&self) -> Result<Vec<Tag>, StorageError> {
+        let conn = lock(&self.conn)?;
+        let mut stmt = conn
+            .prepare("SELECT id, name FROM tag ORDER BY name ASC, id ASC")
+            .map_err(StorageError::sql)?;
+        collect_mapped(stmt.query_map([], map_tag).map_err(StorageError::sql)?)
+    }
+
+    fn delete_tag(&self, id: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        let n = conn
+            .execute("DELETE FROM tag WHERE id = ?1", params![id])
+            .map_err(StorageError::sql)?;
+        if n == 0 {
+            return Err(StorageError::NotFound {
+                id: id.into(),
+                kind: "tag",
+            });
+        }
+        Ok(())
+    }
+
+    fn tag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        ensure_row_exists(&conn, "meeting", meeting_id)?;
+        ensure_row_exists(&conn, "tag", tag_id)?;
+        conn.execute(
+            "INSERT OR IGNORE INTO meeting_tag (meeting_id, tag_id) VALUES (?1, ?2)",
+            params![meeting_id, tag_id],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(())
+    }
+
+    fn untag_meeting(&self, meeting_id: &str, tag_id: &str) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        ensure_row_exists(&conn, "meeting", meeting_id)?;
+        ensure_row_exists(&conn, "tag", tag_id)?;
+        conn.execute(
+            "DELETE FROM meeting_tag WHERE meeting_id = ?1 AND tag_id = ?2",
+            params![meeting_id, tag_id],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(())
+    }
+
+    fn list_tags_for_meeting(&self, meeting_id: &str) -> Result<Vec<Tag>, StorageError> {
+        let conn = lock(&self.conn)?;
+        ensure_row_exists(&conn, "meeting", meeting_id)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT tag.id, tag.name
+                 FROM tag
+                 INNER JOIN meeting_tag ON meeting_tag.tag_id = tag.id
+                 WHERE meeting_tag.meeting_id = ?1
+                 ORDER BY tag.name ASC, tag.id ASC",
+            )
+            .map_err(StorageError::sql)?;
+        collect_mapped(
+            stmt.query_map(params![meeting_id], map_tag)
+                .map_err(StorageError::sql)?,
+        )
+    }
+
+    fn assign_meeting(
+        &self,
+        meeting_id: &str,
+        space_id: Option<String>,
+        project_id: Option<String>,
+    ) -> Result<(), StorageError> {
+        let conn = lock(&self.conn)?;
+        ensure_row_exists(&conn, "meeting", meeting_id)?;
+        let (space_id, project_id) = if let Some(project_id) = project_id {
+            let project_space_id: String = conn
+                .query_row(
+                    "SELECT space_id FROM project WHERE id = ?1",
+                    params![project_id],
+                    |r| r.get(0),
+                )
+                .optional()
+                .map_err(StorageError::sql)?
+                .ok_or_else(|| StorageError::NotFound {
+                    id: project_id.clone(),
+                    kind: "project",
+                })?;
+            (Some(project_space_id), Some(project_id))
+        } else {
+            if let Some(space_id) = space_id.as_deref() {
+                ensure_row_exists(&conn, "space", space_id)?;
+            }
+            (space_id, None)
+        };
+        conn.execute(
+            "UPDATE meeting SET space_id = ?2, project_id = ?3 WHERE id = ?1",
+            params![meeting_id, space_id, project_id],
+        )
+        .map_err(StorageError::sql)?;
+        Ok(())
+    }
+}
+
+fn next_position(
+    conn: &Connection,
+    table: &str,
+    project_space_id: Option<&str>,
+) -> Result<i64, StorageError> {
+    let value: Option<i64> = if table == "project" {
+        conn.query_row(
+            "SELECT MAX(position) FROM project WHERE space_id = ?1",
+            params![project_space_id],
+            |r| r.get(0),
+        )
+        .map_err(StorageError::sql)?
+    } else {
+        conn.query_row("SELECT MAX(position) FROM space", [], |r| r.get(0))
+            .map_err(StorageError::sql)?
+    };
+    Ok(value.map_or(0, |v| v + 1))
+}
+
+fn ensure_row_exists(conn: &Connection, table: &'static str, id: &str) -> Result<(), StorageError> {
+    let sql = format!("SELECT 1 FROM {table} WHERE id = ?1");
+    let exists = conn
+        .query_row(&sql, params![id], |_| Ok(true))
+        .optional()
+        .map_err(StorageError::sql)?
+        .unwrap_or(false);
+    if exists {
+        Ok(())
+    } else {
+        Err(StorageError::NotFound {
+            id: id.into(),
+            kind: table,
+        })
+    }
+}
+
+fn tag_ids_for_meeting(conn: &Connection, meeting_id: &str) -> Result<Vec<String>, StorageError> {
+    let mut stmt = conn
+        .prepare("SELECT tag_id FROM meeting_tag WHERE meeting_id = ?1 ORDER BY tag_id ASC")
+        .map_err(StorageError::sql)?;
+    let rows = stmt
+        .query_map(params![meeting_id], |r| r.get::<_, String>(0))
+        .map_err(StorageError::sql)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(StorageError::sql)?);
+    }
+    Ok(out)
+}
+
+fn get_tag_by_name(conn: &Connection, name: &str) -> Result<Option<Tag>, StorageError> {
+    conn.query_row(
+        "SELECT id, name FROM tag WHERE name = ?1",
+        params![name],
+        map_tag,
+    )
+    .optional()
+    .map_err(StorageError::sql)
+}
+
+fn map_space(r: &rusqlite::Row) -> rusqlite::Result<Space> {
+    Ok(Space {
+        id: r.get(0)?,
+        name: r.get(1)?,
+        position: r.get(2)?,
+    })
+}
+
+fn map_project(r: &rusqlite::Row) -> rusqlite::Result<Project> {
+    Ok(Project {
+        id: r.get(0)?,
+        space_id: r.get(1)?,
+        name: r.get(2)?,
+        position: r.get(3)?,
+    })
+}
+
+fn map_tag(r: &rusqlite::Row) -> rusqlite::Result<Tag> {
+    Ok(Tag {
+        id: r.get(0)?,
+        name: r.get(1)?,
+    })
+}
+
+fn collect_mapped<T, F>(rows: rusqlite::MappedRows<'_, F>) -> Result<Vec<T>, StorageError>
+where
+    F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+{
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(StorageError::sql)?);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -498,5 +981,87 @@ mod tests {
         let storage = RusqliteStorage::new(&db).unwrap();
         let m = storage.get_meeting("a").unwrap();
         assert_eq!(m.id, "a");
+    }
+
+    #[test]
+    fn v1_registry_migrates_preserving_meetings_and_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("panops.db");
+        {
+            let conn = Connection::open(&db).unwrap();
+            conn.execute_batch(
+                r"
+                PRAGMA foreign_keys = ON;
+                CREATE TABLE meeting (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    title TEXT NOT NULL DEFAULT '',
+                    started_at TEXT NOT NULL,
+                    ended_at TEXT,
+                    duration_ms INTEGER,
+                    language TEXT NOT NULL DEFAULT 'auto',
+                    dir_path TEXT NOT NULL UNIQUE
+                );
+                CREATE INDEX idx_meeting_started_at ON meeting(started_at DESC);
+                CREATE TABLE note (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE,
+                    dialect TEXT NOT NULL,
+                    content_md TEXT NOT NULL,
+                    primary_path TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX idx_note_meeting_id ON note(meeting_id);
+                INSERT INTO meeting
+                    (id, title, started_at, ended_at, duration_ms, language, dir_path)
+                VALUES
+                    ('m_old', 'Old Meeting', '2026-05-05T10:00:00+00:00', NULL, NULL, 'en', '/tmp/old');
+                INSERT INTO note
+                    (id, meeting_id, dialect, content_md, primary_path, created_at)
+                VALUES
+                    ('n_old', 'm_old', 'basic', '# old', '/tmp/old/notes.md', '2026-05-05T10:01:00+00:00');
+                PRAGMA user_version = 1;
+                ",
+            )
+            .unwrap();
+        }
+
+        let storage = RusqliteStorage::new(&db).expect("migrate v1 to v2");
+        let meeting = storage.get_meeting("m_old").expect("old meeting survives");
+        assert_eq!(meeting.title, "Old Meeting");
+        assert_eq!(meeting.language, "en");
+        let notes = storage
+            .list_notes_for_meeting("m_old")
+            .expect("old notes survive");
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].id, "n_old");
+        let summary = storage
+            .list_meetings()
+            .expect("list after migration")
+            .into_iter()
+            .find(|m| m.id == "m_old")
+            .expect("old summary");
+        assert!(summary.space_id.is_none());
+        assert!(summary.project_id.is_none());
+        assert!(summary.tags.is_empty());
+
+        let conn = Connection::open(&db).unwrap();
+        let v: u32 = conn
+            .query_row("PRAGMA user_version;", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, EXPECTED_SCHEMA_VERSION);
+        for table in ["space", "project", "tag", "meeting_tag"] {
+            let exists: bool = conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                    params![table],
+                    |_| Ok(true),
+                )
+                .optional()
+                .unwrap()
+                .unwrap_or(false);
+            assert!(exists, "{table} table should exist after migration");
+        }
+        assert!(column_exists(&conn, "meeting", "space_id").unwrap());
+        assert!(column_exists(&conn, "meeting", "project_id").unwrap());
     }
 }

--- a/docs/superpowers/specs/2026-06-08-phase-b-organization-design.md
+++ b/docs/superpowers/specs/2026-06-08-phase-b-organization-design.md
@@ -1,0 +1,83 @@
+# Slice: Phase B — organization (Spaces / Projects / Tags) — design
+
+**Date:** 2026-06-08
+**Status:** Approved for autonomous build (maintainer delegated solo design+build while away, 2026-06-08).
+**Advances:** the UX plan's Phase B (organization), on top of the shipped Phase A workspace.
+
+## Goal
+
+Let the user organize meetings beyond a flat date-grouped list: group them into **Spaces** (e.g. Work / Study / Personal), optionally into **Projects** within a space, and label them with **Tags**. Unassigned meetings live in an implicit **Inbox**. Single-user, on-device, no accounts/members/quotas (open-source local-first).
+
+## Product model
+
+- **Space** — a top-level user-created grouping (id, name, position). No hardcoded names.
+- **Project** — a collection inside exactly one Space (id, space_id, name, position).
+- **Tag** — a free label (id, name unique); many-to-many with meetings via `meeting_tag`.
+- **Meeting** gains `space_id` (nullable) + `project_id` (nullable). Rules: a meeting has 0–1 space and 0–1 project; assigning a project sets the meeting's space to that project's space (project ⊂ space); `space_id IS NULL` ⇒ **Inbox** (no Inbox row exists — it's the null bucket). Deleting a space/project nulls the affected meetings' refs (meetings are never deleted by org changes).
+
+## Architecture
+
+Registry-only change — everything lives in `panops.db` (the cross-meeting registry), not per-meeting dbs. Extends the existing `Storage` port + its SQLite adapter + conformance/fake (no new port — these are storage concerns). IPC adds `space.*` / `project.* `/ `tag.*` / `meeting.assign` / `meeting.tag`. The app's `AppViewModel` + sidebar consume them. Domain types in `panops-core` stay platform-agnostic; wire types in `panops-protocol`.
+
+## Storage migration
+
+`rusqlite_storage.rs` is versioned via `PRAGMA user_version` / `EXPECTED_SCHEMA_VERSION`. Bump it and add a migration step:
+```sql
+CREATE TABLE space   (id TEXT PRIMARY KEY, name TEXT NOT NULL, position INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, space_id TEXT NOT NULL REFERENCES space(id) ON DELETE CASCADE, name TEXT NOT NULL, position INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL);
+CREATE TABLE tag     (id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, created_at TEXT NOT NULL);
+CREATE TABLE meeting_tag (meeting_id TEXT NOT NULL REFERENCES meeting(id) ON DELETE CASCADE, tag_id TEXT NOT NULL REFERENCES tag(id) ON DELETE CASCADE, PRIMARY KEY (meeting_id, tag_id));
+ALTER TABLE meeting ADD COLUMN space_id   TEXT REFERENCES space(id)   ON DELETE SET NULL;
+ALTER TABLE meeting ADD COLUMN project_id TEXT REFERENCES project(id) ON DELETE SET NULL;
+```
+Migration must be forward-only + idempotent on the existing single-version registry; preserve existing meeting/note rows. Test: an old-version db migrates cleanly + existing data survives.
+
+## Domain + Storage port (panops-core)
+
+New domain types: `Space { id, name, position }`, `Project { id, space_id, name, position }`, `Tag { id, name }`. `MeetingSummary` gains `space_id: Option<String>`, `project_id: Option<String>`, `tags: Vec<String>` (tag names or ids — ids, with names resolvable via list_tags).
+
+New `Storage` port methods (each added to the trait + the SQLite adapter + the conformance suite + the fake):
+- spaces: `create_space(name) -> Space`, `list_spaces() -> Vec<Space>`, `rename_space(id, name)`, `delete_space(id)`.
+- projects: `create_project(space_id, name) -> Project`, `list_projects(space_id) -> Vec<Project>` (and/or all), `rename_project`, `delete_project`.
+- tags: `create_tag(name) -> Tag` (idempotent on name), `list_tags() -> Vec<Tag>`, `delete_tag(id)`, `tag_meeting(meeting_id, tag_id)`, `untag_meeting(meeting_id, tag_id)`, `list_tags_for_meeting(meeting_id) -> Vec<Tag>`.
+- assign: `assign_meeting(meeting_id, space_id: Option, project_id: Option)` (project sets space).
+- `list_meetings` gains optional filters (space_id / project_id / tag_id / unsorted) for the sidebar.
+
+## IPC (panops-protocol + engine handlers)
+
+`ipc.space.create|list|rename|delete`, `ipc.project.create|list|rename|delete`, `ipc.tag.create|list|delete|assign|unassign` (assign/unassign = tag/untag a meeting), `ipc.meeting.assign { meeting_id, space_id?, project_id? }`. `ipc.meeting.list` gains optional filter params. Wire types mirror the domain; domain↔wire conversions; conformance updated.
+
+## App UI (apps/Panops)
+
+Sidebar (`MeetingListView` / `ContentView` / `AppViewModel`):
+- **Smart Views** section: Inbox (unsorted), All, Needs Notes, This Week — client-side filters over the meeting list.
+- **Spaces** section: collapsible Spaces → Projects; selecting one filters the meeting list. "+" to create a space/project; rename/delete via context menu.
+- **Tags** section: list tags; selecting filters; meetings show their tag chips.
+- **Assign**: meeting context-menu → Move to Space/Project, Add/Remove Tag. (Drag-and-drop optional, later.)
+- Reuse the date-grouped rich rows within the selected view.
+
+## Build order (thin vertical slices → separate PRs)
+
+- **PR B1 — storage foundation (Rust):** schema migration + bump version + domain types (Space/Project/Tag) + the Storage port methods + SQLite adapter + conformance + fake + MeetingSummary fields. The data layer, fully tested (incl. migration test). No IPC/UI yet.
+- **PR B2 — IPC (Rust):** the `space.*`/`project.*`/`tag.*`/`meeting.assign`/`meeting.tag` methods + handlers + meeting.list filters + wire types. Stacked on B1.
+- **PR B3 — sidebar UI (Swift):** Smart Views + Spaces→Projects + Tags + assign context-menus, wired to the new IPC. Stacked on B2. (May split B3a Spaces/Projects, B3b Tags + Smart Views if large.)
+
+Each PR = isolated-surface, fleet-built, dual-model-reviewed, maintainer-merged.
+
+## Three-tier boundaries
+
+- ✅ Always: `cargo fmt`/`clippy` + `swift build`/`swift test` before pushing; commit per unit; migration must preserve existing data (test it); open issues for deferred items.
+- ⚠️ Ask-first: any change to existing `meeting`/`note` columns beyond the additive `space_id`/`project_id`; any per-meeting-db change (this slice is registry-only); drag-and-drop reordering semantics.
+- 🚫 Never: SaaS-isms (accounts, members, sharing, quotas, "X of N GB"); a destructive migration (must be additive + preserve data); telemetry; cloud sync; user-config env vars.
+
+## Verification
+
+Per PR: `cargo build/test/clippy --workspace --locked` (incl. socket tests + a migration test that an old-version registry upgrades + keeps its meetings); `swift build`+`swift test` (CLT framework paths). A real end-to-end (create space → assign meeting → filter) is exercised via the IPC integration tests + the app's fakes.
+
+## Out of scope (deferred → debt)
+
+- Drag-and-drop assignment (context-menu first).
+- Calendar/Events, Participants/People, Sharing (north-star: future, opt-in).
+- Smart Views beyond the four listed.
+- Tag colors / space icons (names only first).
+- Cross-meeting search beyond title/date/language.


### PR DESCRIPTION
First of three Phase B PRs (organization). Spec: `docs/superpowers/specs/2026-06-08-phase-b-organization-design.md` (in this PR). **Storage layer only — no IPC/UI yet.**

- **Schema v2 migration** (registry `panops.db`): `space`/`project`/`tag`/`meeting_tag` tables + `meeting.space_id`/`project_id`; forward-only, data-preserving (existing meetings/notes survive — covered by `v1_registry_migrates_preserving_meetings_and_notes`).
- **Domain + Storage port**: Space/Project/Tag types; create/list/rename/delete for each; tag/untag + list_tags_for_meeting; `assign_meeting` (project sets space); `list_meetings` filters; `MeetingSummary` += space_id/project_id/tags. Idempotent `create_tag`; delete preserves meetings (project→clears project_id, space→cascade/set-null).
- SQLite adapter + conformance suite + fake all updated.

Verified: `cargo build/test/clippy --workspace --locked` green **incl. the Unix-socket IPC tests + the migration test**. Next: B2 (IPC) stacked on this, then B3 (sidebar UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)