### PR TITLE
Phase B (3/3): organization sidebar UI

### DIFF
--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -965,6 +965,8 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
 
     var body: some View {
         NavigationSplitView {
+            OrgSidebarView(vm: vm)
+        } content: {
             MeetingListView(vm: vm)
         } detail: {
             // Active recording takes over the detail pane with the dedicated
@@ -1022,7 +1024,7 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
                 }
             }
         }
-        .frame(minWidth: 720, minHeight: 480)
+        .frame(minWidth: 900, minHeight: 480)
         .toolbar {
             ToolbarItemGroup {
                 if let llmInfo = vm.llmInfo {
@@ -1064,6 +1066,9 @@ struct ContentView<Controller: RecordingController & ObservableObject>: View {
         }
         .onChange(of: vm.selectedMeetingId) { _, _ in
             Task { await vm.loadSelectedMeeting() }
+        }
+        .onChange(of: vm.sidebarSelection) { _, _ in
+            Task { await vm.applySidebarSelection() }
         }
         .onChange(of: recordingController.isRecording) { _, recording in
             // Keep the invariant "idle ⟹ activeSetup == .default". The sheet

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -30,6 +30,11 @@ final class AppViewModel: ObservableObject {
     /// The displayed meeting list — `allMeetings` narrowed by the current
     /// sidebar selection. The content list renders this.
     @Published var meetings: [MeetingSummary] = []
+    /// Monotonic token, bumped on every sidebar-selection change, used to drop
+    /// out-of-order filtered-fetch results: an in-flight `meeting.list` that
+    /// resolves after a newer selection started must not overwrite `meetings`.
+    /// Main-actor guarded (the view model is `@MainActor`), so not `@Published`.
+    private var loadGeneration: UInt64 = 0
     /// The full unfiltered meeting list (Phase B). Smart Views filter this
     /// client-side; space/project/tag selections refetch via the engine.
     @Published private(set) var allMeetings: [MeetingSummary] = []
@@ -490,22 +495,31 @@ final class AppViewModel: ObservableObject {
     /// Smart Views filter the loaded `allMeetings` client-side; space / project
     /// / tag selections refetch through the engine's `meeting.list` filters.
     func applySidebarSelection() async {
+        // Bump the generation for every selection (incl. the synchronous Smart
+        // View path) so any older in-flight filtered fetch is dropped when it
+        // resolves — prevents a stale fetch clobbering the current list.
+        loadGeneration &+= 1
+        let token = loadGeneration
         switch sidebarSelection {
         case .smart(let view):
             meetings = meetingsForSmartView(view)
         case .space(let id):
-            await loadFilteredMeetings(MeetingListParams(spaceId: id))
+            await loadFilteredMeetings(MeetingListParams(spaceId: id), token: token)
         case .project(let id):
-            await loadFilteredMeetings(MeetingListParams(projectId: id))
+            await loadFilteredMeetings(MeetingListParams(projectId: id), token: token)
         case .tag(let id):
-            await loadFilteredMeetings(MeetingListParams(tagId: id))
+            await loadFilteredMeetings(MeetingListParams(tagId: id), token: token)
         }
     }
 
-    private func loadFilteredMeetings(_ filter: MeetingListParams) async {
+    private func loadFilteredMeetings(_ filter: MeetingListParams, token: UInt64) async {
         do {
-            meetings = try await client.meetingList(filter: filter)
+            let result = try await client.meetingList(filter: filter)
+            // Drop the result if a newer selection superseded us mid-flight.
+            guard token == loadGeneration else { return }
+            meetings = result
         } catch {
+            guard token == loadGeneration else { return }
             Self.logFullError("meeting.list.filter", error)
             meetings = []
         }

--- a/apps/Panops/Sources/Panops/ContentView.swift
+++ b/apps/Panops/Sources/Panops/ContentView.swift
@@ -27,8 +27,20 @@ final class AppViewModel: ObservableObject {
     @Published var state: State = .idle(audio: nil)
     @Published var selectedMeetingId: String?
     @Published var activeRecordingMeetingId: String?
+    /// The displayed meeting list — `allMeetings` narrowed by the current
+    /// sidebar selection. The content list renders this.
     @Published var meetings: [MeetingSummary] = []
+    /// The full unfiltered meeting list (Phase B). Smart Views filter this
+    /// client-side; space/project/tag selections refetch via the engine.
+    @Published private(set) var allMeetings: [MeetingSummary] = []
     @Published var selectedMeeting: Meeting?
+    /// Organization state (Phase B), loaded on connect and after edits.
+    @Published var spaces: [Space] = []
+    @Published var projects: [Project] = []
+    @Published var tags: [Tag] = []
+    /// Current sidebar selection; drives the displayed meeting list. Defaults
+    /// to All (every meeting) so first launch matches the pre-Phase-B view.
+    @Published var sidebarSelection: SidebarSelection = .smart(.all)
     @Published var notesProgress: JobProgressEvent?
     @Published var llmInfo: LlmInfo?
     /// Which meeting the current/last notes generation targets. Lets the meeting
@@ -66,6 +78,7 @@ final class AppViewModel: ObservableObject {
     func connect() async throws {
         try await client.connect()
         await loadServerInfoBestEffort()
+        await refreshOrganization()
         await refreshMeetingsWithStartupRetry()
     }
 
@@ -75,6 +88,7 @@ final class AppViewModel: ObservableObject {
         do {
             try await client.connect()
             await loadServerInfoBestEffort()
+            await refreshOrganization()
             await refreshMeetingsWithStartupRetry()
             state = .idle(audio: nil)
         } catch {
@@ -435,7 +449,8 @@ final class AppViewModel: ObservableObject {
         var delayMs = initialDelayMs
         for attempt in 1...maxAttempts {
             do {
-                meetings = try await client.meetingList()
+                allMeetings = try await client.meetingList()
+                await applySidebarSelection()
                 return
             } catch {
                 Self.logFullError("meeting.list", error)
@@ -445,6 +460,236 @@ final class AppViewModel: ObservableObject {
                     delayMs = min(delayMs * 2, 1_000)
                 }
             }
+        }
+    }
+
+    // MARK: - Organization (Phase B): load + filtering + CRUD + assign
+
+    /// Load spaces / projects / tags. Best-effort like `loadServerInfoBestEffort`:
+    /// an older or unhealthy engine simply leaves the sections empty rather than
+    /// blocking the app.
+    func refreshOrganization() async {
+        do {
+            spaces = Self.sortedSpaces(try await client.spaceList())
+        } catch {
+            Self.logFullError("space.list", error)
+        }
+        do {
+            projects = try await client.projectList()
+        } catch {
+            Self.logFullError("project.list", error)
+        }
+        do {
+            tags = (try await client.tagList()).sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            Self.logFullError("tag.list", error)
+        }
+    }
+
+    /// Recompute the displayed `meetings` for the current sidebar selection.
+    /// Smart Views filter the loaded `allMeetings` client-side; space / project
+    /// / tag selections refetch through the engine's `meeting.list` filters.
+    func applySidebarSelection() async {
+        switch sidebarSelection {
+        case .smart(let view):
+            meetings = meetingsForSmartView(view)
+        case .space(let id):
+            await loadFilteredMeetings(MeetingListParams(spaceId: id))
+        case .project(let id):
+            await loadFilteredMeetings(MeetingListParams(projectId: id))
+        case .tag(let id):
+            await loadFilteredMeetings(MeetingListParams(tagId: id))
+        }
+    }
+
+    private func loadFilteredMeetings(_ filter: MeetingListParams) async {
+        do {
+            meetings = try await client.meetingList(filter: filter)
+        } catch {
+            Self.logFullError("meeting.list.filter", error)
+            meetings = []
+        }
+    }
+
+    private func meetingsForSmartView(_ view: SmartView) -> [MeetingSummary] {
+        switch view {
+        case .all:
+            return allMeetings
+        case .inbox:
+            return allMeetings.filter { $0.spaceId == nil }
+        case .needsNotes:
+            return allMeetings.filter { status(for: $0) == .needsNotes }
+        case .thisWeek:
+            return allMeetings.filter { isInCurrentWeek($0) }
+        }
+    }
+
+    private func isInCurrentWeek(_ summary: MeetingSummary) -> Bool {
+        guard let date = MeetingDate.parse(summary.startedAt) else { return false }
+        let calendar = Calendar.current
+        guard let week = calendar.dateInterval(of: .weekOfYear, for: Date()) else { return false }
+        return week.contains(date)
+    }
+
+    /// Projects within a space, ordered for display.
+    func projects(in spaceId: String) -> [Project] {
+        Self.sortedProjects(projects.filter { $0.spaceId == spaceId })
+    }
+
+    /// Resolve a tag id to its display name (falls back to the id).
+    func tagName(_ id: String) -> String {
+        tags.first { $0.id == id }?.name ?? id
+    }
+
+    private static func sortedSpaces(_ items: [Space]) -> [Space] {
+        items.sorted { ($0.position, $0.name) < ($1.position, $1.name) }
+    }
+
+    private static func sortedProjects(_ items: [Project]) -> [Project] {
+        items.sorted { ($0.position, $0.name) < ($1.position, $1.name) }
+    }
+
+    func createSpace(name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            let space = try await client.spaceCreate(name: trimmed)
+            await refreshOrganization()
+            sidebarSelection = .space(space.id)
+            await applySidebarSelection()
+        } catch {
+            Self.logFullError("space.create", error)
+        }
+    }
+
+    func renameSpace(id: String, name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try await client.spaceRename(id: id, name: trimmed)
+            await refreshOrganization()
+        } catch {
+            Self.logFullError("space.rename", error)
+        }
+    }
+
+    func deleteSpace(id: String) async {
+        do {
+            try await client.spaceDelete(id: id)
+        } catch {
+            Self.logFullError("space.delete", error)
+            return
+        }
+        if isSelectionUnder(spaceId: id) {
+            sidebarSelection = .smart(.all)
+        }
+        await refreshOrganization()
+        await refreshMeetings()
+    }
+
+    func createProject(spaceId: String, name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            let project = try await client.projectCreate(spaceId: spaceId, name: trimmed)
+            await refreshOrganization()
+            sidebarSelection = .project(project.id)
+            await applySidebarSelection()
+        } catch {
+            Self.logFullError("project.create", error)
+        }
+    }
+
+    func renameProject(id: String, name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try await client.projectRename(id: id, name: trimmed)
+            await refreshOrganization()
+        } catch {
+            Self.logFullError("project.rename", error)
+        }
+    }
+
+    func deleteProject(id: String) async {
+        do {
+            try await client.projectDelete(id: id)
+        } catch {
+            Self.logFullError("project.delete", error)
+            return
+        }
+        if case .project(let pid) = sidebarSelection, pid == id {
+            sidebarSelection = .smart(.all)
+        }
+        await refreshOrganization()
+        await refreshMeetings()
+    }
+
+    func createTag(name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            _ = try await client.tagCreate(name: trimmed)
+            await refreshOrganization()
+        } catch {
+            Self.logFullError("tag.create", error)
+        }
+    }
+
+    func deleteTag(id: String) async {
+        do {
+            try await client.tagDelete(id: id)
+        } catch {
+            Self.logFullError("tag.delete", error)
+            return
+        }
+        if case .tag(let tid) = sidebarSelection, tid == id {
+            sidebarSelection = .smart(.all)
+        }
+        await refreshOrganization()
+        await refreshMeetings()
+    }
+
+    /// Assign a meeting to a space/project (both `nil` ⇒ move to Inbox), then
+    /// refresh so the list and tag/space chips reflect the change.
+    func assignMeeting(meetingId: String, spaceId: String?, projectId: String?) async {
+        do {
+            try await client.meetingAssign(meetingId: meetingId, spaceId: spaceId, projectId: projectId)
+        } catch {
+            Self.logFullError("meeting.assign", error)
+            return
+        }
+        await refreshMeetings()
+    }
+
+    func addTag(meetingId: String, tagId: String) async {
+        do {
+            try await client.tagAssign(meetingId: meetingId, tagId: tagId)
+        } catch {
+            Self.logFullError("tag.assign", error)
+            return
+        }
+        await refreshMeetings()
+    }
+
+    func removeTag(meetingId: String, tagId: String) async {
+        do {
+            try await client.tagUnassign(meetingId: meetingId, tagId: tagId)
+        } catch {
+            Self.logFullError("tag.unassign", error)
+            return
+        }
+        await refreshMeetings()
+    }
+
+    private func isSelectionUnder(spaceId: String) -> Bool {
+        switch sidebarSelection {
+        case .space(let id):
+            return id == spaceId
+        case .project(let pid):
+            return projects.first { $0.id == pid }?.spaceId == spaceId
+        case .smart, .tag:
+            return false
         }
     }
 

--- a/apps/Panops/Sources/Panops/IpcClient.swift
+++ b/apps/Panops/Sources/Panops/IpcClient.swift
@@ -626,6 +626,136 @@ actor IpcClient {
         )
     }
 
+    /// `ipc.meeting.list` with organization filters (Phase B). The engine's
+    /// `meeting.list` takes an optional `MeetingListParams`; the no-filter
+    /// `meetingList()` above sends no params (None). This overload sends the
+    /// filter as the single positional param to narrow by space/project/tag.
+    func meetingList(filter: MeetingListParams) async throws -> [MeetingSummary] {
+        return try await sendRequest(
+            method: "ipc.meeting.list",
+            params: filter
+        )
+    }
+
+    // MARK: - Organization (Phase B): spaces / projects / tags / assign
+
+    /// `ipc.meeting.assign` — set a meeting's space/project. A project sets the
+    /// space engine-side; both `nil` moves the meeting back to the Inbox.
+    func meetingAssign(meetingId: String, spaceId: String?, projectId: String?) async throws {
+        try await sendRequestVoid(
+            method: "ipc.meeting.assign",
+            params: MeetingAssignParams(meetingId: meetingId, spaceId: spaceId, projectId: projectId)
+        )
+    }
+
+    /// `ipc.space.create` — create a space, returns the new `Space`.
+    func spaceCreate(name: String) async throws -> Space {
+        return try await sendRequest(
+            method: "ipc.space.create",
+            params: SpaceCreateParams(name: name)
+        )
+    }
+
+    /// `ipc.space.list` — all spaces (engine wraps them in `{"spaces":[...]}`).
+    func spaceList() async throws -> [Space] {
+        let result: SpaceListResult = try await sendRequestNoParams(
+            method: "ipc.space.list"
+        )
+        return result.spaces
+    }
+
+    /// `ipc.space.rename` — rename a space.
+    func spaceRename(id: String, name: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.space.rename",
+            params: SpaceRenameParams(id: id, name: name)
+        )
+    }
+
+    /// `ipc.space.delete` — delete a space. Affected meetings' refs are nulled
+    /// engine-side (meetings are never deleted by org changes).
+    func spaceDelete(id: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.space.delete",
+            params: SpaceDeleteParams(id: id)
+        )
+    }
+
+    /// `ipc.project.create` — create a project inside a space.
+    func projectCreate(spaceId: String, name: String) async throws -> Project {
+        return try await sendRequest(
+            method: "ipc.project.create",
+            params: ProjectCreateParams(spaceId: spaceId, name: name)
+        )
+    }
+
+    /// `ipc.project.list` — projects, optionally scoped to one space.
+    /// `spaceId == nil` returns every project across all spaces.
+    func projectList(spaceId: String? = nil) async throws -> [Project] {
+        let result: ProjectListResult = try await sendRequest(
+            method: "ipc.project.list",
+            params: ProjectListParams(spaceId: spaceId)
+        )
+        return result.projects
+    }
+
+    /// `ipc.project.rename` — rename a project.
+    func projectRename(id: String, name: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.project.rename",
+            params: ProjectRenameParams(id: id, name: name)
+        )
+    }
+
+    /// `ipc.project.delete` — delete a project. Affected meetings' project ref
+    /// is nulled engine-side.
+    func projectDelete(id: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.project.delete",
+            params: ProjectDeleteParams(id: id)
+        )
+    }
+
+    /// `ipc.tag.create` — create (idempotent on name) a tag, returns the `Tag`.
+    func tagCreate(name: String) async throws -> Tag {
+        return try await sendRequest(
+            method: "ipc.tag.create",
+            params: TagCreateParams(name: name)
+        )
+    }
+
+    /// `ipc.tag.list` — all tags (engine wraps them in `{"tags":[...]}`).
+    func tagList() async throws -> [Tag] {
+        let result: TagListResult = try await sendRequestNoParams(
+            method: "ipc.tag.list"
+        )
+        return result.tags
+    }
+
+    /// `ipc.tag.delete` — delete a tag and its meeting associations.
+    func tagDelete(id: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.tag.delete",
+            params: TagDeleteParams(id: id)
+        )
+    }
+
+    /// `ipc.tag.assign` — attach a tag to a meeting.
+    func tagAssign(meetingId: String, tagId: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.tag.assign",
+            params: TagAssignParams(meetingId: meetingId, tagId: tagId)
+        )
+    }
+
+    /// `ipc.tag.unassign` — detach a tag from a meeting.
+    func tagUnassign(meetingId: String, tagId: String) async throws {
+        try await sendRequestVoid(
+            method: "ipc.tag.unassign",
+            params: TagAssignParams(meetingId: meetingId, tagId: tagId)
+        )
+    }
+
     /// `ipc.capture.windows` — fetches available windows for capture.
     /// Sends an empty params object (`{}`, positional like every other method);
     /// the engine replies with a `{"windows":[...]}` wrapper. Sending no params

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -738,25 +738,24 @@ struct MeetingAssignParams: Encodable {
 }
 
 /// Optional filters for `ipc.meeting.list`. Mirrors
-/// `panops-protocol::MeetingListParams`. `nil` filter fields are omitted on
-/// the wire; `unsorted` is always sent (engine default is `false`).
+/// `panops-protocol::MeetingListParams`. Unset filter fields are omitted on
+/// the wire (synthesized `encodeIfPresent`), which the engine treats as "no
+/// filter". Inbox is filtered client-side via `space_id == nil`, so there's no
+/// server-side `unsorted` flag.
 struct MeetingListParams: Encodable {
     let spaceId: String?
     let projectId: String?
     let tagId: String?
-    let unsorted: Bool
 
-    init(spaceId: String? = nil, projectId: String? = nil, tagId: String? = nil, unsorted: Bool = false) {
+    init(spaceId: String? = nil, projectId: String? = nil, tagId: String? = nil) {
         self.spaceId = spaceId
         self.projectId = projectId
         self.tagId = tagId
-        self.unsorted = unsorted
     }
 
     enum CodingKeys: String, CodingKey {
         case spaceId = "space_id"
         case projectId = "project_id"
         case tagId = "tag_id"
-        case unsorted
     }
 }

--- a/apps/Panops/Sources/Panops/Models.swift
+++ b/apps/Panops/Sources/Panops/Models.swift
@@ -540,6 +540,14 @@ struct MeetingSummary: Decodable {
     let language: String
     let endedAt: String?
     let hasNotes: Bool
+    /// Organization space assignment (Phase B). `nil` ⇒ the implicit Inbox
+    /// (unsorted) bucket; no Inbox row exists, it's the null space.
+    let spaceId: String?
+    /// Organization project assignment (Phase B). `nil` when the meeting is
+    /// not in any project.
+    let projectId: String?
+    /// Tag ids assigned to this meeting (Phase B). Names resolve via `tag.list`.
+    let tags: [String]
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -549,6 +557,9 @@ struct MeetingSummary: Decodable {
         case language
         case endedAt = "ended_at"
         case hasNotes = "has_notes"
+        case spaceId = "space_id"
+        case projectId = "project_id"
+        case tags
     }
 
     init(from decoder: Decoder) throws {
@@ -560,6 +571,11 @@ struct MeetingSummary: Decodable {
         language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
         endedAt = try c.decodeIfPresent(String.self, forKey: .endedAt)
         hasNotes = try c.decodeIfPresent(Bool.self, forKey: .hasNotes) ?? false
+        // Phase B fields are decode-if-present: older engine payloads (and
+        // the existing codec tests) omit them, so they default to unsorted.
+        spaceId = try c.decodeIfPresent(String.self, forKey: .spaceId)
+        projectId = try c.decodeIfPresent(String.self, forKey: .projectId)
+        tags = try c.decodeIfPresent([String].self, forKey: .tags) ?? []
     }
 
     // Memberwise init retained for tests/previews constructing summaries directly.
@@ -570,7 +586,10 @@ struct MeetingSummary: Decodable {
         durationMs: UInt64,
         language: String = "",
         endedAt: String? = nil,
-        hasNotes: Bool = false
+        hasNotes: Bool = false,
+        spaceId: String? = nil,
+        projectId: String? = nil,
+        tags: [String] = []
     ) {
         self.id = id
         self.title = title
@@ -579,5 +598,165 @@ struct MeetingSummary: Decodable {
         self.language = language
         self.endedAt = endedAt
         self.hasNotes = hasNotes
+        self.spaceId = spaceId
+        self.projectId = projectId
+        self.tags = tags
+    }
+}
+
+// MARK: - Organization (Phase B): Spaces / Projects / Tags
+
+/// A top-level user-created grouping of meetings. Mirrors
+/// `panops-protocol::Space` (`{id, name, position}`). No hardcoded names —
+/// the implicit Inbox is the null-space bucket, not a `Space` row.
+struct Space: Decodable, Identifiable, Equatable, Hashable {
+    let id: String
+    let name: String
+    let position: Int
+}
+
+/// A collection inside exactly one Space. Mirrors
+/// `panops-protocol::Project` (`{id, space_id, name, position}`).
+struct Project: Decodable, Identifiable, Equatable, Hashable {
+    let id: String
+    let spaceId: String
+    let name: String
+    let position: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case spaceId = "space_id"
+        case name
+        case position
+    }
+}
+
+/// A free label, many-to-many with meetings. Mirrors
+/// `panops-protocol::Tag` (`{id, name}`).
+struct Tag: Decodable, Identifiable, Equatable, Hashable {
+    let id: String
+    let name: String
+}
+
+/// Result wrapper for `ipc.space.list` — the engine returns `{"spaces":[...]}`.
+struct SpaceListResult: Decodable {
+    let spaces: [Space]
+}
+
+/// Result wrapper for `ipc.project.list` — the engine returns `{"projects":[...]}`.
+struct ProjectListResult: Decodable {
+    let projects: [Project]
+}
+
+/// Result wrapper for `ipc.tag.list` — the engine returns `{"tags":[...]}`.
+struct TagListResult: Decodable {
+    let tags: [Tag]
+}
+
+/// Outgoing params for `ipc.space.create`.
+struct SpaceCreateParams: Encodable {
+    let name: String
+}
+
+/// Outgoing params for `ipc.space.rename`.
+struct SpaceRenameParams: Encodable {
+    let id: String
+    let name: String
+}
+
+/// Outgoing params for `ipc.space.delete`.
+struct SpaceDeleteParams: Encodable {
+    let id: String
+}
+
+/// Outgoing params for `ipc.project.create`.
+struct ProjectCreateParams: Encodable {
+    let spaceId: String
+    let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case spaceId = "space_id"
+        case name
+    }
+}
+
+/// Outgoing params for `ipc.project.list`. `spaceId == nil` lists every
+/// project across all spaces (omitted on the wire → engine default).
+struct ProjectListParams: Encodable {
+    let spaceId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case spaceId = "space_id"
+    }
+}
+
+/// Outgoing params for `ipc.project.rename`.
+struct ProjectRenameParams: Encodable {
+    let id: String
+    let name: String
+}
+
+/// Outgoing params for `ipc.project.delete`.
+struct ProjectDeleteParams: Encodable {
+    let id: String
+}
+
+/// Outgoing params for `ipc.tag.create`.
+struct TagCreateParams: Encodable {
+    let name: String
+}
+
+/// Outgoing params for `ipc.tag.delete`.
+struct TagDeleteParams: Encodable {
+    let id: String
+}
+
+/// Outgoing params for `ipc.tag.assign` / `ipc.tag.unassign`.
+struct TagAssignParams: Encodable {
+    let meetingId: String
+    let tagId: String
+
+    enum CodingKeys: String, CodingKey {
+        case meetingId = "meeting_id"
+        case tagId = "tag_id"
+    }
+}
+
+/// Outgoing params for `ipc.meeting.assign`. Assigning a project sets the
+/// meeting's space to that project's space (engine-side). Both `nil` ⇒ move
+/// the meeting back to the Inbox (clears both refs).
+struct MeetingAssignParams: Encodable {
+    let meetingId: String
+    let spaceId: String?
+    let projectId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case meetingId = "meeting_id"
+        case spaceId = "space_id"
+        case projectId = "project_id"
+    }
+}
+
+/// Optional filters for `ipc.meeting.list`. Mirrors
+/// `panops-protocol::MeetingListParams`. `nil` filter fields are omitted on
+/// the wire; `unsorted` is always sent (engine default is `false`).
+struct MeetingListParams: Encodable {
+    let spaceId: String?
+    let projectId: String?
+    let tagId: String?
+    let unsorted: Bool
+
+    init(spaceId: String? = nil, projectId: String? = nil, tagId: String? = nil, unsorted: Bool = false) {
+        self.spaceId = spaceId
+        self.projectId = projectId
+        self.tagId = tagId
+        self.unsorted = unsorted
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case spaceId = "space_id"
+        case projectId = "project_id"
+        case tagId = "tag_id"
+        case unsorted
     }
 }

--- a/apps/Panops/Sources/Panops/OrgModel.swift
+++ b/apps/Panops/Sources/Panops/OrgModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Built-in cross-cutting filters shown in the sidebar's "Smart Views" section.
+/// These filter the loaded meeting list client-side (no dedicated IPC method);
+/// space/project/tag selections refetch through the engine's `meeting.list`
+/// filters instead.
+enum SmartView: String, CaseIterable, Identifiable, Hashable {
+    case inbox
+    case all
+    case needsNotes
+    case thisWeek
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .inbox: return "Inbox"
+        case .all: return "All"
+        case .needsNotes: return "Needs Notes"
+        case .thisWeek: return "This Week"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .inbox: return "tray"
+        case .all: return "rectangle.stack"
+        case .needsNotes: return "doc.badge.ellipsis"
+        case .thisWeek: return "calendar"
+        }
+    }
+}
+
+/// The current sidebar selection that drives which meetings the content list
+/// shows. The default `.smart(.all)` lists every meeting (the pre-Phase-B
+/// behavior).
+enum SidebarSelection: Hashable {
+    case smart(SmartView)
+    case space(String)    // space id
+    case project(String)  // project id
+    case tag(String)      // tag id
+}

--- a/apps/Panops/Sources/Panops/Views/MeetingContextMenu.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingContextMenu.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// The meeting-row context menu (Phase B): assign to a Space/Project, add or
+/// remove Tags, and the existing Delete. Each action calls the matching IPC and
+/// the view model refreshes the list. Kept as its own small view so the menu
+/// tree stays out of `MeetingListView`'s row body.
+struct MeetingContextMenu: View {
+    @ObservedObject var vm: AppViewModel
+    let meeting: MeetingSummary
+    let status: MeetingStatus
+
+    var body: some View {
+        moveToSpaceMenu
+        moveToProjectMenu
+        addTagMenu
+        removeTagMenu
+        Divider()
+        Button(role: .destructive) {
+            Task { await vm.deleteMeeting(id: meeting.id) }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+        // Don't delete a meeting whose capture or notes work is still in flight.
+        .disabled(!status.isDeletable)
+    }
+
+    private var moveToSpaceMenu: some View {
+        Menu("Move to Space") {
+            Button("Inbox") { assign(spaceId: nil, projectId: nil) }
+            if !vm.spaces.isEmpty {
+                Divider()
+                ForEach(vm.spaces) { space in
+                    Button(space.name) { assign(spaceId: space.id, projectId: nil) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var moveToProjectMenu: some View {
+        Menu("Move to Project") {
+            if spacesWithProjects.isEmpty {
+                Text("No projects")
+            } else {
+                ForEach(spacesWithProjects) { space in
+                    Menu(space.name) {
+                        ForEach(vm.projects(in: space.id)) { project in
+                            // Assigning a project sets the space engine-side.
+                            Button(project.name) { assign(spaceId: nil, projectId: project.id) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var addTagMenu: some View {
+        Menu("Add Tag") {
+            if availableTags.isEmpty {
+                Text("No tags")
+            } else {
+                ForEach(availableTags) { tag in
+                    Button(tag.name) {
+                        Task { await vm.addTag(meetingId: meeting.id, tagId: tag.id) }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var removeTagMenu: some View {
+        Menu("Remove Tag") {
+            if assignedTags.isEmpty {
+                Text("No tags")
+            } else {
+                ForEach(assignedTags) { tag in
+                    Button(tag.name) {
+                        Task { await vm.removeTag(meetingId: meeting.id, tagId: tag.id) }
+                    }
+                }
+            }
+        }
+        .disabled(assignedTags.isEmpty)
+    }
+
+    // MARK: - Derived
+
+    private var spacesWithProjects: [Space] {
+        vm.spaces.filter { !vm.projects(in: $0.id).isEmpty }
+    }
+
+    private var assignedTags: [Tag] {
+        let ids = Set(meeting.tags)
+        return vm.tags.filter { ids.contains($0.id) }
+    }
+
+    private var availableTags: [Tag] {
+        let ids = Set(meeting.tags)
+        return vm.tags.filter { !ids.contains($0.id) }
+    }
+
+    private func assign(spaceId: String?, projectId: String?) {
+        Task { await vm.assignMeeting(meetingId: meeting.id, spaceId: spaceId, projectId: projectId) }
+    }
+}

--- a/apps/Panops/Sources/Panops/Views/MeetingListView.swift
+++ b/apps/Panops/Sources/Panops/Views/MeetingListView.swift
@@ -47,18 +47,15 @@ struct MeetingListView: View {
                         Section(section.title) {
                             ForEach(section.meetings, id: \.id) { meeting in
                                 let status = vm.status(for: meeting)
-                                MeetingRow(meeting: meeting, status: status)
-                                    .tag(meeting.id)
-                                    .contextMenu {
-                                        Button(role: .destructive) {
-                                            Task { await vm.deleteMeeting(id: meeting.id) }
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                        // Don't delete a meeting whose capture or
-                                        // notes work is still in flight.
-                                        .disabled(!status.isDeletable)
-                                    }
+                                MeetingRow(
+                                    meeting: meeting,
+                                    status: status,
+                                    tagNames: meeting.tags.map { vm.tagName($0) }
+                                )
+                                .tag(meeting.id)
+                                .contextMenu {
+                                    MeetingContextMenu(vm: vm, meeting: meeting, status: status)
+                                }
                             }
                         }
                     }
@@ -143,10 +140,12 @@ struct MeetingListView: View {
     }
 }
 
-/// A rich sidebar row: title + status pill, then time · duration · language.
+/// A rich sidebar row: title + status pill, then time · duration · language,
+/// then tag chips (Phase B) when the meeting carries any.
 struct MeetingRow: View {
     let meeting: MeetingSummary
     let status: MeetingStatus
+    var tagNames: [String] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -170,8 +169,32 @@ struct MeetingRow: View {
             }
             .font(.caption)
             .foregroundStyle(.secondary)
+            if !tagNames.isEmpty {
+                tagChips
+            }
         }
         .padding(.vertical, 2)
+    }
+
+    private var tagChips: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "tag")
+                .imageScale(.small)
+                .foregroundStyle(.secondary)
+            ForEach(Array(tagNames.prefix(4)), id: \.self) { name in
+                Text(name)
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Color.accentColor.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+            if tagNames.count > 4 {
+                Text("+\(tagNames.count - 4)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     private var metaLine: String {

--- a/apps/Panops/Sources/Panops/Views/OrgSidebarView.swift
+++ b/apps/Panops/Sources/Panops/Views/OrgSidebarView.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+
+/// The organization sidebar (Phase B): three sections — Smart Views, Spaces
+/// (collapsible → Projects), and Tags. Selecting a row drives the meeting
+/// list's filter via `vm.sidebarSelection`. "+" creates; context menus
+/// rename/delete. No drag-and-drop (context-menu only).
+struct OrgSidebarView: View {
+    @ObservedObject var vm: AppViewModel
+    /// Which spaces are expanded to show their projects.
+    @State private var expandedSpaces: Set<String> = []
+    /// The active create/rename prompt, if any (drives the name alert).
+    @State private var prompt: OrgPrompt?
+    @State private var promptText: String = ""
+
+    var body: some View {
+        List(selection: selectionBinding) {
+            smartViewsSection
+            spacesSection
+            tagsSection
+        }
+        .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 340)
+        .alert(prompt?.title ?? "", isPresented: promptPresented) {
+            TextField(prompt?.fieldPrompt ?? "Name", text: $promptText)
+            Button(prompt?.actionLabel ?? "OK") { submitPrompt() }
+            Button("Cancel", role: .cancel) { prompt = nil }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var smartViewsSection: some View {
+        Section("Smart Views") {
+            ForEach(SmartView.allCases) { view in
+                Label(view.title, systemImage: view.systemImage)
+                    .tag(SidebarSelection.smart(view))
+            }
+        }
+    }
+
+    private var spacesSection: some View {
+        Section {
+            ForEach(vm.spaces) { space in
+                spaceRow(space)
+                if expandedSpaces.contains(space.id) {
+                    ForEach(vm.projects(in: space.id)) { project in
+                        projectRow(project)
+                    }
+                }
+            }
+        } header: {
+            sectionHeader("Spaces", add: "New space") { beginPrompt(.newSpace) }
+        }
+    }
+
+    private var tagsSection: some View {
+        Section {
+            ForEach(vm.tags) { tag in
+                tagRow(tag)
+            }
+        } header: {
+            sectionHeader("Tags", add: "New tag") { beginPrompt(.newTag) }
+        }
+    }
+
+    // MARK: - Rows
+
+    private func spaceRow(_ space: Space) -> some View {
+        HStack(spacing: 4) {
+            Button { toggleExpanded(space.id) } label: {
+                Image(systemName: expandedSpaces.contains(space.id) ? "chevron.down" : "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12)
+            }
+            .buttonStyle(.plain)
+            Label(space.name, systemImage: "folder")
+            Spacer(minLength: 4)
+            Button { beginPrompt(.newProject(spaceId: space.id)) } label: {
+                Image(systemName: "plus").imageScale(.small)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("New project in \(space.name)")
+        }
+        .tag(SidebarSelection.space(space.id))
+        .contextMenu { spaceContextMenu(space) }
+    }
+
+    private func projectRow(_ project: Project) -> some View {
+        Label(project.name, systemImage: "list.bullet")
+            .padding(.leading, 16)
+            .tag(SidebarSelection.project(project.id))
+            .contextMenu { projectContextMenu(project) }
+    }
+
+    private func tagRow(_ tag: Tag) -> some View {
+        Label(tag.name, systemImage: "tag")
+            .tag(SidebarSelection.tag(tag.id))
+            .contextMenu {
+                Button(role: .destructive) {
+                    Task { await vm.deleteTag(id: tag.id) }
+                } label: {
+                    Label("Delete Tag", systemImage: "trash")
+                }
+            }
+    }
+
+    private func sectionHeader(_ title: String, add help: String, action: @escaping () -> Void) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Button(action: action) {
+                Image(systemName: "plus").imageScale(.small)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help(help)
+        }
+    }
+
+    // MARK: - Context menus
+
+    @ViewBuilder
+    private func spaceContextMenu(_ space: Space) -> some View {
+        Button { beginPrompt(.newProject(spaceId: space.id)) } label: {
+            Label("New Project", systemImage: "plus")
+        }
+        Button { beginPrompt(.renameSpace(id: space.id, current: space.name)) } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+        Button(role: .destructive) {
+            Task { await vm.deleteSpace(id: space.id) }
+        } label: {
+            Label("Delete Space", systemImage: "trash")
+        }
+    }
+
+    @ViewBuilder
+    private func projectContextMenu(_ project: Project) -> some View {
+        Button { beginPrompt(.renameProject(id: project.id, current: project.name)) } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+        Button(role: .destructive) {
+            Task { await vm.deleteProject(id: project.id) }
+        } label: {
+            Label("Delete Project", systemImage: "trash")
+        }
+    }
+
+    // MARK: - Selection binding
+
+    /// `List(selection:)` wants an optional; map it onto the view model's
+    /// non-optional `sidebarSelection`, ignoring deselection (nil) so a filter
+    /// is always active.
+    private var selectionBinding: Binding<SidebarSelection?> {
+        Binding(
+            get: { vm.sidebarSelection },
+            set: { newValue in
+                if let newValue { vm.sidebarSelection = newValue }
+            }
+        )
+    }
+
+    // MARK: - Expansion + prompts
+
+    private func toggleExpanded(_ spaceId: String) {
+        if expandedSpaces.contains(spaceId) {
+            expandedSpaces.remove(spaceId)
+        } else {
+            expandedSpaces.insert(spaceId)
+        }
+    }
+
+    private var promptPresented: Binding<Bool> {
+        Binding(
+            get: { prompt != nil },
+            set: { if !$0 { prompt = nil } }
+        )
+    }
+
+    private func beginPrompt(_ p: OrgPrompt) {
+        switch p {
+        case .renameSpace(_, let current), .renameProject(_, let current):
+            promptText = current
+        case .newSpace, .newProject, .newTag:
+            promptText = ""
+        }
+        prompt = p
+    }
+
+    private func submitPrompt() {
+        guard let prompt else { return }
+        let text = promptText
+        Task {
+            switch prompt {
+            case .newSpace:
+                await vm.createSpace(name: text)
+            case .newProject(let spaceId):
+                await vm.createProject(spaceId: spaceId, name: text)
+            case .renameSpace(let id, _):
+                await vm.renameSpace(id: id, name: text)
+            case .renameProject(let id, _):
+                await vm.renameProject(id: id, name: text)
+            case .newTag:
+                await vm.createTag(name: text)
+            }
+        }
+        self.prompt = nil
+    }
+}
+
+/// A pending create/rename action that the name alert collects text for.
+enum OrgPrompt: Identifiable {
+    case newSpace
+    case newProject(spaceId: String)
+    case renameSpace(id: String, current: String)
+    case renameProject(id: String, current: String)
+    case newTag
+
+    var id: String {
+        switch self {
+        case .newSpace: return "newSpace"
+        case .newProject(let spaceId): return "newProject-\(spaceId)"
+        case .renameSpace(let id, _): return "renameSpace-\(id)"
+        case .renameProject(let id, _): return "renameProject-\(id)"
+        case .newTag: return "newTag"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .newSpace: return "New Space"
+        case .newProject: return "New Project"
+        case .renameSpace: return "Rename Space"
+        case .renameProject: return "Rename Project"
+        case .newTag: return "New Tag"
+        }
+    }
+
+    var actionLabel: String {
+        switch self {
+        case .newSpace, .newProject, .newTag: return "Create"
+        case .renameSpace, .renameProject: return "Rename"
+        }
+    }
+
+    var fieldPrompt: String {
+        switch self {
+        case .newTag: return "Tag name"
+        default: return "Name"
+        }
+    }
+}

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -431,4 +431,153 @@ struct IpcClientCodecTests {
         #expect(json.contains("\"kind\":\"window\""))
         #expect(json.contains("\"window_id\":456"))
     }
+
+    // MARK: - Organization (Phase B) decode
+
+    @Test("Space decodes from engine response")
+    func space_decodes() throws {
+        let json = #"{ "id": "space_1", "name": "Work", "position": 0 }"#
+        let space = try decoder.decode(Space.self, from: json.data(using: .utf8)!)
+        #expect(space == Space(id: "space_1", name: "Work", position: 0))
+    }
+
+    @Test("Project decodes with space_id")
+    func project_decodes() throws {
+        let json = #"{ "id": "p1", "space_id": "s1", "name": "Launch", "position": 2 }"#
+        let project = try decoder.decode(Project.self, from: json.data(using: .utf8)!)
+        #expect(project == Project(id: "p1", spaceId: "s1", name: "Launch", position: 2))
+    }
+
+    @Test("Tag decodes")
+    func tag_decodes() throws {
+        // Qualify `Panops.Tag` — swift-testing exports its own `Tag` type.
+        let json = #"{ "id": "t1", "name": "urgent" }"#
+        let tag = try decoder.decode(Panops.Tag.self, from: json.data(using: .utf8)!)
+        #expect(tag == Panops.Tag(id: "t1", name: "urgent"))
+    }
+
+    @Test("SpaceListResult decodes the {spaces:[...]} wrapper")
+    func spaceListResult_decodes() throws {
+        let json = #"""
+        { "spaces": [
+            { "id": "s1", "name": "Work", "position": 0 },
+            { "id": "s2", "name": "Personal", "position": 1 }
+        ] }
+        """#
+        let result = try decoder.decode(SpaceListResult.self, from: json.data(using: .utf8)!)
+        #expect(result.spaces.count == 2)
+        #expect(result.spaces[0] == Space(id: "s1", name: "Work", position: 0))
+        #expect(result.spaces[1].name == "Personal")
+    }
+
+    @Test("ProjectListResult decodes the {projects:[...]} wrapper")
+    func projectListResult_decodes() throws {
+        let json = #"{ "projects": [ { "id": "p1", "space_id": "s1", "name": "Launch", "position": 0 } ] }"#
+        let result = try decoder.decode(ProjectListResult.self, from: json.data(using: .utf8)!)
+        #expect(result.projects == [Project(id: "p1", spaceId: "s1", name: "Launch", position: 0)])
+    }
+
+    @Test("TagListResult decodes the {tags:[...]} wrapper")
+    func tagListResult_decodes() throws {
+        let json = #"{ "tags": [ { "id": "t1", "name": "urgent" }, { "id": "t2", "name": "bug" } ] }"#
+        let result = try decoder.decode(TagListResult.self, from: json.data(using: .utf8)!)
+        #expect(result.tags.count == 2)
+        #expect(result.tags.map(\.name) == ["urgent", "bug"])
+    }
+
+    @Test("MeetingSummary decodes the Phase B org fields")
+    func meetingSummary_decodesOrgFields() throws {
+        let json = #"""
+        {
+          "id": "m1",
+          "title": "Sync",
+          "started_at": "2026-06-05T10:00:00Z",
+          "duration_ms": 60000,
+          "space_id": "s1",
+          "project_id": "p1",
+          "tags": ["t1", "t2"]
+        }
+        """#
+        let summary = try decoder.decode(MeetingSummary.self, from: json.data(using: .utf8)!)
+        #expect(summary.spaceId == "s1")
+        #expect(summary.projectId == "p1")
+        #expect(summary.tags == ["t1", "t2"])
+    }
+
+    @Test("MeetingSummary defaults org fields when omitted (Inbox)")
+    func meetingSummary_defaultsOrgFields() throws {
+        let json = #"""
+        { "id": "m1", "title": "Sync", "started_at": "2026-06-05T10:00:00Z", "duration_ms": 60000 }
+        """#
+        let summary = try decoder.decode(MeetingSummary.self, from: json.data(using: .utf8)!)
+        #expect(summary.spaceId == nil)
+        #expect(summary.projectId == nil)
+        #expect(summary.tags.isEmpty)
+    }
+
+    // MARK: - Organization (Phase B) encode
+
+    @Test("MeetingListParams encodes only the set filter plus unsorted")
+    func meetingListParams_encodesFilter() throws {
+        let data = try encoder.encode(MeetingListParams(spaceId: "s1"))
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"space_id\":\"s1\""), "space_id missing: \(json)")
+        #expect(json.contains("\"unsorted\":false"), "unsorted missing: \(json)")
+        // Unset optional filters must be omitted, not sent as null.
+        #expect(!json.contains("project_id"), "project_id should be omitted: \(json)")
+        #expect(!json.contains("tag_id"), "tag_id should be omitted: \(json)")
+    }
+
+    @Test("filtered meeting.list request encodes params as positional array")
+    func meetingListFilteredRequest_encodes() throws {
+        let req = JsonRpcRequest(
+            id: 1,
+            method: "ipc.meeting.list",
+            param: MeetingListParams(tagId: "t1")
+        )
+        let data = try encoder.encode(req)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"method\":\"ipc.meeting.list\""), "method missing: \(json)")
+        #expect(json.contains("\"params\":[{"), "expected positional-array params: \(json)")
+        #expect(json.contains("\"tag_id\":\"t1\""), "tag_id missing: \(json)")
+    }
+
+    @Test("MeetingAssignParams omits nil refs; move-to-inbox sends only meeting_id")
+    func meetingAssignParams_encodes() throws {
+        let toSpace = try encoder.encode(MeetingAssignParams(meetingId: "m1", spaceId: "s1", projectId: nil))
+        let toSpaceJson = String(data: toSpace, encoding: .utf8)!
+        #expect(toSpaceJson.contains("\"meeting_id\":\"m1\""))
+        #expect(toSpaceJson.contains("\"space_id\":\"s1\""))
+        #expect(!toSpaceJson.contains("project_id"), "nil project_id should be omitted: \(toSpaceJson)")
+
+        let toInbox = try encoder.encode(MeetingAssignParams(meetingId: "m1", spaceId: nil, projectId: nil))
+        let toInboxJson = String(data: toInbox, encoding: .utf8)!
+        #expect(toInboxJson.contains("\"meeting_id\":\"m1\""))
+        #expect(!toInboxJson.contains("space_id"), "nil space_id should be omitted: \(toInboxJson)")
+        #expect(!toInboxJson.contains("project_id"), "nil project_id should be omitted: \(toInboxJson)")
+    }
+
+    @Test("TagAssignParams encodes meeting_id and tag_id")
+    func tagAssignParams_encodes() throws {
+        let data = try encoder.encode(TagAssignParams(meetingId: "m1", tagId: "t1"))
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"meeting_id\":\"m1\""))
+        #expect(json.contains("\"tag_id\":\"t1\""))
+    }
+
+    @Test("ProjectCreateParams encodes space_id")
+    func projectCreateParams_encodes() throws {
+        let data = try encoder.encode(ProjectCreateParams(spaceId: "s1", name: "Launch"))
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"space_id\":\"s1\""))
+        #expect(json.contains("\"name\":\"Launch\""))
+    }
+
+    @Test("ProjectListParams omits space_id when listing all projects")
+    func projectListParams_encodesAll() throws {
+        let all = String(data: try encoder.encode(ProjectListParams(spaceId: nil)), encoding: .utf8)!
+        #expect(all == "{}", "all-projects list should encode to {}: \(all)")
+        let scoped = String(data: try encoder.encode(ProjectListParams(spaceId: "s1")), encoding: .utf8)!
+        #expect(scoped.contains("\"space_id\":\"s1\""))
+    }
 }

--- a/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
+++ b/apps/Panops/Tests/PanopsTests/IpcClientCodecTests.swift
@@ -517,12 +517,11 @@ struct IpcClientCodecTests {
 
     // MARK: - Organization (Phase B) encode
 
-    @Test("MeetingListParams encodes only the set filter plus unsorted")
+    @Test("MeetingListParams encodes only the set filter, omitting unset ones")
     func meetingListParams_encodesFilter() throws {
         let data = try encoder.encode(MeetingListParams(spaceId: "s1"))
         let json = String(data: data, encoding: .utf8)!
         #expect(json.contains("\"space_id\":\"s1\""), "space_id missing: \(json)")
-        #expect(json.contains("\"unsorted\":false"), "unsorted missing: \(json)")
         // Unset optional filters must be omitted, not sent as null.
         #expect(!json.contains("project_id"), "project_id should be omitted: \(json)")
         #expect(!json.contains("tag_id"), "tag_id should be omitted: \(json)")


### PR DESCRIPTION
## Phase B — PR B3: organization sidebar UI (SwiftUI)

Completes Phase B (B1 storage #225, B2 IPC #231): organization is now **visible + usable** in the app.

### What's new (`apps/Panops`)
- **Three-column layout**: org sidebar | filtered meeting list | detail.
- **Smart Views**: Inbox (unsorted), All, Needs Notes, This Week — client-side filters over the loaded list.
- **Spaces**: collapsible space rows → projects; section "+" creates a space, per-space "+" creates a project; context-menu rename/delete. Selecting refetches via the `meeting.list` space/project filter.
- **Tags**: tag rows; "+" creates, context-menu deletes; selecting filters via IPC. Tag chips render on each meeting row.
- **Assign** (meeting-row context menu): Move to Space ▸ (incl. Inbox), Move to Project ▸ (nested by space), Add/Remove Tag ▸ → then refresh. Context-menu only (no drag-and-drop — deferred).

### Wiring
New Codable `Space`/`Project`/`Tag` wire models + `space.*`/`project.*`/`tag.*`/`meeting.assign` client methods in `IpcClient`, matching the B2 engine methods; org state + selection-driven filtering in the view model.

### Verification (run locally)
- `cd apps/Panops && swift build` → Build complete.
- `swift test` → **115 tests in 20 suites passed** (was 101; +14 new model/codec tests).

Built on `claude` CLI; verified + pushed from the primary session.