### PR TITLE
Phase B (2/3): spaces/projects/tags IPC layer

### DIFF
--- a/crates/panops-engine/src/server/handlers.rs
+++ b/crates/panops-engine/src/server/handlers.rs
@@ -27,10 +27,13 @@ use panops_core::notes::pipeline::NotesGenerator;
 use panops_core::notes::raw_transcript::write_raw_transcript;
 use panops_protocol::{
     CaptureWindowsParams, CaptureWindowsResult, Event, IpcError, JobAccepted, JobDoneEvent,
-    JobErrorEvent, JobProgressEvent, Meeting, MeetingConfig, MeetingDeleteVideoParams,
-    MeetingDeleteVideoResult, MeetingSummary, NotesDialect, NotesGenerateParams,
-    NotesGenerateResult, RecordingAccepted, RecordingStartParams, RecordingStopParams,
-    RecordingStopped, ServerInfo, WindowInfo,
+    JobErrorEvent, JobProgressEvent, Meeting, MeetingAssignParams, MeetingConfig,
+    MeetingDeleteVideoParams, MeetingDeleteVideoResult, MeetingListParams, MeetingSummary,
+    NotesDialect, NotesGenerateParams, NotesGenerateResult, Project, ProjectCreateParams,
+    ProjectDeleteParams, ProjectListParams, ProjectListResult, ProjectRenameParams,
+    RecordingAccepted, RecordingStartParams, RecordingStopParams, RecordingStopped, ServerInfo,
+    Space, SpaceCreateParams, SpaceDeleteParams, SpaceListResult, SpaceRenameParams, Tag,
+    TagAssignParams, TagCreateParams, TagDeleteParams, TagListResult, WindowInfo,
 };
 use tokio::sync::broadcast;
 
@@ -58,7 +61,10 @@ pub(super) trait Ipc {
     ) -> Result<JobAccepted, ErrorObjectOwned>;
 
     #[method(name = "meeting.list")]
-    async fn meeting_list(&self) -> Result<Vec<MeetingSummary>, ErrorObjectOwned>;
+    async fn meeting_list(
+        &self,
+        params: Option<MeetingListParams>,
+    ) -> Result<Vec<MeetingSummary>, ErrorObjectOwned>;
 
     #[method(name = "server.info")]
     async fn server_info(&self) -> Result<ServerInfo, ErrorObjectOwned>;
@@ -81,11 +87,59 @@ pub(super) trait Ipc {
     #[method(name = "meeting.delete")]
     async fn meeting_delete(&self, params: MeetingIdParam) -> Result<(), ErrorObjectOwned>;
 
+    #[method(name = "meeting.assign")]
+    async fn meeting_assign(&self, params: MeetingAssignParams) -> Result<(), ErrorObjectOwned>;
+
     #[method(name = "meeting.deleteVideo")]
     async fn meeting_delete_video(
         &self,
         params: MeetingDeleteVideoParams,
     ) -> Result<MeetingDeleteVideoResult, ErrorObjectOwned>;
+
+    #[method(name = "space.create")]
+    async fn space_create(&self, params: SpaceCreateParams) -> Result<Space, ErrorObjectOwned>;
+
+    #[method(name = "space.list")]
+    async fn space_list(&self) -> Result<SpaceListResult, ErrorObjectOwned>;
+
+    #[method(name = "space.rename")]
+    async fn space_rename(&self, params: SpaceRenameParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "space.delete")]
+    async fn space_delete(&self, params: SpaceDeleteParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "project.create")]
+    async fn project_create(
+        &self,
+        params: ProjectCreateParams,
+    ) -> Result<Project, ErrorObjectOwned>;
+
+    #[method(name = "project.list")]
+    async fn project_list(
+        &self,
+        params: Option<ProjectListParams>,
+    ) -> Result<ProjectListResult, ErrorObjectOwned>;
+
+    #[method(name = "project.rename")]
+    async fn project_rename(&self, params: ProjectRenameParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "project.delete")]
+    async fn project_delete(&self, params: ProjectDeleteParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "tag.create")]
+    async fn tag_create(&self, params: TagCreateParams) -> Result<Tag, ErrorObjectOwned>;
+
+    #[method(name = "tag.list")]
+    async fn tag_list(&self) -> Result<TagListResult, ErrorObjectOwned>;
+
+    #[method(name = "tag.delete")]
+    async fn tag_delete(&self, params: TagDeleteParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "tag.assign")]
+    async fn tag_assign(&self, params: TagAssignParams) -> Result<(), ErrorObjectOwned>;
+
+    #[method(name = "tag.unassign")]
+    async fn tag_unassign(&self, params: TagAssignParams) -> Result<(), ErrorObjectOwned>;
 
     #[method(name = "recording.start")]
     async fn recording_start(
@@ -143,19 +197,21 @@ impl IpcServer for IpcImpl {
         ))
     }
 
-    async fn meeting_list(&self) -> Result<Vec<MeetingSummary>, ErrorObjectOwned> {
+    async fn meeting_list(
+        &self,
+        params: Option<MeetingListParams>,
+    ) -> Result<Vec<MeetingSummary>, ErrorObjectOwned> {
         let storage = self.services.storage.clone();
-        let rows = tokio::task::spawn_blocking(move || storage.list_meetings())
-            .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "meeting.list spawn_blocking join");
-                ipc_error_to_obj(IpcError::Internal {
-                    message: "meeting.list internal error".into(),
-                })
-            })?
-            .map_err(|e| ipc_error_to_obj(e.into()))?;
-
-        Ok(rows.into_iter().map(MeetingSummary::from).collect())
+        spawn_blocking_into_ipc("meeting.list", move || {
+            let rows = match params {
+                Some(params) => storage
+                    .list_meetings_filtered(params.into())
+                    .map_err(IpcError::from)?,
+                None => storage.list_meetings().map_err(IpcError::from)?,
+            };
+            Ok(rows.into_iter().map(MeetingSummary::from).collect())
+        })
+        .await
     }
 
     async fn server_info(&self) -> Result<ServerInfo, ErrorObjectOwned> {
@@ -269,6 +325,16 @@ impl IpcServer for IpcImpl {
         .await
     }
 
+    async fn meeting_assign(&self, params: MeetingAssignParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("meeting.assign", move || {
+            storage
+                .assign_meeting(&params.meeting_id, params.space_id, params.project_id)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
     async fn meeting_delete_video(
         &self,
         params: MeetingDeleteVideoParams,
@@ -324,6 +390,152 @@ impl IpcServer for IpcImpl {
                     })
                 }
             }
+        })
+        .await
+    }
+
+    async fn space_create(&self, params: SpaceCreateParams) -> Result<Space, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("space.create", move || {
+            storage
+                .create_space(&params.name)
+                .map(Space::from)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn space_list(&self) -> Result<SpaceListResult, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("space.list", move || {
+            let spaces = storage
+                .list_spaces()
+                .map_err(IpcError::from)?
+                .into_iter()
+                .map(Space::from)
+                .collect();
+            Ok(SpaceListResult { spaces })
+        })
+        .await
+    }
+
+    async fn space_rename(&self, params: SpaceRenameParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("space.rename", move || {
+            storage
+                .rename_space(&params.id, &params.name)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn space_delete(&self, params: SpaceDeleteParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("space.delete", move || {
+            storage.delete_space(&params.id).map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn project_create(
+        &self,
+        params: ProjectCreateParams,
+    ) -> Result<Project, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("project.create", move || {
+            storage
+                .create_project(&params.space_id, &params.name)
+                .map(Project::from)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn project_list(
+        &self,
+        params: Option<ProjectListParams>,
+    ) -> Result<ProjectListResult, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("project.list", move || {
+            let space_id = params.as_ref().and_then(|p| p.space_id.as_deref());
+            let projects = storage
+                .list_projects(space_id)
+                .map_err(IpcError::from)?
+                .into_iter()
+                .map(Project::from)
+                .collect();
+            Ok(ProjectListResult { projects })
+        })
+        .await
+    }
+
+    async fn project_rename(&self, params: ProjectRenameParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("project.rename", move || {
+            storage
+                .rename_project(&params.id, &params.name)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn project_delete(&self, params: ProjectDeleteParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("project.delete", move || {
+            storage.delete_project(&params.id).map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn tag_create(&self, params: TagCreateParams) -> Result<Tag, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("tag.create", move || {
+            storage
+                .create_tag(&params.name)
+                .map(Tag::from)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn tag_list(&self) -> Result<TagListResult, ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("tag.list", move || {
+            let tags = storage
+                .list_tags()
+                .map_err(IpcError::from)?
+                .into_iter()
+                .map(Tag::from)
+                .collect();
+            Ok(TagListResult { tags })
+        })
+        .await
+    }
+
+    async fn tag_delete(&self, params: TagDeleteParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("tag.delete", move || {
+            storage.delete_tag(&params.id).map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn tag_assign(&self, params: TagAssignParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("tag.assign", move || {
+            storage
+                .tag_meeting(&params.meeting_id, &params.tag_id)
+                .map_err(IpcError::from)
+        })
+        .await
+    }
+
+    async fn tag_unassign(&self, params: TagAssignParams) -> Result<(), ErrorObjectOwned> {
+        let storage = self.services.storage.clone();
+        spawn_blocking_into_ipc("tag.unassign", move || {
+            storage
+                .untag_meeting(&params.meeting_id, &params.tag_id)
+                .map_err(IpcError::from)
         })
         .await
     }

--- a/crates/panops-engine/tests/ipc_organization_meeting_list_filter.rs
+++ b/crates/panops-engine/tests/ipc_organization_meeting_list_filter.rs
@@ -11,24 +11,36 @@ use jsonrpsee::rpc_params;
 use panops_core::conformance::fakes::{
     FakeNotesExporter, KnownRegionsFake, KnownTurnsFake, MockLlm, TranscriptFileFake,
 };
+use panops_core::storage::Storage;
 use panops_engine::server::{EngineServices, run_serve_in_process};
-use panops_protocol::{MeetingSummary, Space};
+use panops_protocol::{
+    MeetingSummary, Project, ProjectListResult, Space, SpaceListResult, Tag, TagListResult,
+};
 use serde_json::json;
 use tempfile::tempdir;
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 
 use common::{tempdir_storage, uds_ws_client, wait_for_socket};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn meeting_list_space_filter_returns_only_assigned_meeting() {
+struct IpcHarness {
+    _socket_tmp: tempfile::TempDir,
+    _storage_tmp: tempfile::TempDir,
+    storage: Arc<dyn Storage>,
+    client: jsonrpsee::ws_client::WsClient,
+    shutdown_tx: watch::Sender<bool>,
+    server: JoinHandle<()>,
+}
+
+async fn start_harness() -> IpcHarness {
     let dir = tempdir().unwrap();
     let socket = dir.path().join("engine.sock");
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let (storage_tmp, storage, data_dir) = tempdir_storage();
     let services = EngineServices::ready(
         Arc::new(MockLlm::default()),
-        storage,
+        storage.clone(),
         data_dir,
         Arc::new(TranscriptFileFake::default()),
         Arc::new(KnownTurnsFake),
@@ -47,15 +59,35 @@ async fn meeting_list_space_filter_returns_only_assigned_meeting() {
 
     let client = uds_ws_client(&socket).await;
 
+    IpcHarness {
+        _socket_tmp: dir,
+        _storage_tmp: storage_tmp,
+        storage,
+        client,
+        shutdown_tx,
+        server,
+    }
+}
+
+async fn shutdown(harness: IpcHarness) {
+    let _ = harness.shutdown_tx.send(true);
+    let _ = harness.server.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_list_space_filter_returns_only_assigned_meeting() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
     let assigned_meeting_id: String = ClientT::request(
-        &client,
+        client,
         "ipc.meeting.start",
         rpc_params![json!({"title":"Assigned"})],
     )
     .await
     .expect("meeting.start assigned");
     let _unassigned_meeting_id: String = ClientT::request(
-        &client,
+        client,
         "ipc.meeting.start",
         rpc_params![json!({"title":"Unassigned"})],
     )
@@ -63,7 +95,7 @@ async fn meeting_list_space_filter_returns_only_assigned_meeting() {
     .expect("meeting.start unassigned");
 
     let space: Space = ClientT::request(
-        &client,
+        client,
         "ipc.space.create",
         rpc_params![json!({"name":"Work"})],
     )
@@ -71,7 +103,7 @@ async fn meeting_list_space_filter_returns_only_assigned_meeting() {
     .expect("space.create");
 
     let _: () = ClientT::request(
-        &client,
+        client,
         "ipc.meeting.assign",
         rpc_params![
             json!({"meeting_id": assigned_meeting_id.clone(), "space_id": space.id.clone()})
@@ -81,7 +113,7 @@ async fn meeting_list_space_filter_returns_only_assigned_meeting() {
     .expect("meeting.assign");
 
     let filtered: Vec<MeetingSummary> = ClientT::request(
-        &client,
+        client,
         "ipc.meeting.list",
         rpc_params![json!({"space_id": space.id.clone()})],
     )
@@ -98,6 +130,492 @@ async fn meeting_list_space_filter_returns_only_assigned_meeting() {
     assert_eq!(filtered[0].space_id.as_deref(), Some(space.id.as_str()));
     assert!(filtered[0].project_id.is_none());
 
-    let _ = shutdown_tx.send(true);
-    let _ = server.await;
+    shutdown(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn space_rename_and_delete_are_reflected_by_space_list() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
+    let space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Work"})],
+    )
+    .await
+    .expect("space.create");
+    assert_eq!(space.id, "space_1");
+    assert_eq!(space.name, "Work");
+    assert_eq!(space.position, 0);
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.space.rename",
+        rpc_params![json!({"id": space.id.clone(), "name":"Renamed Work"})],
+    )
+    .await
+    .expect("space.rename");
+
+    let listed: SpaceListResult = ClientT::request(client, "ipc.space.list", rpc_params![])
+        .await
+        .expect("space.list after rename");
+    assert_eq!(
+        listed.spaces,
+        vec![Space {
+            id: space.id.clone(),
+            name: "Renamed Work".into(),
+            position: 0,
+        }]
+    );
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.space.delete",
+        rpc_params![json!({"id": space.id.clone()})],
+    )
+    .await
+    .expect("space.delete");
+
+    let listed: SpaceListResult = ClientT::request(client, "ipc.space.list", rpc_params![])
+        .await
+        .expect("space.list after delete");
+    assert!(listed.spaces.is_empty(), "space should be gone: {listed:?}");
+
+    shutdown(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_create_rename_delete_are_reflected_by_project_list_space_filter() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
+    let target_space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Client Work"})],
+    )
+    .await
+    .expect("target space.create");
+    let other_space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Personal"})],
+    )
+    .await
+    .expect("other space.create");
+    assert_eq!(target_space.id, "space_1");
+    assert_eq!(other_space.id, "space_2");
+
+    let project: Project = ClientT::request(
+        client,
+        "ipc.project.create",
+        rpc_params![json!({"space_id": target_space.id.clone(), "name":"Launch"})],
+    )
+    .await
+    .expect("project.create");
+    let other_project: Project = ClientT::request(
+        client,
+        "ipc.project.create",
+        rpc_params![json!({"space_id": other_space.id.clone(), "name":"Errands"})],
+    )
+    .await
+    .expect("other project.create");
+    assert_eq!(
+        project,
+        Project {
+            id: "project_1".into(),
+            space_id: target_space.id.clone(),
+            name: "Launch".into(),
+            position: 0,
+        }
+    );
+    assert_eq!(other_project.id, "project_2");
+
+    let listed: ProjectListResult = ClientT::request(
+        client,
+        "ipc.project.list",
+        rpc_params![json!({"space_id": target_space.id.clone()})],
+    )
+    .await
+    .expect("project.list target space");
+    assert_eq!(listed.projects, vec![project.clone()]);
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.project.rename",
+        rpc_params![json!({"id": project.id.clone(), "name":"Renamed Launch"})],
+    )
+    .await
+    .expect("project.rename");
+
+    let listed: ProjectListResult = ClientT::request(
+        client,
+        "ipc.project.list",
+        rpc_params![json!({"space_id": target_space.id.clone()})],
+    )
+    .await
+    .expect("project.list after rename");
+    assert_eq!(
+        listed.projects,
+        vec![Project {
+            id: project.id.clone(),
+            space_id: target_space.id.clone(),
+            name: "Renamed Launch".into(),
+            position: 0,
+        }]
+    );
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.project.delete",
+        rpc_params![json!({"id": project.id.clone()})],
+    )
+    .await
+    .expect("project.delete");
+
+    let listed: ProjectListResult = ClientT::request(
+        client,
+        "ipc.project.list",
+        rpc_params![json!({"space_id": target_space.id.clone()})],
+    )
+    .await
+    .expect("project.list after delete");
+    assert!(
+        listed.projects.is_empty(),
+        "deleted project should be gone from target space: {listed:?}"
+    );
+    let other_listed: ProjectListResult = ClientT::request(
+        client,
+        "ipc.project.list",
+        rpc_params![json!({"space_id": other_space.id.clone()})],
+    )
+    .await
+    .expect("project.list other space after target delete");
+    assert_eq!(other_listed.projects, vec![other_project]);
+
+    shutdown(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tag_create_is_idempotent_and_assign_unassign_updates_meeting_tags() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
+    let meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Tagged"})],
+    )
+    .await
+    .expect("meeting.start tagged");
+
+    let tag: Tag = ClientT::request(
+        client,
+        "ipc.tag.create",
+        rpc_params![json!({"name":"customer"})],
+    )
+    .await
+    .expect("tag.create");
+    let same_tag: Tag = ClientT::request(
+        client,
+        "ipc.tag.create",
+        rpc_params![json!({"name":"customer"})],
+    )
+    .await
+    .expect("tag.create duplicate");
+    assert_eq!(
+        tag,
+        Tag {
+            id: "tag_1".into(),
+            name: "customer".into(),
+        }
+    );
+    assert_eq!(same_tag, tag, "duplicate tag.create should be idempotent");
+
+    let listed: TagListResult = ClientT::request(client, "ipc.tag.list", rpc_params![])
+        .await
+        .expect("tag.list");
+    assert_eq!(listed.tags, vec![tag.clone()]);
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.tag.assign",
+        rpc_params![json!({"meeting_id": meeting_id.clone(), "tag_id": tag.id.clone()})],
+    )
+    .await
+    .expect("tag.assign");
+
+    let meetings: Vec<MeetingSummary> = ClientT::request(client, "ipc.meeting.list", rpc_params![])
+        .await
+        .expect("meeting.list after tag.assign");
+    assert_eq!(meetings.len(), 1, "expected one meeting: {meetings:?}");
+    assert_eq!(meetings[0].id, meeting_id);
+    assert_eq!(meetings[0].title, "Tagged");
+    assert_eq!(meetings[0].tags, vec![tag.id.clone()]);
+
+    let meeting_tags = harness
+        .storage
+        .list_tags_for_meeting(&meeting_id)
+        .expect("storage list_tags_for_meeting after tag.assign");
+    assert_eq!(
+        meeting_tags,
+        vec![panops_core::storage::Tag::from(tag.clone())]
+    );
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.tag.unassign",
+        rpc_params![json!({"meeting_id": meeting_id.clone(), "tag_id": tag.id.clone()})],
+    )
+    .await
+    .expect("tag.unassign");
+
+    let meetings: Vec<MeetingSummary> = ClientT::request(client, "ipc.meeting.list", rpc_params![])
+        .await
+        .expect("meeting.list after tag.unassign");
+    assert_eq!(meetings.len(), 1, "expected one meeting: {meetings:?}");
+    assert_eq!(meetings[0].id, meeting_id);
+    assert!(
+        meetings[0].tags.is_empty(),
+        "tag should be gone: {meetings:?}"
+    );
+    let meeting_tags = harness
+        .storage
+        .list_tags_for_meeting(&meeting_id)
+        .expect("storage list_tags_for_meeting after tag.unassign");
+    assert!(
+        meeting_tags.is_empty(),
+        "tag should be gone: {meeting_tags:?}"
+    );
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.tag.delete",
+        rpc_params![json!({"id": tag.id.clone()})],
+    )
+    .await
+    .expect("tag.delete");
+
+    let listed: TagListResult = ClientT::request(client, "ipc.tag.list", rpc_params![])
+        .await
+        .expect("tag.list after delete");
+    assert!(
+        listed.tags.is_empty(),
+        "deleted tag should be gone: {listed:?}"
+    );
+
+    shutdown(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_assign_with_project_id_sets_project_and_project_space() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
+    let meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Project Meeting"})],
+    )
+    .await
+    .expect("meeting.start");
+    let space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Work"})],
+    )
+    .await
+    .expect("space.create");
+    let project: Project = ClientT::request(
+        client,
+        "ipc.project.create",
+        rpc_params![json!({"space_id": space.id.clone(), "name":"Launch"})],
+    )
+    .await
+    .expect("project.create");
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.meeting.assign",
+        rpc_params![json!({"meeting_id": meeting_id.clone(), "project_id": project.id.clone()})],
+    )
+    .await
+    .expect("meeting.assign project");
+
+    let listed: Vec<MeetingSummary> = ClientT::request(client, "ipc.meeting.list", rpc_params![])
+        .await
+        .expect("meeting.list after project assign");
+    assert_eq!(listed.len(), 1, "expected one meeting: {listed:?}");
+    assert_eq!(listed[0].id, meeting_id);
+    assert_eq!(listed[0].title, "Project Meeting");
+    assert_eq!(listed[0].project_id.as_deref(), Some(project.id.as_str()));
+    assert_eq!(listed[0].space_id.as_deref(), Some(space.id.as_str()));
+
+    shutdown(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_list_project_tag_and_unsorted_filters_return_exact_meetings() {
+    let harness = start_harness().await;
+    let client = &harness.client;
+
+    let project_meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Project Filter Match"})],
+    )
+    .await
+    .expect("meeting.start project match");
+    let other_project_meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Other Project"})],
+    )
+    .await
+    .expect("meeting.start other project");
+    let tagged_meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Tagged Filter Match"})],
+    )
+    .await
+    .expect("meeting.start tagged match");
+    let unsorted_meeting_id: String = ClientT::request(
+        client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Inbox"})],
+    )
+    .await
+    .expect("meeting.start unsorted");
+
+    let space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Work"})],
+    )
+    .await
+    .expect("space.create work");
+    let other_space: Space = ClientT::request(
+        client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Other Space"})],
+    )
+    .await
+    .expect("space.create other");
+    let project: Project = ClientT::request(
+        client,
+        "ipc.project.create",
+        rpc_params![json!({"space_id": space.id.clone(), "name":"Launch"})],
+    )
+    .await
+    .expect("project.create launch");
+    let other_project: Project = ClientT::request(
+        client,
+        "ipc.project.create",
+        rpc_params![json!({"space_id": other_space.id.clone(), "name":"Ops"})],
+    )
+    .await
+    .expect("project.create ops");
+    let tag: Tag = ClientT::request(
+        client,
+        "ipc.tag.create",
+        rpc_params![json!({"name":"customer"})],
+    )
+    .await
+    .expect("tag.create customer");
+
+    let _: () = ClientT::request(
+        client,
+        "ipc.meeting.assign",
+        rpc_params![
+            json!({"meeting_id": project_meeting_id.clone(), "project_id": project.id.clone()})
+        ],
+    )
+    .await
+    .expect("meeting.assign project match");
+    let _: () = ClientT::request(
+        client,
+        "ipc.meeting.assign",
+        rpc_params![
+            json!({"meeting_id": other_project_meeting_id.clone(), "project_id": other_project.id.clone()})
+        ],
+    )
+    .await
+    .expect("meeting.assign other project");
+    let _: () = ClientT::request(
+        client,
+        "ipc.meeting.assign",
+        rpc_params![json!({"meeting_id": tagged_meeting_id.clone(), "space_id": space.id.clone()})],
+    )
+    .await
+    .expect("meeting.assign tagged to a space");
+    let _: () = ClientT::request(
+        client,
+        "ipc.tag.assign",
+        rpc_params![json!({"meeting_id": tagged_meeting_id.clone(), "tag_id": tag.id.clone()})],
+    )
+    .await
+    .expect("tag.assign tagged match");
+
+    let project_filtered: Vec<MeetingSummary> = ClientT::request(
+        client,
+        "ipc.meeting.list",
+        rpc_params![json!({"project_id": project.id.clone()})],
+    )
+    .await
+    .expect("meeting.list project_id filter");
+    assert_eq!(
+        meeting_ids(&project_filtered),
+        vec![project_meeting_id.clone()],
+        "project filter should only return matching project: {project_filtered:?}"
+    );
+    assert_eq!(project_filtered[0].title, "Project Filter Match");
+    assert_eq!(
+        project_filtered[0].project_id.as_deref(),
+        Some(project.id.as_str())
+    );
+    assert_eq!(
+        project_filtered[0].space_id.as_deref(),
+        Some(space.id.as_str())
+    );
+
+    let tag_filtered: Vec<MeetingSummary> = ClientT::request(
+        client,
+        "ipc.meeting.list",
+        rpc_params![json!({"tag_id": tag.id.clone()})],
+    )
+    .await
+    .expect("meeting.list tag_id filter");
+    assert_eq!(
+        meeting_ids(&tag_filtered),
+        vec![tagged_meeting_id.clone()],
+        "tag filter should only return tagged meeting: {tag_filtered:?}"
+    );
+    assert_eq!(tag_filtered[0].title, "Tagged Filter Match");
+    assert_eq!(tag_filtered[0].tags, vec![tag.id.clone()]);
+
+    let unsorted: Vec<MeetingSummary> = ClientT::request(
+        client,
+        "ipc.meeting.list",
+        rpc_params![json!({"unsorted": true})],
+    )
+    .await
+    .expect("meeting.list unsorted filter");
+    assert_eq!(
+        meeting_ids(&unsorted),
+        vec![unsorted_meeting_id.clone()],
+        "unsorted filter should only return meetings with no space: {unsorted:?}"
+    );
+    assert_eq!(unsorted[0].title, "Inbox");
+    assert!(unsorted[0].space_id.is_none());
+    assert!(unsorted[0].project_id.is_none());
+
+    shutdown(harness).await;
+}
+
+fn meeting_ids(meetings: &[MeetingSummary]) -> Vec<String> {
+    let mut ids: Vec<String> = meetings.iter().map(|m| m.id.clone()).collect();
+    ids.sort();
+    ids
 }

--- a/crates/panops-engine/tests/ipc_organization_meeting_list_filter.rs
+++ b/crates/panops-engine/tests/ipc_organization_meeting_list_filter.rs
@@ -1,0 +1,103 @@
+//! Phase B PR B2 — organization IPC exposes spaces and meeting.list filters.
+//! Creates two meetings, assigns one to a space, then verifies the space_id
+//! filter returns only the assigned meeting over the socket API.
+
+mod common;
+
+use std::sync::Arc;
+
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use panops_core::conformance::fakes::{
+    FakeNotesExporter, KnownRegionsFake, KnownTurnsFake, MockLlm, TranscriptFileFake,
+};
+use panops_engine::server::{EngineServices, run_serve_in_process};
+use panops_protocol::{MeetingSummary, Space};
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::sync::watch;
+
+use common::{tempdir_storage, uds_ws_client, wait_for_socket};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn meeting_list_space_filter_returns_only_assigned_meeting() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("engine.sock");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let (_storage_tmp, storage, data_dir) = tempdir_storage();
+    let services = EngineServices::ready(
+        Arc::new(MockLlm::default()),
+        storage,
+        data_dir,
+        Arc::new(TranscriptFileFake::default()),
+        Arc::new(KnownTurnsFake),
+        Arc::new(FakeNotesExporter),
+        Arc::new(KnownRegionsFake::default()),
+    );
+
+    let server_socket = socket.clone();
+    let server_shutdown = shutdown_rx.clone();
+    let server = tokio::spawn(async move {
+        run_serve_in_process(&server_socket, services, Some(server_shutdown))
+            .await
+            .unwrap();
+    });
+    wait_for_socket(&socket).await;
+
+    let client = uds_ws_client(&socket).await;
+
+    let assigned_meeting_id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Assigned"})],
+    )
+    .await
+    .expect("meeting.start assigned");
+    let _unassigned_meeting_id: String = ClientT::request(
+        &client,
+        "ipc.meeting.start",
+        rpc_params![json!({"title":"Unassigned"})],
+    )
+    .await
+    .expect("meeting.start unassigned");
+
+    let space: Space = ClientT::request(
+        &client,
+        "ipc.space.create",
+        rpc_params![json!({"name":"Work"})],
+    )
+    .await
+    .expect("space.create");
+
+    let _: () = ClientT::request(
+        &client,
+        "ipc.meeting.assign",
+        rpc_params![
+            json!({"meeting_id": assigned_meeting_id.clone(), "space_id": space.id.clone()})
+        ],
+    )
+    .await
+    .expect("meeting.assign");
+
+    let filtered: Vec<MeetingSummary> = ClientT::request(
+        &client,
+        "ipc.meeting.list",
+        rpc_params![json!({"space_id": space.id.clone()})],
+    )
+    .await
+    .expect("meeting.list filtered by space_id");
+
+    assert_eq!(
+        filtered.len(),
+        1,
+        "expected only assigned row: {filtered:?}"
+    );
+    assert_eq!(filtered[0].id, assigned_meeting_id);
+    assert_eq!(filtered[0].title, "Assigned");
+    assert_eq!(filtered[0].space_id.as_deref(), Some(space.id.as_str()));
+    assert!(filtered[0].project_id.is_none());
+
+    let _ = shutdown_tx.send(true);
+    let _ = server.await;
+}

--- a/crates/panops-protocol/src/lib.rs
+++ b/crates/panops-protocol/src/lib.rs
@@ -15,9 +15,12 @@ pub mod methods;
 pub use error::IpcError;
 pub use methods::{
     AudioSourcesWire, CaptureTarget, CaptureWindowsParams, CaptureWindowsResult, Event,
-    JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, LlmInfo, Meeting, MeetingConfig,
-    MeetingDeleteVideoParams, MeetingDeleteVideoResult, MeetingSummary, NotesDialect,
-    NotesGenerateParams, NotesGenerateResult, RecordingAccepted, RecordingProgressEvent,
-    RecordingStartParams, RecordingStopParams, RecordingStopped, ScreenshotEvent, ServerInfo,
-    WindowInfo,
+    JobAccepted, JobDoneEvent, JobErrorEvent, JobProgressEvent, LlmInfo, Meeting,
+    MeetingAssignParams, MeetingConfig, MeetingDeleteVideoParams, MeetingDeleteVideoResult,
+    MeetingListParams, MeetingSummary, NotesDialect, NotesGenerateParams, NotesGenerateResult,
+    Project, ProjectCreateParams, ProjectDeleteParams, ProjectListParams, ProjectListResult,
+    ProjectRenameParams, RecordingAccepted, RecordingProgressEvent, RecordingStartParams,
+    RecordingStopParams, RecordingStopped, ScreenshotEvent, ServerInfo, Space, SpaceCreateParams,
+    SpaceDeleteParams, SpaceListResult, SpaceRenameParams, Tag, TagAssignParams, TagCreateParams,
+    TagDeleteParams, TagListResult, WindowInfo,
 };

--- a/crates/panops-protocol/src/methods.rs
+++ b/crates/panops-protocol/src/methods.rs
@@ -207,6 +207,16 @@ pub struct MeetingSummary {
     pub language: String,
     /// Whether at least one note row exists for this meeting.
     pub has_notes: bool,
+    /// Optional organization space assignment. `None` means the meeting
+    /// is in the implicit Inbox/unsorted bucket.
+    #[serde(default)]
+    pub space_id: Option<String>,
+    /// Optional organization project assignment.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// Tag ids assigned to this meeting.
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Full meeting record returned by `meeting.get` / `meeting.start` /
@@ -238,6 +248,214 @@ impl From<panops_core::storage::MeetingSummary> for MeetingSummary {
             duration_ms: value.duration_ms,
             language: value.language,
             has_notes: value.has_notes,
+            space_id: value.space_id,
+            project_id: value.project_id,
+            tags: value.tags,
+        }
+    }
+}
+
+/// Wire organization space.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Space {
+    pub id: String,
+    pub name: String,
+    pub position: i64,
+}
+
+/// Wire organization project.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Project {
+    pub id: String,
+    pub space_id: String,
+    pub name: String,
+    pub position: i64,
+}
+
+/// Wire organization tag.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Tag {
+    pub id: String,
+    pub name: String,
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::storage::Space> for Space {
+    fn from(value: panops_core::storage::Space) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            position: value.position,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<Space> for panops_core::storage::Space {
+    fn from(value: Space) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            position: value.position,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::storage::Project> for Project {
+    fn from(value: panops_core::storage::Project) -> Self {
+        Self {
+            id: value.id,
+            space_id: value.space_id,
+            name: value.name,
+            position: value.position,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<Project> for panops_core::storage::Project {
+    fn from(value: Project) -> Self {
+        Self {
+            id: value.id,
+            space_id: value.space_id,
+            name: value.name,
+            position: value.position,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::storage::Tag> for Tag {
+    fn from(value: panops_core::storage::Tag) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<Tag> for panops_core::storage::Tag {
+    fn from(value: Tag) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpaceCreateParams {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpaceListResult {
+    pub spaces: Vec<Space>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpaceRenameParams {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpaceDeleteParams {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectCreateParams {
+    pub space_id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectListResult {
+    pub projects: Vec<Project>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectRenameParams {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectDeleteParams {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagCreateParams {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagListResult {
+    pub tags: Vec<Tag>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagDeleteParams {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagAssignParams {
+    pub meeting_id: String,
+    pub tag_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MeetingAssignParams {
+    pub meeting_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MeetingListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tag_id: Option<String>,
+    #[serde(default)]
+    pub unsorted: bool,
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<MeetingListParams> for panops_core::storage::MeetingListFilter {
+    fn from(value: MeetingListParams) -> Self {
+        Self {
+            space_id: value.space_id,
+            project_id: value.project_id,
+            tag_id: value.tag_id,
+            unsorted: value.unsorted,
+        }
+    }
+}
+
+#[cfg(feature = "domain-conversions")]
+impl From<panops_core::storage::MeetingListFilter> for MeetingListParams {
+    fn from(value: panops_core::storage::MeetingListFilter) -> Self {
+        Self {
+            space_id: value.space_id,
+            project_id: value.project_id,
+            tag_id: value.tag_id,
+            unsorted: value.unsorted,
         }
     }
 }
@@ -698,10 +916,227 @@ mod tests {
             duration_ms: 60_000,
             language: "en".into(),
             has_notes: true,
+            space_id: Some("space_1".into()),
+            project_id: Some("project_1".into()),
+            tags: vec!["tag_1".into()],
         };
         let back: MeetingSummary =
             serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn meeting_summary_accepts_legacy_payload_without_org_fields() {
+        let json = r#"{"id":"m1","title":"Test","started_at":"2026-05-02T10:00:00Z","ended_at":null,"duration_ms":0,"language":"auto","has_notes":false}"#;
+        let m: MeetingSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(m.space_id, None);
+        assert_eq!(m.project_id, None);
+        assert!(m.tags.is_empty());
+    }
+
+    #[test]
+    fn organization_wire_shapes_round_trip() {
+        let space = Space {
+            id: "space_1".into(),
+            name: "Work".into(),
+            position: 0,
+        };
+        assert_eq!(
+            serde_json::to_string(&space).unwrap(),
+            r#"{"id":"space_1","name":"Work","position":0}"#
+        );
+        let spaces = SpaceListResult {
+            spaces: vec![space.clone()],
+        };
+        assert_eq!(
+            serde_json::to_string(&spaces).unwrap(),
+            r#"{"spaces":[{"id":"space_1","name":"Work","position":0}]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<SpaceListResult>(&serde_json::to_string(&spaces).unwrap())
+                .unwrap(),
+            spaces
+        );
+
+        let project = Project {
+            id: "project_1".into(),
+            space_id: "space_1".into(),
+            name: "Panops".into(),
+            position: 1,
+        };
+        let projects = ProjectListResult {
+            projects: vec![project],
+        };
+        assert_eq!(
+            serde_json::to_string(&projects).unwrap(),
+            r#"{"projects":[{"id":"project_1","space_id":"space_1","name":"Panops","position":1}]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ProjectListResult>(&serde_json::to_string(&projects).unwrap())
+                .unwrap(),
+            projects
+        );
+
+        let tag = Tag {
+            id: "tag_1".into(),
+            name: "follow-up".into(),
+        };
+        let tags = TagListResult { tags: vec![tag] };
+        assert_eq!(
+            serde_json::to_string(&tags).unwrap(),
+            r#"{"tags":[{"id":"tag_1","name":"follow-up"}]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<TagListResult>(&serde_json::to_string(&tags).unwrap()).unwrap(),
+            tags
+        );
+    }
+
+    #[test]
+    fn organization_param_shapes_round_trip() {
+        assert_eq!(
+            serde_json::to_string(&SpaceCreateParams {
+                name: "Work".into()
+            })
+            .unwrap(),
+            r#"{"name":"Work"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&SpaceRenameParams {
+                id: "space_1".into(),
+                name: "Study".into()
+            })
+            .unwrap(),
+            r#"{"id":"space_1","name":"Study"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&SpaceDeleteParams {
+                id: "space_1".into()
+            })
+            .unwrap(),
+            r#"{"id":"space_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectCreateParams {
+                space_id: "space_1".into(),
+                name: "Panops".into()
+            })
+            .unwrap(),
+            r#"{"space_id":"space_1","name":"Panops"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectListParams {
+                space_id: Some("space_1".into())
+            })
+            .unwrap(),
+            r#"{"space_id":"space_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectRenameParams {
+                id: "project_1".into(),
+                name: "Phase B".into()
+            })
+            .unwrap(),
+            r#"{"id":"project_1","name":"Phase B"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectDeleteParams {
+                id: "project_1".into()
+            })
+            .unwrap(),
+            r#"{"id":"project_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&TagCreateParams {
+                name: "follow-up".into()
+            })
+            .unwrap(),
+            r#"{"name":"follow-up"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&TagDeleteParams { id: "tag_1".into() }).unwrap(),
+            r#"{"id":"tag_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&TagAssignParams {
+                meeting_id: "m1".into(),
+                tag_id: "tag_1".into()
+            })
+            .unwrap(),
+            r#"{"meeting_id":"m1","tag_id":"tag_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&MeetingAssignParams {
+                meeting_id: "m1".into(),
+                space_id: Some("space_1".into()),
+                project_id: None,
+            })
+            .unwrap(),
+            r#"{"meeting_id":"m1","space_id":"space_1"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&MeetingListParams {
+                space_id: Some("space_1".into()),
+                project_id: None,
+                tag_id: Some("tag_1".into()),
+                unsorted: false,
+            })
+            .unwrap(),
+            r#"{"space_id":"space_1","tag_id":"tag_1","unsorted":false}"#
+        );
+        let empty_list_params: MeetingListParams = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty_list_params, MeetingListParams::default());
+    }
+
+    #[cfg(feature = "domain-conversions")]
+    #[test]
+    fn organization_wire_converts_both_directions() {
+        let domain_space = panops_core::storage::Space {
+            id: "space_1".into(),
+            name: "Work".into(),
+            position: 0,
+        };
+        let wire_space = Space::from(domain_space.clone());
+        assert_eq!(wire_space.id, "space_1");
+        assert_eq!(panops_core::storage::Space::from(wire_space), domain_space);
+
+        let domain_project = panops_core::storage::Project {
+            id: "project_1".into(),
+            space_id: "space_1".into(),
+            name: "Panops".into(),
+            position: 1,
+        };
+        let wire_project = Project::from(domain_project.clone());
+        assert_eq!(wire_project.space_id, "space_1");
+        assert_eq!(
+            panops_core::storage::Project::from(wire_project),
+            domain_project
+        );
+
+        let domain_tag = panops_core::storage::Tag {
+            id: "tag_1".into(),
+            name: "follow-up".into(),
+        };
+        let wire_tag = Tag::from(domain_tag.clone());
+        assert_eq!(wire_tag.name, "follow-up");
+        assert_eq!(panops_core::storage::Tag::from(wire_tag), domain_tag);
+    }
+
+    #[cfg(feature = "domain-conversions")]
+    #[test]
+    fn meeting_list_params_convert_to_filter_and_back() {
+        let params = MeetingListParams {
+            space_id: Some("space_1".into()),
+            project_id: Some("project_1".into()),
+            tag_id: Some("tag_1".into()),
+            unsorted: true,
+        };
+        let filter = panops_core::storage::MeetingListFilter::from(params.clone());
+        assert_eq!(filter.space_id.as_deref(), Some("space_1"));
+        assert_eq!(filter.project_id.as_deref(), Some("project_1"));
+        assert_eq!(filter.tag_id.as_deref(), Some("tag_1"));
+        assert!(filter.unsorted);
+        assert_eq!(MeetingListParams::from(filter), params);
     }
 
     // === Recording IPC type tests (slice 11) ===


### PR DESCRIPTION
## Phase B — PR B2: IPC layer

Exposes the B1 storage foundation (#225) over JSON-RPC. **Rust only — no UI.** Stacked conceptually on B1 (already in main); B3 (the sidebar UI) comes next and consumes these methods.

### Methods added (`panops-protocol` wire types + `panops-engine` handlers)
- `ipc.space.create | list | rename | delete`
- `ipc.project.create | list | rename | delete`
- `ipc.tag.create | list | delete | assign | unassign` (assign/unassign = tag/untag a meeting)
- `ipc.meeting.assign { meeting_id, space_id?, project_id? }` (project sets space — logic already in storage)
- `ipc.meeting.list` extended with optional `space_id` / `project_id` / `tag_id` / `unsorted` filters, routed through the existing `MeetingListFilter`. **No-param behavior is unchanged (list all).**

### How
Reuses the existing `spawn_blocking_into_ipc` handler path + `StorageError` mapping; wire types mirror the domain `Space`/`Project`/`Tag` with `From` conversions both ways (round-trip tested). No domain error type derives `Serialize` (project rule). No new Storage methods, no schema change.

### Verification (run locally, full — incl. socket tests)
- `cargo fmt --all --check` ✓ · `cargo build --workspace --locked` ✓ · `cargo clippy --workspace --all-targets --locked -D warnings` ✓ · `cargo test --workspace --locked` ✓ (incl. socket/IPC tests)
- New socket integration test `ipc_organization_meeting_list_filter` (create space + meeting → assign → `meeting.list` with a `space_id` filter returns only that meeting): **1 passed**.

Implemented by codex (workspace-write); the socket gate was run + the commit made from the primary session (codex's sandbox can't bind UDS).