### PR TITLE
Capture conformance: capture_target preservation + list_windows robustness (#221)

### DIFF
--- a/crates/panops-core/src/capture.rs
+++ b/crates/panops-core/src/capture.rs
@@ -75,6 +75,8 @@ impl Default for CaptureConfig {
 pub struct CaptureSession {
     pub meeting_id: String,
     pub started_at_ms: u64,
+    /// Screen target selected when the session was started.
+    pub capture_target: CaptureTarget,
 }
 
 /// Result returned by `stop_capture`. Contains paths to captured artifacts.
@@ -175,9 +177,11 @@ mod tests {
         let s = CaptureSession {
             meeting_id: "abc123".into(),
             started_at_ms: 1_700_000_000_000,
+            capture_target: CaptureTarget::Display,
         };
         assert_eq!(s.meeting_id, "abc123");
         assert_eq!(s.started_at_ms, 1_700_000_000_000);
+        assert_eq!(s.capture_target, CaptureTarget::Display);
     }
 
     #[test]

--- a/crates/panops-core/src/conformance/capture.rs
+++ b/crates/panops-core/src/conformance/capture.rs
@@ -44,7 +44,15 @@ pub fn run_suite_with<C: Capture>(adapter: &C, fixtures_dir: &Path, expected_is_
 }
 
 fn list_windows_returns_window_info<C: Capture>(adapter: &C) {
-    let windows = adapter.list_windows().expect("list_windows should succeed");
+    let windows = match adapter.list_windows() {
+        Ok(windows) => windows,
+        Err(err) if is_not_implemented_capture_error(&err) => return,
+        Err(err) => panic!("list_windows should succeed or be explicitly not implemented: {err:?}"),
+    };
+    assert_window_infos_are_well_formed(&windows);
+}
+
+fn assert_window_infos_are_well_formed(windows: &[crate::capture::WindowInfo]) {
     assert!(
         !windows.is_empty(),
         "list_windows must return at least one capturable window"
@@ -57,6 +65,16 @@ fn list_windows_returns_window_info<C: Capture>(adapter: &C) {
         );
         assert!(!window.title.trim().is_empty(), "title should be non-empty");
     }
+}
+
+fn is_not_implemented_capture_error(err: &CaptureError) -> bool {
+    let (CaptureError::Capture(message) | CaptureError::Sidecar(message)) = err else {
+        return false;
+    };
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("not implemented")
+        || normalized.contains("not yet implemented")
+        || normalized.contains("not available")
 }
 
 fn temp_meeting_dir() -> std::path::PathBuf {
@@ -105,22 +123,31 @@ fn start_accepts_window_capture_target<C: Capture>(adapter: &C, _fixtures_dir: &
     let meeting_dir = temp_meeting_dir();
     std::fs::create_dir_all(&meeting_dir).expect("create temp meeting dir");
 
-    let window = adapter
-        .list_windows()
-        .expect("list_windows should succeed")
-        .into_iter()
-        .next()
-        .expect("conformance window");
+    let windows = match adapter.list_windows() {
+        Ok(windows) => windows,
+        Err(err) if is_not_implemented_capture_error(&err) => {
+            let _ = std::fs::remove_dir_all(&meeting_dir);
+            return;
+        }
+        Err(err) => panic!("list_windows should succeed before window-target capture: {err:?}"),
+    };
+    assert_window_infos_are_well_formed(&windows);
+    let window = windows.into_iter().next().expect("conformance window");
+    let capture_target = CaptureTarget::Window {
+        window_id: window.window_id,
+    };
     let config = CaptureConfig {
-        capture_target: CaptureTarget::Window {
-            window_id: window.window_id,
-        },
+        capture_target,
         ..CaptureConfig::default()
     };
     let session = adapter
         .start_capture(meeting_id, &meeting_dir, &config)
         .expect("start_capture should accept a window target");
     assert_eq!(session.meeting_id, meeting_id);
+    assert_eq!(
+        session.capture_target, capture_target,
+        "start_capture must preserve the requested capture_target on the session"
+    );
     let _ = adapter.stop_capture(&session);
 
     let _ = std::fs::remove_dir_all(&meeting_dir);
@@ -264,6 +291,7 @@ fn stop_session_not_found<C: Capture>(adapter: &C) {
     let fake_session = CaptureSession {
         meeting_id: "nonexistent_session".into(),
         started_at_ms: 0,
+        capture_target: CaptureTarget::Display,
     };
     let err = adapter
         .stop_capture(&fake_session)

--- a/crates/panops-core/src/conformance/fakes.rs
+++ b/crates/panops-core/src/conformance/fakes.rs
@@ -794,6 +794,7 @@ impl Capture for FakeCapture {
         Ok(CaptureSession {
             meeting_id: meeting_id.to_string(),
             started_at_ms,
+            capture_target: config.capture_target,
         })
     }
 
@@ -805,7 +806,12 @@ impl Capture for FakeCapture {
         let fake_session = sessions
             .remove(&session.meeting_id)
             .ok_or_else(|| CaptureError::SessionNotFound(session.meeting_id.clone()))?;
-        let _capture_target = fake_session.capture_target;
+        if session.capture_target != fake_session.capture_target {
+            return Err(CaptureError::InvalidConfig(format!(
+                "session capture target {:?} did not match started target {:?}",
+                session.capture_target, fake_session.capture_target
+            )));
+        }
 
         // Compute duration (at least 1s for valid WAV).
         let ended_at_ms = std::time::SystemTime::now()

--- a/crates/panops-mac/src/screencapturekit_capture.rs
+++ b/crates/panops-mac/src/screencapturekit_capture.rs
@@ -385,6 +385,7 @@ impl Capture for ScreenCaptureKitCapture {
         Ok(CaptureSession {
             meeting_id: meeting_id.to_string(),
             started_at_ms: started.started_at_ms,
+            capture_target: config.capture_target,
         })
     }
 
@@ -546,6 +547,7 @@ mod tests {
         let session = CaptureSession {
             meeting_id: "never_started".into(),
             started_at_ms: 0,
+            capture_target: CaptureTarget::Display,
         };
         let err = cap.stop_capture(&session).expect_err("should fail");
         assert!(matches!(err, CaptureError::SessionNotFound(id) if id == "never_started"));


### PR DESCRIPTION
Closes #221 (from the #220 review). Conformance-only (panops-core):
- FakeCapture carries `capture_target` through the session; conformance now asserts the start-time target is preserved.
- `list_windows_returns_window_info` tolerates a not-yet-implemented adapter (Err → skip) while still enforcing well-formed non-empty windows for adapters that implement listing.

Verified: capture conformance + capture tests pass (`capture_target_default_is_display`, fake conformance, etc.). NOTE: the local `cargo test --workspace` shows one unrelated failure — `ipc_refuses_to_steal_live_socket` — because this dev machine's registry was migrated to schema v2 by a Phase B B1 test run (the engine integration tests don't isolate the data dir → v1 engines can't open the v2 registry). That's environment pollution, not this PR; CI runs on a fresh registry. Filing the test-isolation gap separately.