### PR TITLE
fix: bundle onnxruntime/sherpa dylibs so packaged engine launches

### DIFF
--- a/apps/Panops/Panops-engine.entitlements
+++ b/apps/Panops/Panops-engine.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the bundled panops-engine. The engine loads the ad-hoc-signed
+  onnxruntime + sherpa-onnx dylibs that sit next to it in Resources/. Under the
+  hardened runtime, library validation rejects libraries whose Team ID differs
+  from the loading process (ad-hoc signatures carry no Team ID), so the engine
+  needs disable-library-validation or it crashes on launch with a dyld
+  "different Team IDs" error.
+-->
+<plist version="1.0"><dict>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict></plist>

--- a/apps/Panops/Panops-engine.entitlements
+++ b/apps/Panops/Panops-engine.entitlements
@@ -7,6 +7,12 @@
   from the loading process (ad-hoc signatures carry no Team ID), so the engine
   needs disable-library-validation or it crashes on launch with a dyld
   "different Team IDs" error.
+
+  Trade-off: this lets the engine load any dylib found in its rpath, not just the
+  bundled copies. Acceptable here — the .app is code-signed, so tampering with
+  Resources/ breaks the signature (Gatekeeper blocks the app), and without an
+  Apple Developer ID we can't instead sign the dylibs with the app's Team ID.
+  Revisit if a Developer ID signing channel lands.
 -->
 <plist version="1.0"><dict>
   <key>com.apple.security.cs.disable-library-validation</key><true/>

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -26,6 +26,13 @@ cargo build --release -p panops-engine
 # sibling-of-engine resolver finds them (asr_resolver / llm_resolver /
 # capture_resolver) — no env vars needed in the bundle.
 cp target/release/panops-engine "$RES/panops-engine"
+# The engine dynamically links onnxruntime + sherpa-onnx (via sherpa-rs, for
+# diarization/VAD). cargo's build-time rpath finds them in target/release; the
+# bundle has no such path, so copy them next to the engine — its rpath is
+# @executable_path (= Resources/). Missing → the engine dies on launch with
+# "dyld: Library not loaded: @rpath/libonnxruntime…" and nothing records.
+cp target/release/libonnxruntime.*.dylib "$RES/"
+cp target/release/libsherpa-onnx-c-api.dylib "$RES/"
 cp apps/Panops/.build/release/Panops "$MACOS/Panops"
 cp apps/panops-asr-mac/.build/release/panops-asr-mac "$RES/panops-asr-mac"
 cp apps/panops-llm-mac/.build/release/panops-llm-mac "$RES/panops-llm-mac"
@@ -47,10 +54,17 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </dict></plist>
 PLIST
 
-# 4. Ad-hoc sign (inner binaries first, then the app), hardened runtime + entitlements
-for b in "$RES/panops-engine" "$RES/panops-asr-mac" "$RES/panops-llm-mac"; do
+# 4. Ad-hoc sign (inner code first, then the app), hardened runtime + entitlements.
+# The bundled dylibs + the ASR/LLM sidecars carry no special entitlements.
+for b in "$RES"/lib*.dylib "$RES/panops-asr-mac" "$RES/panops-llm-mac"; do
   codesign --force --options runtime --timestamp=none -s - "$b"
 done
+# The engine loads the ad-hoc-signed onnxruntime/sherpa dylibs copied above.
+# Under the hardened runtime, library validation rejects libraries whose Team ID
+# differs from the loading process (ad-hoc = no Team ID), so the engine needs
+# disable-library-validation or it can't load them (dyld "different Team IDs").
+codesign --force --options runtime --timestamp=none \
+  --entitlements apps/Panops/Panops-engine.entitlements -s - "$RES/panops-engine"
 # The capture sidecar is the process that opens the microphone, so under the
 # hardened runtime IT needs the audio-input entitlement on its own executable
 # (it isn't inherited from the outer .app). Without this, mic recording fails
@@ -59,6 +73,16 @@ codesign --force --options runtime --timestamp=none \
   --entitlements apps/Panops/Panops.entitlements -s - "$RES/panops-capture-mac"
 codesign --force --options runtime --timestamp=none \
   --entitlements apps/Panops/Panops.entitlements -s - "$APP"
+
+# Smoke: the bundled engine must actually launch under the hardened runtime
+# (i.e. its dylibs resolve + load). Catches a missing bundled dylib or a
+# library-validation/signing regression before we ship a non-starting app.
+if ! "$RES/panops-engine" --help >/dev/null 2>&1; then
+  echo "error: bundled panops-engine failed to launch (dylib/signing problem):" >&2
+  "$RES/panops-engine" --help 2>&1 | head -6 >&2
+  exit 1
+fi
+
 codesign --verify --deep --strict "$APP"
 
 # 5. Tar + sha256 (bare hash in the .sha256 file — the cask needs just the

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -31,8 +31,13 @@ cp target/release/panops-engine "$RES/panops-engine"
 # bundle has no such path, so copy them next to the engine — its rpath is
 # @executable_path (= Resources/). Missing → the engine dies on launch with
 # "dyld: Library not loaded: @rpath/libonnxruntime…" and nothing records.
-cp target/release/libonnxruntime.*.dylib "$RES/"
-cp target/release/libsherpa-onnx-c-api.dylib "$RES/"
+# Derive the exact filenames from the binary (not a glob) so a version bump or a
+# stale copy left in target/release can't bundle the wrong dylib. The engine's
+# direct @rpath deps also cover the transitive chain (sherpa-onnx-c-api links
+# only onnxruntime, already listed); the launch smoke test below is the backstop.
+for dylib in $(otool -L target/release/panops-engine | awk '/@rpath\/.*\.dylib/ {sub(/@rpath\//,"",$1); print $1}'); do
+  cp "target/release/$dylib" "$RES/$dylib"
+done
 cp apps/Panops/.build/release/Panops "$MACOS/Panops"
 cp apps/panops-asr-mac/.build/release/panops-asr-mac "$RES/panops-asr-mac"
 cp apps/panops-llm-mac/.build/release/panops-llm-mac "$RES/panops-llm-mac"


### PR DESCRIPTION
## Problem

The packaged `Panops.app` was **completely non-functional**: the bundled engine crashed on launch and no engine process ever spawned, so nothing could record. dyld error:

```
dyld: Library not loaded: @rpath/libonnxruntime.1.17.1.dylib
  Referenced from: …/Panops.app/Contents/Resources/panops-engine
```

## Root cause

`panops-engine` dynamically links two native dylibs via `sherpa-rs` (diarization/VAD): `libonnxruntime.1.17.1.dylib` and `libsherpa-onnx-c-api.dylib`. In dev, cargo's build-time rpath points at `target/release` so they resolve; `package.sh` copied the engine binary but **not** these dylibs, and the bundle has no such path (the engine's rpath is `@executable_path` = `Resources/`).

## Fix

- Copy both dylibs into `Contents/Resources/` next to the engine.
- Sign the engine with a new `apps/Panops/Panops-engine.entitlements` granting `com.apple.security.cs.disable-library-validation`. The engine runs under the hardened runtime, whose **library validation rejects ad-hoc-signed third-party dylibs** ("mapping process and mapped file … have different Team IDs"); ad-hoc signatures carry no Team ID, so this entitlement is required to load them.
- Add a post-sign **launch smoke test** (`panops-engine --help`) so a missing dylib or signing regression fails the build instead of shipping a non-starting app.

## Verification

Applied the identical steps by hand to the live signed bundle (didn't re-run `package.sh` to avoid wiping the bundle under active testing): the engine now spawns, binds `engine.sock`, the app connects and shows meetings, and the New Recording sheet appears. `panops-engine --help` from inside the bundle exits 0 (the smoke test's premise). No Rust/Swift code changed — packaging only.

Found while testing the signed app for real Screen Recording capture.