### PR TITLE
Notes: render NotionEnhanced callout/details/table (fix raw tags)

### DIFF
--- a/apps/Panops/Sources/Panops/Views/MarkdownText.swift
+++ b/apps/Panops/Sources/Panops/Views/MarkdownText.swift
@@ -354,7 +354,9 @@ enum Markdown {
 
     /// Strip HTML-tag-like sequences (`<tag …>`, `</tag>`) from inline text so
     /// no stray markup renders raw. A `<` not followed by a letter (or `/`+letter)
-    /// is left alone, so prose like `a < b` survives.
+    /// is left alone, so prose like `a < b` survives. CommonMark autolinks
+    /// (`<scheme://…>`) and emails (`<…@…>`) are spared so `inlineAttributed`
+    /// can render them as links.
     static func sanitizeInline(_ text: String) -> String {
         guard text.contains("<") else { return text }
         var result = ""
@@ -366,7 +368,8 @@ enum Markdown {
                     probe = text.index(after: probe)
                 }
                 if probe < text.endIndex, text[probe].isLetter,
-                   let gt = text.range(of: ">", range: i..<text.endIndex) {
+                   let gt = text.range(of: ">", range: i..<text.endIndex),
+                   !isAutolinkOrEmail(text[text.index(after: i)..<gt.lowerBound]) {
                     i = gt.upperBound
                     continue
                 }
@@ -375,6 +378,14 @@ enum Markdown {
             i = text.index(after: i)
         }
         return result
+    }
+
+    /// A CommonMark autolink (`scheme://…`) or email (`local@domain`) inside
+    /// angle brackets — never a real tag (those carry attributes or whitespace),
+    /// so it must not be stripped.
+    private static func isAutolinkOrEmail(_ inner: Substring) -> Bool {
+        guard !inner.contains(" ") else { return false }
+        return inner.contains("://") || inner.contains("@")
     }
 
     /// Render a single line of inline markdown, falling back to plain text.

--- a/apps/Panops/Sources/Panops/Views/MarkdownText.swift
+++ b/apps/Panops/Sources/Panops/Views/MarkdownText.swift
@@ -44,10 +44,13 @@ enum Markdown {
     /// so nothing renders as raw `<tag>` text.
     static func parseBlocks(_ source: String) -> [MarkdownBlock] {
         let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+        // Fenced code is parsed downstream by `parseTextBlocks`; compute its
+        // ranges up front so container scanning skips tags written inside code.
+        let fenced = fencedCodeRanges(in: normalized)
         var blocks: [MarkdownBlock] = []
         var cursor = normalized.startIndex
         while cursor < normalized.endIndex {
-            guard let match = nextContainerTag(in: normalized, from: cursor) else {
+            guard let match = nextContainerTag(in: normalized, from: cursor, fenced: fenced) else {
                 blocks.append(contentsOf: parseTextBlocks(String(normalized[cursor...])))
                 break
             }
@@ -70,7 +73,7 @@ enum Markdown {
         var blocks: [MarkdownBlock] = []
         var paragraph: [String] = []
         var codeLines: [String] = []
-        var inCode = false
+        var openFence: String?
 
         func flushParagraph() {
             if !paragraph.isEmpty {
@@ -87,18 +90,20 @@ enum Markdown {
             let line = rawLine
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
-            if trimmed.hasPrefix("```") {
-                if inCode {
+            if let marker = fenceMarker(of: trimmed) {
+                if openFence == nil {
+                    flushParagraph()
+                    openFence = marker
+                    continue
+                } else if marker == openFence {
                     blocks.append(.code(text: codeLines.joined(separator: "\n")))
                     codeLines.removeAll()
-                    inCode = false
-                } else {
-                    flushParagraph()
-                    inCode = true
+                    openFence = nil
+                    continue
                 }
-                continue
+                // A non-matching fence marker inside a block is code content.
             }
-            if inCode {
+            if openFence != nil {
                 codeLines.append(line)
                 continue
             }
@@ -132,7 +137,7 @@ enum Markdown {
 
             paragraph.append(trimmed)
         }
-        if inCode, !codeLines.isEmpty {
+        if openFence != nil, !codeLines.isEmpty {
             blocks.append(.code(text: codeLines.joined(separator: "\n")))
         }
         flushParagraph()
@@ -188,10 +193,55 @@ enum Markdown {
 
     private static let containerNames = ["callout", "details", "table"]
 
+    /// Fence markers that open/close a code block (CommonMark + NotionEnhanced).
+    private static let fenceMarkers = ["```", "~~~"]
+
+    /// The fence marker a trimmed line opens/closes with, or nil if it is not a
+    /// fence line.
+    private static func fenceMarker(of trimmed: String) -> String? {
+        for marker in fenceMarkers where trimmed.hasPrefix(marker) { return marker }
+        return nil
+    }
+
+    /// Source ranges covered by fenced code blocks (` ``` ` or `~~~`), fence
+    /// lines included, so container scanning ignores tags written inside code.
+    /// An unterminated fence runs to the end of the source.
+    private static func fencedCodeRanges(in source: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var openStart: String.Index?
+        var openMarker: String?
+        var lineStart = source.startIndex
+        while true {
+            let lineEnd = source.range(of: "\n", range: lineStart..<source.endIndex)?.lowerBound
+                ?? source.endIndex
+            let trimmed = source[lineStart..<lineEnd].trimmingCharacters(in: .whitespaces)
+            if let marker = openMarker, let start = openStart {
+                if trimmed.hasPrefix(marker) {
+                    let next = lineEnd < source.endIndex ? source.index(after: lineEnd) : source.endIndex
+                    ranges.append(start..<next)
+                    openStart = nil
+                    openMarker = nil
+                }
+            } else if let marker = fenceMarker(of: trimmed) {
+                openStart = lineStart
+                openMarker = marker
+            }
+            if lineEnd == source.endIndex { break }
+            lineStart = source.index(after: lineEnd)
+        }
+        if let start = openStart {
+            ranges.append(start..<source.endIndex)
+        }
+        return ranges
+    }
+
     /// Find the earliest `<callout>` / `<details>` / `<table>` opening at or
-    /// after `from`, consume through its matching close tag (which may be many
-    /// lines later), and parse it into a block.
-    private static func nextContainerTag(in text: String, from: String.Index) -> ContainerMatch? {
+    /// after `from` (skipping any inside a fenced code range), consume through
+    /// its matching close tag (which may be many lines later), and parse it into
+    /// a block.
+    private static func nextContainerTag(
+        in text: String, from: String.Index, fenced: [Range<String.Index>]
+    ) -> ContainerMatch? {
         var best: (open: Range<String.Index>, name: String)?
         for name in containerNames {
             var searchStart = from
@@ -200,7 +250,8 @@ enum Markdown {
             ) {
                 let after = openMark.upperBound
                 let boundaryOk = after != text.endIndex && " \t\r\n>/".contains(text[after])
-                if boundaryOk {
+                let inFence = fenced.contains { $0.contains(openMark.lowerBound) }
+                if boundaryOk && !inFence {
                     if best == nil || openMark.lowerBound < best!.open.lowerBound {
                         best = (openMark, name)
                     }

--- a/apps/Panops/Sources/Panops/Views/MarkdownText.swift
+++ b/apps/Panops/Sources/Panops/Views/MarkdownText.swift
@@ -10,6 +10,12 @@ enum MarkdownBlock: Equatable {
     case paragraph(text: String)
     case code(text: String)
     case quote(text: String)
+    /// NotionEnhanced `<callout icon="X">…</callout>` — a highlighted note.
+    case callout(icon: String?, body: String)
+    /// NotionEnhanced `<details><summary>Title</summary>…</details>` — collapsible.
+    case disclosure(summary: String, body: String)
+    /// NotionEnhanced `<table>…</table>` rows; first row is the header.
+    case table(rows: [[String]])
 }
 
 enum Markdown {
@@ -31,11 +37,36 @@ enum Markdown {
         return source
     }
 
-    /// Parse markdown text into block-level structure. Consecutive plain lines
-    /// coalesce into a single paragraph; blank lines separate blocks.
+    /// Parse markdown text into block-level structure. NotionEnhanced container
+    /// tags (`<callout>`, `<details>`, `<table>`) — which may span multiple
+    /// lines — are lifted out into dedicated blocks first; the text between them
+    /// is parsed as ordinary markdown. Any other angle-bracket tag is stripped
+    /// so nothing renders as raw `<tag>` text.
     static func parseBlocks(_ source: String) -> [MarkdownBlock] {
         let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
-        let lines = normalized.components(separatedBy: "\n")
+        var blocks: [MarkdownBlock] = []
+        var cursor = normalized.startIndex
+        while cursor < normalized.endIndex {
+            guard let match = nextContainerTag(in: normalized, from: cursor) else {
+                blocks.append(contentsOf: parseTextBlocks(String(normalized[cursor...])))
+                break
+            }
+            if match.range.lowerBound > cursor {
+                blocks.append(contentsOf: parseTextBlocks(String(normalized[cursor..<match.range.lowerBound])))
+            }
+            if let block = match.block {
+                blocks.append(block)
+            }
+            cursor = match.range.upperBound
+        }
+        return blocks
+    }
+
+    /// Parse a run of plain markdown (no container tags). Consecutive plain
+    /// lines coalesce into a single paragraph; blank lines separate blocks.
+    /// Inline text is sanitized of stray angle-bracket tags.
+    private static func parseTextBlocks(_ source: String) -> [MarkdownBlock] {
+        let lines = source.components(separatedBy: "\n")
         var blocks: [MarkdownBlock] = []
         var paragraph: [String] = []
         var codeLines: [String] = []
@@ -43,7 +74,11 @@ enum Markdown {
 
         func flushParagraph() {
             if !paragraph.isEmpty {
-                blocks.append(.paragraph(text: paragraph.joined(separator: " ")))
+                let text = sanitizeInline(paragraph.joined(separator: " "))
+                    .trimmingCharacters(in: .whitespaces)
+                if !text.isEmpty {
+                    blocks.append(.paragraph(text: text))
+                }
                 paragraph.removeAll()
             }
         }
@@ -73,25 +108,25 @@ enum Markdown {
                 continue
             }
 
-            if let heading = parseHeading(trimmed) {
+            if let (level, text) = parseHeading(trimmed) {
                 flushParagraph()
-                blocks.append(heading)
+                blocks.append(.heading(level: level, text: sanitizeInline(text)))
                 continue
             }
             if let (number, text) = parseOrdered(trimmed) {
                 flushParagraph()
-                blocks.append(.ordered(number: number, text: text))
+                blocks.append(.ordered(number: number, text: sanitizeInline(text)))
                 continue
             }
             if let bullet = parseBullet(trimmed) {
                 flushParagraph()
-                blocks.append(.bullet(text: bullet))
+                blocks.append(.bullet(text: sanitizeInline(bullet)))
                 continue
             }
             if trimmed.hasPrefix(">") {
                 flushParagraph()
                 let text = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
-                blocks.append(.quote(text: text))
+                blocks.append(.quote(text: sanitizeInline(text)))
                 continue
             }
 
@@ -104,7 +139,7 @@ enum Markdown {
         return blocks
     }
 
-    private static func parseHeading(_ trimmed: String) -> MarkdownBlock? {
+    private static func parseHeading(_ trimmed: String) -> (Int, String)? {
         var level = 0
         for ch in trimmed {
             if ch == "#" { level += 1 } else { break }
@@ -114,7 +149,7 @@ enum Markdown {
         guard rest.first == " " else { return nil }
         let text = rest.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return nil }
-        return .heading(level: level, text: text)
+        return (level, text)
     }
 
     private static func parseBullet(_ trimmed: String) -> String? {
@@ -138,6 +173,157 @@ enum Markdown {
         guard afterSep < trimmed.endIndex, trimmed[afterSep] == " " else { return nil }
         let text = String(trimmed[trimmed.index(after: afterSep)...]).trimmingCharacters(in: .whitespaces)
         return (number, text)
+    }
+
+    // MARK: - NotionEnhanced container tags
+
+    /// A located container tag: the full source range it occupies (used to slice
+    /// the text around it) and the block it parses into. `block` is nil when the
+    /// open tag has no matching close — the range then covers only the orphan
+    /// open tag so the caller drops it.
+    private struct ContainerMatch {
+        let range: Range<String.Index>
+        let block: MarkdownBlock?
+    }
+
+    private static let containerNames = ["callout", "details", "table"]
+
+    /// Find the earliest `<callout>` / `<details>` / `<table>` opening at or
+    /// after `from`, consume through its matching close tag (which may be many
+    /// lines later), and parse it into a block.
+    private static func nextContainerTag(in text: String, from: String.Index) -> ContainerMatch? {
+        var best: (open: Range<String.Index>, name: String)?
+        for name in containerNames {
+            var searchStart = from
+            while let openMark = text.range(
+                of: "<\(name)", options: .caseInsensitive, range: searchStart..<text.endIndex
+            ) {
+                let after = openMark.upperBound
+                let boundaryOk = after != text.endIndex && " \t\r\n>/".contains(text[after])
+                if boundaryOk {
+                    if best == nil || openMark.lowerBound < best!.open.lowerBound {
+                        best = (openMark, name)
+                    }
+                    break
+                }
+                searchStart = openMark.upperBound
+            }
+        }
+        guard let chosen = best else { return nil }
+        let name = chosen.name
+        // End of the open tag (its `>`); without one the tag is malformed.
+        guard let openEnd = text.range(of: ">", range: chosen.open.upperBound..<text.endIndex) else {
+            return ContainerMatch(range: chosen.open, block: nil)
+        }
+        let openTag = String(text[chosen.open.lowerBound..<openEnd.upperBound])
+        guard let close = text.range(
+            of: "</\(name)>", options: .caseInsensitive, range: openEnd.upperBound..<text.endIndex
+        ) else {
+            // Orphan open tag: drop just the open tag, keep the rest as text.
+            return ContainerMatch(range: chosen.open.lowerBound..<openEnd.upperBound, block: nil)
+        }
+        let inner = String(text[openEnd.upperBound..<close.lowerBound])
+        let full = chosen.open.lowerBound..<close.upperBound
+        return ContainerMatch(range: full, block: makeContainerBlock(name: name, openTag: openTag, inner: inner))
+    }
+
+    private static func makeContainerBlock(name: String, openTag: String, inner: String) -> MarkdownBlock {
+        switch name {
+        case "callout":
+            return .callout(
+                icon: parseIconAttr(openTag),
+                body: inner.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        case "details":
+            let (summary, body) = parseDetails(inner)
+            return .disclosure(summary: summary, body: body)
+        default:
+            return .table(rows: parseTableRows(inner))
+        }
+    }
+
+    /// Extract `icon="…"` (or single-quoted) from a `<callout …>` open tag.
+    private static func parseIconAttr(_ openTag: String) -> String? {
+        for quote in ["icon=\"", "icon='"] {
+            guard let start = openTag.range(of: quote) else { continue }
+            let close = quote.hasSuffix("\"") ? "\"" : "'"
+            guard let end = openTag.range(of: close, range: start.upperBound..<openTag.endIndex) else { continue }
+            let icon = String(openTag[start.upperBound..<end.lowerBound]).trimmingCharacters(in: .whitespaces)
+            return icon.isEmpty ? nil : icon
+        }
+        return nil
+    }
+
+    /// Split `<details>` inner content into its `<summary>` label and body.
+    private static func parseDetails(_ inner: String) -> (summary: String, body: String) {
+        guard let sOpen = inner.range(of: "<summary", options: .caseInsensitive),
+              let sOpenEnd = inner.range(of: ">", range: sOpen.upperBound..<inner.endIndex),
+              let sClose = inner.range(of: "</summary>", options: .caseInsensitive, range: sOpenEnd.upperBound..<inner.endIndex)
+        else {
+            return ("", inner.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        let summary = sanitizeInline(String(inner[sOpenEnd.upperBound..<sClose.lowerBound]))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = String(inner[sClose.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (summary, body)
+    }
+
+    /// Parse `<tr>` rows of `<td>`/`<th>` cells into a string grid.
+    private static func parseTableRows(_ inner: String) -> [[String]] {
+        var rows: [[String]] = []
+        var search = inner.startIndex
+        while let trOpen = inner.range(of: "<tr", options: .caseInsensitive, range: search..<inner.endIndex),
+              let trGt = inner.range(of: ">", range: trOpen.upperBound..<inner.endIndex),
+              let trClose = inner.range(of: "</tr>", options: .caseInsensitive, range: trGt.upperBound..<inner.endIndex) {
+            let cells = parseCells(String(inner[trGt.upperBound..<trClose.lowerBound]))
+            if !cells.isEmpty { rows.append(cells) }
+            search = trClose.upperBound
+        }
+        return rows
+    }
+
+    private static func parseCells(_ rowInner: String) -> [String] {
+        var cells: [String] = []
+        var search = rowInner.startIndex
+        while let lt = rowInner.range(of: "<", range: search..<rowInner.endIndex) {
+            let after = lt.upperBound
+            let rest = rowInner[after...].lowercased()
+            let name = rest.hasPrefix("td") ? "td" : (rest.hasPrefix("th") ? "th" : nil)
+            guard let name else { search = after; continue }
+            guard let gt = rowInner.range(of: ">", range: after..<rowInner.endIndex),
+                  let close = rowInner.range(of: "</\(name)>", options: .caseInsensitive, range: gt.upperBound..<rowInner.endIndex)
+            else { break }
+            let cell = sanitizeInline(String(rowInner[gt.upperBound..<close.lowerBound]))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            cells.append(cell)
+            search = close.upperBound
+        }
+        return cells
+    }
+
+    /// Strip HTML-tag-like sequences (`<tag …>`, `</tag>`) from inline text so
+    /// no stray markup renders raw. A `<` not followed by a letter (or `/`+letter)
+    /// is left alone, so prose like `a < b` survives.
+    static func sanitizeInline(_ text: String) -> String {
+        guard text.contains("<") else { return text }
+        var result = ""
+        var i = text.startIndex
+        while i < text.endIndex {
+            if text[i] == "<" {
+                var probe = text.index(after: i)
+                if probe < text.endIndex, text[probe] == "/" {
+                    probe = text.index(after: probe)
+                }
+                if probe < text.endIndex, text[probe].isLetter,
+                   let gt = text.range(of: ">", range: i..<text.endIndex) {
+                    i = gt.upperBound
+                    continue
+                }
+            }
+            result.append(text[i])
+            i = text.index(after: i)
+        }
+        return result
     }
 
     /// Render a single line of inline markdown, falling back to plain text.
@@ -199,6 +385,12 @@ struct MarkdownBlocksView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color.secondary.opacity(0.08))
                         .clipShape(RoundedRectangle(cornerRadius: 6))
+                case .callout(let icon, let body):
+                    CalloutBlockView(icon: icon, content: body)
+                case .disclosure(let summary, let body):
+                    DisclosureBlockView(summary: summary, content: body)
+                case .table(let rows):
+                    TableBlockView(rows: rows)
                 }
             }
         }
@@ -212,5 +404,73 @@ struct MarkdownBlocksView: View {
         case 2: return .title3
         default: return .headline
         }
+    }
+}
+
+/// A NotionEnhanced callout: a tinted rounded box with an optional leading icon
+/// and a markdown-rendered body.
+private struct CalloutBlockView: View {
+    let icon: String?
+    let content: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            if let icon, !icon.isEmpty {
+                Text(icon)
+            }
+            MarkdownBlocksView(markdown: content)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.accentColor.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// A NotionEnhanced `<details>` block as a default-expanded disclosure whose
+/// content renders as markdown.
+private struct DisclosureBlockView: View {
+    let summary: String
+    let content: String
+    @State private var expanded = true
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            MarkdownBlocksView(markdown: content)
+                .padding(.top, 4)
+        } label: {
+            Text(Markdown.inlineAttributed(summary))
+                .fontWeight(.semibold)
+        }
+    }
+}
+
+/// A NotionEnhanced `<table>` rendered as an aligned grid. The first row is
+/// treated as the header and rendered bold.
+private struct TableBlockView: View {
+    let rows: [[String]]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, cells in
+                HStack(alignment: .top, spacing: 0) {
+                    ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                        Text(Markdown.inlineAttributed(cell))
+                            .fontWeight(rowIndex == 0 ? .semibold : .regular)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                    }
+                }
+                .background(rowIndex == 0 ? Color.secondary.opacity(0.08) : Color.clear)
+                if rowIndex < rows.count - 1 {
+                    Divider()
+                }
+            }
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.secondary.opacity(0.2))
+        )
     }
 }

--- a/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
+++ b/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
@@ -67,4 +67,102 @@ struct MarkdownTests {
         let blocks = Markdown.parseBlocks(src)
         #expect(blocks.contains(.code(text: "let x = 1\nlet y = 2")))
     }
+
+    // MARK: - NotionEnhanced container tags
+
+    private func callouts(in blocks: [MarkdownBlock]) -> [(icon: String?, body: String)] {
+        blocks.compactMap { block in
+            if case let .callout(icon, body) = block { return (icon, body) }
+            return nil
+        }
+    }
+
+    @Test("parseBlocks renders a callout with an icon")
+    func calloutWithIcon() {
+        let blocks = Markdown.parseBlocks(#"<callout icon="🎯">Watch the budget.</callout>"#)
+        let found = callouts(in: blocks)
+        #expect(found.count == 1)
+        #expect(found.first?.icon == "🎯")
+        #expect(found.first?.body == "Watch the budget.")
+        #expect(!blocks.contains { describe($0).contains("<callout") })
+    }
+
+    @Test("parseBlocks renders a callout without an icon")
+    func calloutWithoutIcon() {
+        let blocks = Markdown.parseBlocks("<callout>Heads up.</callout>")
+        let found = callouts(in: blocks)
+        #expect(found.count == 1)
+        #expect(found.first?.icon == nil)
+        #expect(found.first?.body == "Heads up.")
+    }
+
+    @Test("parseBlocks parses a multi-line details/summary block")
+    func disclosureMultiLine() {
+        let src = """
+        <details><summary>Rollout plan</summary>
+        First we ship the parser.
+        Then we wire the view.
+        </details>
+        """
+        let blocks = Markdown.parseBlocks(src)
+        let found: (summary: String, body: String)? = blocks.compactMap { block in
+            if case let .disclosure(summary, body) = block { return (summary: summary, body: body) }
+            return nil
+        }.first
+        #expect(found?.summary == "Rollout plan")
+        #expect(found?.body.contains("First we ship the parser.") == true)
+        #expect(found?.body.contains("Then we wire the view.") == true)
+        #expect(!blocks.contains { describe($0).contains("<summary") })
+    }
+
+    @Test("parseBlocks parses table rows and cells")
+    func tableRows() {
+        let src = "<table><tr><th>Name</th><th>Role</th></tr><tr><td>Ana</td><td>PM</td></tr></table>"
+        let blocks = Markdown.parseBlocks(src)
+        let rows: [[String]]? = blocks.compactMap { block in
+            if case let .table(rows) = block { return rows }
+            return nil
+        }.first
+        #expect(rows == [["Name", "Role"], ["Ana", "PM"]])
+    }
+
+    @Test("parseBlocks strips an unknown angle-bracket tag")
+    func stripsUnknownTag() {
+        let blocks = Markdown.parseBlocks("See <span>this</span> note.")
+        #expect(blocks == [.paragraph(text: "See this note.")])
+        #expect(!blocks.contains { describe($0).contains("<") })
+    }
+
+    @Test("parseBlocks lifts an inline callout out of a paragraph")
+    func inlineCalloutDoesNotLeak() {
+        let blocks = Markdown.parseBlocks(#"Intro text <callout icon="🎯">be careful</callout> outro text"#)
+        #expect(!blocks.contains { describe($0).contains("<callout") })
+        #expect(!blocks.contains { describe($0).contains("</callout>") })
+        let found = callouts(in: blocks)
+        #expect(found.count == 1)
+        #expect(found.first?.body == "be careful")
+        #expect(blocks.contains(.paragraph(text: "Intro text")))
+        #expect(blocks.contains(.paragraph(text: "outro text")))
+    }
+
+    @Test("parseBlocks leaves plain `<` in prose untouched")
+    func keepsBareLessThan() {
+        let blocks = Markdown.parseBlocks("The value a < b holds.")
+        #expect(blocks == [.paragraph(text: "The value a < b holds.")])
+    }
+
+    /// Render any block to a string for raw-tag-leak assertions.
+    private func describe(_ block: MarkdownBlock) -> String {
+        switch block {
+        case .heading(_, let text): return text
+        case .bullet(let text): return text
+        case .ordered(_, let text): return text
+        case .paragraph(let text): return text
+        case .code(let text): return text
+        case .quote(let text): return text
+        case .callout(let icon, let body): return (icon ?? "") + body
+        case .disclosure(let summary, let body): return summary + body
+        case .table(let rows): return rows.flatMap { $0 }.joined(separator: " ")
+        }
+    }
 }

--- a/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
+++ b/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
@@ -174,6 +174,25 @@ struct MarkdownTests {
         #expect(blocks.contains(.paragraph(text: "After the block")))
     }
 
+    @Test("parseBlocks keeps autolinks and emails intact")
+    func keepsAutolinksAndEmails() {
+        let blocks = Markdown.parseBlocks("Visit <https://example.com> or mail <a@b.com>.")
+        let paragraph = blocks.compactMap { block -> String? in
+            if case let .paragraph(text) = block { return text }
+            return nil
+        }.first
+        #expect(paragraph?.contains("<https://example.com>") == true)
+        #expect(paragraph?.contains("<a@b.com>") == true)
+    }
+
+    @Test("sanitizeInline strips known tags but spares autolinks and emails")
+    func sanitizeSparesLinks() {
+        #expect(Markdown.sanitizeInline("a <td>x</td> b") == "a x b")
+        #expect(Markdown.sanitizeInline("see <span>y</span>") == "see y")
+        #expect(Markdown.sanitizeInline("<https://example.com>") == "<https://example.com>")
+        #expect(Markdown.sanitizeInline("<alice@example.com>") == "<alice@example.com>")
+    }
+
     /// Render any block to a string for raw-tag-leak assertions.
     private func describe(_ block: MarkdownBlock) -> String {
         switch block {

--- a/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
+++ b/apps/Panops/Tests/PanopsTests/MarkdownTests.swift
@@ -151,6 +151,29 @@ struct MarkdownTests {
         #expect(blocks == [.paragraph(text: "The value a < b holds.")])
     }
 
+    @Test("parseBlocks keeps a NotionEnhanced tag inside fenced code as code")
+    func fencedTagStaysCode() {
+        let src = """
+        Before the block
+
+        ```
+        <table><tr><td>x</td></tr></table>
+        ```
+
+        After the block
+        """
+        let blocks = Markdown.parseBlocks(src)
+        // The fenced tag must NOT be lifted into a table block.
+        #expect(!blocks.contains { if case .table = $0 { return true }; return false })
+        // It stays verbatim inside the code block.
+        #expect(blocks.contains { block in
+            guard case let .code(text) = block else { return false }
+            return text.contains("<table>") && text.contains("</table>")
+        })
+        #expect(blocks.contains(.paragraph(text: "Before the block")))
+        #expect(blocks.contains(.paragraph(text: "After the block")))
+    }
+
     /// Render any block to a string for raw-tag-leak assertions.
     private func describe(_ block: MarkdownBlock) -> String {
         switch block {


### PR DESCRIPTION
Fixes the visible bug in the maintainer's screenshot: NotionEnhanced inline tags rendered as **raw literal text** in the Notes tab (`<details><summary>…</summary></details>`, `<callout icon="🎯">…</callout>`).

The `.md`/`.json` stay NotionEnhanced (per north-star); this fixes the **app renderer**. `MarkdownText`/`NotesView` now parse + render the dialect: `<callout>` → tinted box, `<details><summary>` → DisclosureGroup, `<table>` → grid; stray/unknown tags are stripped (nothing renders raw). Multi-line tags handled. Existing markdown unchanged.

Verified: `swift build` clean + **98 tests** (added coverage for callout/details/table parsing + tag stripping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)