### PR TITLE
Screenshots-from-video (foundation): ChangeDetector + --extract-screenshots

### DIFF
--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/ChangeDetector.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/ChangeDetector.swift
@@ -1,0 +1,108 @@
+import CoreGraphics
+import CoreImage
+import CoreVideo
+import Foundation
+@preconcurrency import Vision
+
+// The screenshot change-detection unit, shared by the live `Screenshotter`
+// (samples SCStream frames) and the `--extract-screenshots` path (decodes
+// `.mov` frames). Both feed frames through the SAME interval + cosine-distance
+// gate so video-derived screenshots match what the live recorder would keep.
+
+/// Cosine *distance* (1 − cosine similarity) between two feature vectors.
+/// Range [0, 2]; 0 = identical direction. Pure, so dedup math is testable
+/// without Vision. Mismatched lengths or a zero vector → maximal distance (1)
+/// so the frame is conservatively kept.
+func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
+    guard a.count == b.count, !a.isEmpty else { return 1 }
+    let dot = zip(a, b).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+    let na = sqrt(a.reduce(Float(0)) { $0 + $1 * $1 })
+    let nb = sqrt(b.reduce(Float(0)) { $0 + $1 * $1 })
+    guard na > 0, nb > 0 else { return 1 }
+    return 1 - dot / (na * nb)
+}
+
+/// Extract the Float32 vector backing a Vision feature print.
+func featurePrintVector(_ observation: VNFeaturePrintObservation) -> [Float] {
+    let count = observation.elementCount
+    guard count > 0 else { return [] }
+    var out = [Float](repeating: 0, count: count)
+    out.withUnsafeMutableBytes { dst in
+        _ = observation.data.copyBytes(to: dst, count: count * MemoryLayout<Float>.stride)
+    }
+    return out
+}
+
+/// Vision feature print of a live `.screen` pixel buffer (the live path's
+/// frame source). nil on failure (logged to stderr) ⇒ the frame is skipped.
+func featurePrint(cvPixelBuffer pixelBuffer: CVPixelBuffer) -> [Float]? {
+    featurePrint(handler: VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:]))
+}
+
+/// Vision feature print of a decoded video frame (the extract path's frame
+/// source). nil on failure (logged to stderr) ⇒ the frame is skipped.
+func featurePrint(cgImage: CGImage) -> [Float]? {
+    featurePrint(handler: VNImageRequestHandler(cgImage: cgImage, options: [:]))
+}
+
+private func featurePrint(handler: VNImageRequestHandler) -> [Float]? {
+    let request = VNGenerateImageFeaturePrintRequest()
+    do {
+        try handler.perform([request])
+    } catch {
+        FileHandle.standardError.write(Data("feature print failed: \(error)\n".utf8))
+        return nil
+    }
+    guard let observation = request.results?.first else { return nil }
+    return featurePrintVector(observation)
+}
+
+/// Encode a screenshot frame as JPEG, identical to the live `Screenshotter`'s
+/// output (device-RGB, default quality), so video-extracted screenshots share
+/// the live ones' format. Both paths route their frame through here.
+func encodeScreenshotJPEG(_ image: CIImage, using ciContext: CIContext) -> Data? {
+    ciContext.jpegRepresentation(of: image, colorSpace: CGColorSpaceCreateDeviceRGB(), options: [:])
+}
+
+/// Stateful keep/drop gate shared by the live `Screenshotter` and the
+/// `--extract-screenshots` path. A frame is kept when it arrives at least
+/// `intervalMs` after the last sampled frame AND its feature print differs from
+/// the last *kept* frame by at least `threshold` cosine distance. The first
+/// frame is always kept (no prior reference).
+///
+/// Not internally synchronized: the live `Screenshotter` calls it under its own
+/// `lock`; the extract path calls it serially on one task. One instance per
+/// capture/extract session.
+final class ChangeDetector {
+    let intervalMs: UInt64
+    let threshold: Float
+
+    private var lastSampleMs: UInt64?
+    private var lastKeptVector: [Float]?
+
+    init(intervalMs: UInt64, threshold: Float) {
+        self.intervalMs = max(intervalMs, 1)
+        self.threshold = threshold
+    }
+
+    /// Decide whether to keep the frame sampled at `atSampleMs`. `featurePrint`
+    /// is evaluated lazily — only after the interval gate passes — so the
+    /// costly Vision call is skipped for interval-dropped frames, exactly as the
+    /// live path did inline. Returns true ⇒ keep the frame and adopt it as the
+    /// new reference for subsequent change comparisons.
+    func shouldKeep(atSampleMs nowMs: UInt64, featurePrint: () -> [Float]?) -> Bool {
+        // Interval gate: drop frames arriving within `intervalMs` of the last
+        // sampled one. The `nowMs >= last` guard keeps the subtraction
+        // underflow-safe for any non-monotonic sample times; live wall-clock is
+        // monotonic, so the guard never fires there and behavior is identical.
+        if let last = lastSampleMs, nowMs >= last, nowMs - last < intervalMs { return false }
+        lastSampleMs = nowMs
+
+        guard let vector = featurePrint() else { return false }
+        if let prev = lastKeptVector, cosineDistance(vector, prev) < threshold {
+            return false   // near-duplicate of the last kept frame
+        }
+        lastKeptVector = vector
+        return true
+    }
+}

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/ChangeDetector.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/ChangeDetector.swift
@@ -96,9 +96,12 @@ final class ChangeDetector {
         // underflow-safe for any non-monotonic sample times; live wall-clock is
         // monotonic, so the guard never fires there and behavior is identical.
         if let last = lastSampleMs, nowMs >= last, nowMs - last < intervalMs { return false }
-        lastSampleMs = nowMs
 
+        // Only advance the interval clock after a SUCCESSFUL feature print: a
+        // Vision failure must not gate out the next good frame (a streak of
+        // failures would otherwise permanently suppress capture).
         guard let vector = featurePrint() else { return false }
+        lastSampleMs = nowMs
         if let prev = lastKeptVector, cosineDistance(vector, prev) < threshold {
             return false   // near-duplicate of the last kept frame
         }

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/ScreenshotExtractor.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/ScreenshotExtractor.swift
@@ -62,7 +62,12 @@ enum ScreenshotExtractor {
         generator.requestedTimeToleranceBefore = .zero
         generator.requestedTimeToleranceAfter = .zero
 
-        let detector = ChangeDetector(intervalMs: intervalMs, threshold: threshold)
+        // Cadence is already enforced by `times` (sampleTimes step by intervalMs),
+        // and zero-tolerance decoding returns frames at-or-before each mark, so
+        // re-applying the interval gate on the quantized actualMs would drop
+        // on-cadence frames. Neutralize it (intervalMs: 1 still dedups
+        // identical-timestamp frames); change-detection is the only real filter here.
+        let detector = ChangeDetector(intervalMs: 1, threshold: threshold)
         let ciContext = CIContext()
         var kept: [ExtractedScreenshot] = []
 

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/ScreenshotExtractor.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/ScreenshotExtractor.swift
@@ -1,0 +1,114 @@
+import CoreImage
+import CoreMedia
+import Foundation
+@preconcurrency import AVFoundation
+
+/// One extracted screenshot's metadata, emitted as JSON by
+/// `--extract-screenshots`. `timestamp_ms` is the frame's position in the
+/// recording (0 = start) — the same anchor the live `Screenshotter` uses for
+/// its filenames.
+struct ExtractedScreenshot: Encodable {
+    let timestampMs: UInt64
+    let path: String
+
+    enum CodingKeys: String, CodingKey {
+        case timestampMs = "timestamp_ms"
+        case path
+    }
+}
+
+enum ScreenshotExtractionError: Error, CustomStringConvertible {
+    case noVideoTrack(String)
+
+    var description: String {
+        switch self {
+        case .noVideoTrack(let path): return "no video track in \(path)"
+        }
+    }
+}
+
+/// Decodes frames from a recorded `.mov`/`.mp4` at `intervalMs` cadence, runs
+/// the shared `ChangeDetector`, and writes the kept frames as time-anchored
+/// JPEGs into `outDir` — the SAME naming + JPEG format the live `Screenshotter`
+/// produces. The one-shot counterpart to live screenshotting: identical
+/// detector + encoding, a decoded-video frame source instead of live SCStream
+/// frames. Stage A is purely additive — nothing calls this from the pipeline
+/// yet (that is Stage B's engine rewire).
+enum ScreenshotExtractor {
+    static func extract(
+        movPath: String,
+        outDir: String,
+        intervalMs: UInt64,
+        threshold: Float
+    ) async throws -> [ExtractedScreenshot] {
+        let movURL = URL(fileURLWithPath: movPath)
+        let asset = AVURLAsset(url: movURL)
+
+        // A video track must exist; otherwise there is nothing to extract.
+        guard try await !asset.loadTracks(withMediaType: .video).isEmpty else {
+            throw ScreenshotExtractionError.noVideoTrack(movPath)
+        }
+
+        let outDirURL = URL(fileURLWithPath: outDir)
+        try FileManager.default.createDirectory(at: outDirURL, withIntermediateDirectories: true)
+
+        let times = sampleTimes(durationMs: await durationMs(of: asset), intervalMs: intervalMs)
+
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        // Zero tolerance ⇒ the exact frame on screen at each requested instant,
+        // so the JPEG filename's timestamp matches the recording. In-range marks
+        // always resolve to a frame; only marks past the end fail (skipped).
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        let detector = ChangeDetector(intervalMs: intervalMs, threshold: threshold)
+        let ciContext = CIContext()
+        var kept: [ExtractedScreenshot] = []
+
+        for await result in generator.images(for: times) {
+            let cg: CGImage
+            let actualMs: UInt64
+            do {
+                cg = try result.image
+                actualMs = UInt64(max(0, try result.actualTime.seconds * 1000))
+            } catch {
+                continue   // no decodable frame at this mark (e.g. past the end)
+            }
+            let keep = detector.shouldKeep(atSampleMs: actualMs) {
+                featurePrint(cgImage: cg)
+            }
+            guard keep else { continue }
+
+            let url = outDirURL.appendingPathComponent(String(format: "%09d.jpg", actualMs))
+            guard let data = encodeScreenshotJPEG(CIImage(cgImage: cg), using: ciContext) else { continue }
+            do {
+                try data.write(to: url)
+                kept.append(ExtractedScreenshot(timestampMs: actualMs, path: url.path))
+            } catch {
+                FileHandle.standardError.write(Data("extract jpeg write failed: \(error)\n".utf8))
+            }
+        }
+        return kept
+    }
+
+    /// Asset duration in ms, or 0 when indefinite/unavailable.
+    private static func durationMs(of asset: AVURLAsset) async -> Int64 {
+        guard let duration = try? await asset.load(.duration), duration.isNumeric else { return 0 }
+        return Int64(max(0, duration.seconds * 1000))
+    }
+
+    /// Sample marks at 0, interval, 2·interval, … up to (and including) the
+    /// asset duration. Always includes t=0, so even a zero/unknown-duration
+    /// asset yields at least the first frame.
+    private static func sampleTimes(durationMs: Int64, intervalMs: UInt64) -> [CMTime] {
+        let step = Int64(max(intervalMs, 1))
+        var times: [CMTime] = []
+        var t: Int64 = 0
+        repeat {
+            times.append(CMTime(value: t, timescale: 1000))
+            t += step
+        } while t <= durationMs
+        return times
+    }
+}

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/Screenshotter.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/Screenshotter.swift
@@ -2,38 +2,15 @@ import CoreImage
 import CoreMedia
 import Foundation
 import ScreenCaptureKit
-import Vision
 
-/// Cosine *distance* (1 − cosine similarity) between two feature vectors.
-/// Range [0, 2]; 0 = identical direction. Pure, so dedup math is testable
-/// without Vision. Mismatched lengths or a zero vector → maximal distance (1)
-/// so the frame is conservatively kept.
-func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
-    guard a.count == b.count, !a.isEmpty else { return 1 }
-    let dot = zip(a, b).reduce(Float(0)) { $0 + $1.0 * $1.1 }
-    let na = sqrt(a.reduce(Float(0)) { $0 + $1 * $1 })
-    let nb = sqrt(b.reduce(Float(0)) { $0 + $1 * $1 })
-    guard na > 0, nb > 0 else { return 1 }
-    return 1 - dot / (na * nb)
-}
-
-/// Extract the Float32 vector backing a Vision feature print.
-func featurePrintVector(_ observation: VNFeaturePrintObservation) -> [Float] {
-    let count = observation.elementCount
-    guard count > 0 else { return [] }
-    var out = [Float](repeating: 0, count: count)
-    out.withUnsafeMutableBytes { dst in
-        _ = observation.data.copyBytes(to: dst, count: count * MemoryLayout<Float>.stride)
-    }
-    return out
-}
-
-/// Samples `SCStream` `.screen` frames, dedups near-duplicates via a Vision
-/// feature print (cosine distance vs the last *kept* frame, below
-/// `threshold` ⇒ drop), and writes the kept ones as time-anchored JPEGs.
+/// Samples `SCStream` `.screen` frames, dedups near-duplicates via the shared
+/// `ChangeDetector` (Vision feature print + cosine distance vs the last *kept*
+/// frame, below `threshold` ⇒ drop), and writes the kept ones as time-anchored
+/// JPEGs. The `--extract-screenshots` path uses the same `ChangeDetector` and
+/// JPEG encoding against decoded `.mov` frames.
 ///
 /// `@unchecked Sendable`: the callback fires on a background queue; all mutable
-/// state is guarded by `lock`.
+/// state (including the `ChangeDetector`) is guarded by `lock`.
 final class Screenshotter: NSObject, SCStreamOutput, @unchecked Sendable {
     let intervalMs: UInt64
     let threshold: Float
@@ -48,15 +25,15 @@ final class Screenshotter: NSObject, SCStreamOutput, @unchecked Sendable {
     private let dir: URL
     private let lock = NSLock()
     private let ciContext = CIContext()
+    private let detector: ChangeDetector
     private var startedAtMs: UInt64 = 0
-    private var lastSampleMs: UInt64?
-    private var lastKeptVector: [Float]?
     private var kept: [String] = []
 
     init(dir: String, intervalMs: UInt64, threshold: Float) throws {
         self.dir = URL(fileURLWithPath: dir)
         self.intervalMs = max(intervalMs, 1)
         self.threshold = threshold
+        self.detector = ChangeDetector(intervalMs: intervalMs, threshold: threshold)
         super.init()
         do {
             try FileManager.default.createDirectory(at: self.dir, withIntermediateDirectories: true)
@@ -94,14 +71,9 @@ final class Screenshotter: NSObject, SCStreamOutput, @unchecked Sendable {
         defer { lock.unlock() }
 
         let nowMs = UInt64(Date().timeIntervalSince1970 * 1000)
-        if let last = lastSampleMs, nowMs - last < intervalMs { return }
-        lastSampleMs = nowMs
-
-        guard let vector = featurePrint(of: pixelBuffer) else { return }
-        if let prev = lastKeptVector, cosineDistance(vector, prev) < threshold {
-            return   // near-duplicate of the last kept frame
-        }
-        lastKeptVector = vector
+        guard detector.shouldKeep(atSampleMs: nowMs, featurePrint: {
+            featurePrint(cvPixelBuffer: pixelBuffer)
+        }) else { return }
 
         let tsMs = startedAtMs == 0 ? 0 : nowMs - startedAtMs
         let url = dir.appendingPathComponent(String(format: "%09d.jpg", tsMs))
@@ -110,26 +82,11 @@ final class Screenshotter: NSObject, SCStreamOutput, @unchecked Sendable {
         }
     }
 
-    // MARK: - Vision + JPEG
-
-    private func featurePrint(of pixelBuffer: CVPixelBuffer) -> [Float]? {
-        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
-        let request = VNGenerateImageFeaturePrintRequest()
-        do {
-            try handler.perform([request])
-        } catch {
-            FileHandle.standardError.write(Data("feature print failed: \(error)\n".utf8))
-            return nil
-        }
-        guard let observation = request.results?.first else { return nil }
-        return featurePrintVector(observation)
-    }
+    // MARK: - JPEG
 
     private func writeJPEG(_ pixelBuffer: CVPixelBuffer, to url: URL) -> Bool {
         let image = CIImage(cvImageBuffer: pixelBuffer)
-        guard let jpeg = ciContext.jpegRepresentation(
-            of: image, colorSpace: CGColorSpaceCreateDeviceRGB(), options: [:]
-        ) else { return false }
+        guard let jpeg = encodeScreenshotJPEG(image, using: ciContext) else { return false }
         do {
             try jpeg.write(to: url)
             return true

--- a/apps/panops-capture-mac/Sources/PanopsCaptureMac/main.swift
+++ b/apps/panops-capture-mac/Sources/PanopsCaptureMac/main.swift
@@ -36,6 +36,54 @@ if CommandLine.arguments.contains("--list-windows") {
     exit(0)
 }
 
+/// Value of a `--flag <value>` option, or nil if absent / missing its value.
+func optionValue(_ args: [String], _ name: String) -> String? {
+    guard let i = args.firstIndex(of: name), i + 1 < args.count else { return nil }
+    return args[i + 1]
+}
+
+/// One-shot screenshot extraction: decode `<mov>` at `--interval-ms` cadence,
+/// run the shared `ChangeDetector`, write kept frames as JPEGs into `<out_dir>`
+/// (same naming + format as live screenshots), and print
+/// `[{timestamp_ms, path}, …]` JSON to stdout. Mirrors `--list-windows`: a
+/// stateless subcommand that runs and exits before any capture session. On any
+/// failure it emits `[]` so the engine always parses valid JSON.
+func runExtractScreenshots(_ args: [String]) async -> Int32 {
+    guard let flagIdx = args.firstIndex(of: "--extract-screenshots"), flagIdx + 2 < args.count else {
+        FileHandle.standardError.write(Data(
+            "usage: --extract-screenshots <mov> <out_dir> [--interval-ms N] [--threshold T]\n".utf8))
+        print("[]"); fflush(stdout)
+        return 2
+    }
+    let movPath = args[flagIdx + 1]
+    let outDir = args[flagIdx + 2]
+    let intervalMs = optionValue(args, "--interval-ms").flatMap(UInt64.init) ?? 500
+    let threshold = optionValue(args, "--threshold").flatMap(Float.init) ?? 0.15
+
+    do {
+        let shots = try await ScreenshotExtractor.extract(
+            movPath: movPath, outDir: outDir, intervalMs: intervalMs, threshold: threshold)
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.withoutEscapingSlashes]
+        if let data = try? enc.encode(shots), let line = String(data: data, encoding: .utf8) {
+            print(line)
+        } else {
+            print("[]")
+        }
+        fflush(stdout)
+        return 0
+    } catch {
+        FileHandle.standardError.write(Data("--extract-screenshots failed: \(error)\n".utf8))
+        print("[]"); fflush(stdout)
+        return 1
+    }
+}
+
+if CommandLine.arguments.contains("--extract-screenshots") {
+    let code = await runExtractScreenshots(CommandLine.arguments)
+    exit(code)
+}
+
 /// A live capture: the SCStream recorder + the screen-frame screenshotter,
 /// keyed by the meeting that started it.
 final class CaptureSession {

--- a/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/ChangeDetectorTests.swift
+++ b/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/ChangeDetectorTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import PanopsCaptureMac
+
+/// Covers the stateful keep/drop gate the live `Screenshotter` and the
+/// `--extract-screenshots` path share: feeds it feature-print vectors at chosen
+/// sample times and asserts it keeps a frame when cosine distance exceeds the
+/// threshold and skips when below, plus the interval gate. The pure cosine math
+/// is exercised separately in `DedupTests`.
+struct ChangeDetectorTests {
+    // Reference vectors: `a` vs `b` are orthogonal (distance 1 ≥ 0.15 ⇒ keep);
+    // `aNear` is a tiny perturbation of `a` (distance < 0.15 ⇒ drop).
+    private let a: [Float] = [1, 0, 0]
+    private let b: [Float] = [0, 1, 0]
+    private let aNear: [Float] = [0.99, 0.01, 0]
+
+    @Test func firstFrameIsAlwaysKept() {
+        let d = ChangeDetector(intervalMs: 100, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })
+    }
+
+    @Test func keepsWhenCosineDistanceExceedsThreshold() {
+        let d = ChangeDetector(intervalMs: 100, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })       // kept (first)
+        #expect(d.shouldKeep(atSampleMs: 200) { self.b })     // orthogonal → kept
+    }
+
+    @Test func skipsWhenCosineDistanceBelowThreshold() {
+        let d = ChangeDetector(intervalMs: 100, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })       // kept (first)
+        #expect(!d.shouldKeep(atSampleMs: 200) { self.aNear }) // near-dup → dropped
+    }
+
+    @Test func comparesAgainstLastKeptNotLastSeen() {
+        let d = ChangeDetector(intervalMs: 100, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })        // keep `a` (reference)
+        #expect(!d.shouldKeep(atSampleMs: 200) { self.aNear }) // dropped; reference stays `a`
+        #expect(!d.shouldKeep(atSampleMs: 400) { self.aNear }) // still near `a` → dropped
+        #expect(d.shouldKeep(atSampleMs: 600) { self.b })      // far from `a` → kept
+    }
+
+    @Test func intervalGateDropsFramesWithinInterval() {
+        let d = ChangeDetector(intervalMs: 500, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })        // kept
+        // 100ms later, totally different content, still dropped by the interval.
+        #expect(!d.shouldKeep(atSampleMs: 100) { self.b })
+        // At the interval boundary the frame passes the interval gate again.
+        #expect(d.shouldKeep(atSampleMs: 500) { self.b })
+    }
+
+    @Test func intervalDroppedFrameSkipsTheFeaturePrintWork() {
+        let d = ChangeDetector(intervalMs: 500, threshold: 0.15)
+        #expect(d.shouldKeep(atSampleMs: 0) { self.a })
+        var evaluated = false
+        _ = d.shouldKeep(atSampleMs: 100) { evaluated = true; return self.b }
+        #expect(!evaluated)   // interval-dropped ⇒ Vision feature print never computed
+    }
+
+    @Test func nilFeaturePrintIsNotKept() {
+        let d = ChangeDetector(intervalMs: 100, threshold: 0.15)
+        #expect(!d.shouldKeep(atSampleMs: 0) { nil })
+    }
+}

--- a/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/ScreenshotExtractorTests.swift
+++ b/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/ScreenshotExtractorTests.swift
@@ -1,0 +1,171 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+import Testing
+@testable import PanopsCaptureMac
+
+/// Exercises the `--extract-screenshots` decode → detect → write → JSON path
+/// end to end: a synthetic `.mov` built in-test (deterministic, no fixture
+/// dependency) and the git-tracked `tests/fixtures/video/screen_60s.mp4`. Both
+/// assert ≥1 JPEG on disk plus valid, self-consistent JSON metadata. The
+/// detector's keep/skip logic itself is covered in `ChangeDetectorTests`.
+struct ScreenshotExtractorTests {
+    @Test func extractsFromSyntheticMovWritesJpegsAndJSON() async throws {
+        let movURL = Self.tempURL("mov")
+        let outDir = Self.tempURL("dir")
+        defer {
+            try? FileManager.default.removeItem(at: movURL)
+            try? FileManager.default.removeItem(at: outDir)
+        }
+        // Distinctly-colored solid frames 250ms apart (4 fps, ~1s of video).
+        try await Self.writeSyntheticMov(
+            to: movURL, width: 64, height: 48,
+            colors: [.red, .green, .blue, .yellow], fps: 4)
+
+        let shots = try await ScreenshotExtractor.extract(
+            movPath: movURL.path, outDir: outDir.path, intervalMs: 250, threshold: 0.15)
+
+        // The change detector always keeps the first frame.
+        #expect(shots.count >= 1)
+
+        // Every metadata entry points at a real `.jpg`, named by its timestamp.
+        for shot in shots {
+            #expect(shot.path.hasSuffix(".jpg"))
+            #expect(FileManager.default.fileExists(atPath: shot.path))
+            #expect(shot.path.hasSuffix(String(format: "%09d.jpg", shot.timestampMs)))
+        }
+        // Metadata count matches the JPEGs actually written to out_dir.
+        let jpegs = try FileManager.default.contentsOfDirectory(atPath: outDir.path)
+            .filter { $0.hasSuffix(".jpg") }
+        #expect(jpegs.count == shots.count)
+
+        // The emitted JSON is the wire shape the engine will parse.
+        let data = try JSONEncoder().encode(shots)
+        let decoded = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        #expect(decoded?.count == shots.count)
+        #expect(decoded?.allSatisfy { $0["timestamp_ms"] != nil && $0["path"] != nil } == true)
+    }
+
+    @Test func extractsFromFixtureMov() async throws {
+        // The fixture is committed to the repo, so it must be present.
+        let fixture = try #require(Self.fixtureVideoURL(), "missing tests/fixtures/video/screen_60s.mp4")
+        let outDir = Self.tempURL("dir")
+        defer { try? FileManager.default.removeItem(at: outDir) }
+
+        let shots = try await ScreenshotExtractor.extract(
+            movPath: fixture.path, outDir: outDir.path, intervalMs: 1000, threshold: 0.15)
+
+        #expect(shots.count >= 1)
+        for shot in shots {
+            #expect(FileManager.default.fileExists(atPath: shot.path))
+        }
+        // Metadata round-trips to JSON.
+        let data = try JSONEncoder().encode(shots)
+        let decoded = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        #expect(decoded?.count == shots.count)
+    }
+
+    // MARK: - Fixtures
+
+    private static func tempURL(_ ext: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("panops-extract-\(UUID().uuidString).\(ext)")
+    }
+
+    /// Repo `tests/fixtures` dir, located from this source file's path so it
+    /// resolves regardless of the test's working directory. `PANOPS_FIXTURES_DIR`
+    /// overrides it (matching the Mac-shell smoke test).
+    private static func fixturesDir() -> URL {
+        if let override = ProcessInfo.processInfo.environment["PANOPS_FIXTURES_DIR"] {
+            return URL(fileURLWithPath: override)
+        }
+        // <repo>/apps/panops-capture-mac/Tests/PanopsCaptureMacTests/<thisfile>
+        return URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // PanopsCaptureMacTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // panops-capture-mac
+            .deletingLastPathComponent()   // apps
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("tests/fixtures")
+    }
+
+    private static func fixtureVideoURL() -> URL? {
+        let url = fixturesDir().appendingPathComponent("video/screen_60s.mp4")
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    /// A solid BGRA fill color for synthetic frames.
+    struct SolidColor {
+        let b, g, r, a: UInt8
+        static let red = SolidColor(b: 0, g: 0, r: 255, a: 255)
+        static let green = SolidColor(b: 0, g: 255, r: 0, a: 255)
+        static let blue = SolidColor(b: 255, g: 0, r: 0, a: 255)
+        static let yellow = SolidColor(b: 0, g: 255, r: 255, a: 255)
+    }
+
+    /// Write `colors.count` solid-color frames into a playable `.mov` via the
+    /// project's `VideoWriter` — no TCC, display, or SCStream needed.
+    private static func writeSyntheticMov(
+        to url: URL, width: Int, height: Int, colors: [SolidColor], fps: Int32
+    ) async throws {
+        let writer = try VideoWriter(url: url, width: width, height: height)
+        for (i, color) in colors.enumerated() {
+            let pts = CMTime(value: Int64(i), timescale: fps)
+            if let frame = makeSolidFrame(
+                width: width, height: height, color: color, pts: pts,
+                duration: CMTime(value: 1, timescale: fps)) {
+                writer.appendVideo(frame)
+            }
+        }
+        await writer.finish()
+    }
+
+    /// A solid-color BGRA IOSurface-backed sample buffer (same construction as
+    /// `VideoWriterTests.makeFrame`, filled with one color).
+    static func makeSolidFrame(
+        width: Int, height: Int, color: SolidColor, pts: CMTime, duration: CMTime
+    ) -> CMSampleBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        let attrs: [String: Any] = [kCVPixelBufferIOSurfacePropertiesKey as String: [:]]
+        guard
+            CVPixelBufferCreate(
+                kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA,
+                attrs as CFDictionary, &pixelBuffer) == kCVReturnSuccess,
+            let pb = pixelBuffer
+        else { return nil }
+
+        CVPixelBufferLockBaseAddress(pb, [])
+        if let base = CVPixelBufferGetBaseAddress(pb) {
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(pb)
+            let ptr = base.assumingMemoryBound(to: UInt8.self)
+            for y in 0..<height {
+                for x in 0..<width {
+                    let o = y * bytesPerRow + x * 4
+                    ptr[o + 0] = color.b
+                    ptr[o + 1] = color.g
+                    ptr[o + 2] = color.r
+                    ptr[o + 3] = color.a
+                }
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(pb, [])
+
+        var formatDesc: CMVideoFormatDescription?
+        guard
+            CMVideoFormatDescriptionCreateForImageBuffer(
+                allocator: kCFAllocatorDefault, imageBuffer: pb, formatDescriptionOut: &formatDesc) == noErr,
+            let fmt = formatDesc
+        else { return nil }
+
+        var timing = CMSampleTimingInfo(
+            duration: duration, presentationTimeStamp: pts, decodeTimeStamp: .invalid)
+        var sampleBuffer: CMSampleBuffer?
+        guard
+            CMSampleBufferCreateReadyWithImageBuffer(
+                allocator: kCFAllocatorDefault, imageBuffer: pb, formatDescription: fmt,
+                sampleTiming: &timing, sampleBufferOut: &sampleBuffer) == noErr
+        else { return nil }
+        return sampleBuffer
+    }
+}

--- a/docs/superpowers/specs/2026-06-08-screenshots-from-video-design.md
+++ b/docs/superpowers/specs/2026-06-08-screenshots-from-video-design.md
@@ -1,0 +1,45 @@
+# Screenshots from video — single screenshot source via frame extraction — design
+
+**Date:** 2026-06-08
+**Status:** Drafted autonomously for maintainer review (maintainer approved doing this slice "after" the editing work, high-level). **Spec + the foundation stage build first; the engine-rewire stage waits for maintainer review of this spec.**
+**Advances:** consolidation the maintainer asked for — "we have both video recording and screenshots; maybe screenshots should come from the video, not two systems."
+
+## Goal
+
+Today there are **two independent screen-capture systems**: a live `Screenshotter` (samples frames during recording with Vision FeaturePrint change-detection → screenshot JPEGs) and ScreenCaptureKit video recording (→ `recording.mov`). When both run, the screen is sampled twice. Consolidate to **one source of truth**: when video is recorded, derive the screenshot anchors by extracting + change-detecting frames from `recording.mov`. Keep the live `Screenshotter` only as a **fallback when video is off** (audio-only meetings still get anchors).
+
+Benefits: one capture path; screenshots are exactly consistent with what was recorded; fits the deferred-processing model (extract during processing, then the video can be deleted). Trade-off (accepted): screenshots inherit the video's resolution.
+
+## Approach
+
+Reuse the existing change-detection; only the frame **source** changes (live SC frames → decoded `.mov` frames).
+
+1. **Factor out the detector.** Extract the Vision FeaturePrint cosine-distance change-detection out of the live `Screenshotter` (`apps/panops-capture-mac/Sources/PanopsCaptureMac/Screenshotter.swift`) into a reusable unit both the live path and the extract path call. Keep its threshold/interval semantics identical.
+2. **`--extract-screenshots` sidecar command.** Add a one-shot mode to `panops-capture-mac`: `--extract-screenshots <mov> <out_dir> --interval-ms N --threshold T`. It decodes frames at the interval (AVAssetImageGenerator / AVFoundation), runs the shared detector, writes changed frames as JPEGs (same naming + output shape as the live `Screenshotter`), and prints the screenshot metadata (timestamp_ms + path per kept frame) as JSON.
+3. **Engine wires the video path.** When a recording **with video** finishes, the engine invokes `--extract-screenshots` on the `recording.mov` (as part of post-recording processing / before notes generation) to produce the screenshot set, instead of relying on live screenshots. When video is **off**, the engine keeps the live `Screenshotter` path unchanged (fallback).
+4. **Don't double-sample.** During a video recording, the live `Screenshotter` is **not** run (one system when video is on).
+
+## Where extraction runs
+
+For this slice: at post-recording processing (engine side, after `recording.stop`, before/with notes generation), gated on "video was recorded." The full deferred-processing model (record now, process later, delete video) is a **separate slice** — this slice just makes screenshots come from the video when both exist, so it composes cleanly with deferred processing later.
+
+## Build order (staged PRs)
+
+- **Stage A — foundation (safe, isolated; build now):** factor the change-detector into a reusable unit (with unit tests on the detector) + add the `--extract-screenshots` sidecar command + a test that runs it on a fixture `.mov` and asserts it writes the expected changed frames. **No engine/pipeline change yet** — purely additive (a new command + a refactor). Verifiable in isolation.
+- **Stage B — engine rewire (hold for maintainer review of this spec):** wire post-recording processing to call `--extract-screenshots` for video recordings; skip the live `Screenshotter` when video is on; keep it as the no-video fallback. This changes runtime behavior, so it lands after the maintainer reviews the spec.
+
+## Three-tier boundaries
+- ✅ Always: `cargo fmt`/`clippy` + `swift build`/`swift test`; reuse the existing detector (identical threshold/interval); unit-test the detector + the extract command on a fixture `.mov`; open issues for deferred items.
+- ⚠️ Ask-first (Stage B): changing when/where screenshots are produced in the pipeline; removing the live `Screenshotter` from the video path; any change to screenshot output naming/format consumed by notes.
+- 🚫 Never: SaaS-isms; telemetry; dropping screenshot anchors for audio-only meetings (keep the live fallback); deleting the user's `recording.mov` (that's the deferred-processing slice's concern, opt-in); user-config env vars.
+
+## Verification
+- Swift: `swift build` + `swift test` for the detector unit + the `--extract-screenshots` command on a fixture `.mov` (use/extend `tests/fixtures/`).
+- Stage B (later): an engine test that a video recording yields screenshots from the `.mov`, and an audio-only recording still yields live screenshots.
+- Manual smoke (signed bundle, after Stage B): record with video → notes show screenshots that match the recording.
+
+## Out of scope (deferred → debt)
+- The full deferred-processing model (record now / process later / delete video) — separate slice.
+- Deleting `recording.mov` after extraction (opt-in, deferred slice).
+- Cursor/click highlights, presenter overlay.
+- Re-extracting at a different interval/threshold after the fact.


### PR DESCRIPTION
Stage A (safe foundation) of screenshots-from-video (spec: `docs/superpowers/specs/2026-06-08-screenshots-from-video-design.md`). **Purely additive — no pipeline/runtime change.**

- Factored the Vision FeaturePrint change-detection out of `Screenshotter` into a reusable `ChangeDetector` (identical threshold/interval; the live Screenshotter is unchanged in behavior) + unit tests.
- New sidecar one-shot `panops-capture-mac --extract-screenshots <mov> <out_dir> --interval-ms N --threshold T`: decodes `.mov` frames, runs the shared detector, writes kept JPEGs + prints `{timestamp_ms, path}` JSON.
- Tests on a synthetic + fixture `.mov`.

Verified locally: `swift build` + `swift test` green. **Stage B (wire the engine to use extraction for video recordings, drop double-sampling) is HELD for your review of the spec** — no live behavior changes here.

⚠️ Note: this slice's spec defers items (full deferred-processing model, deleting recording.mov, cursor highlights) — I'll file those as debt issues per the repo rule.

Built by claude CLI; verified + pushed from the primary session.